### PR TITLE
Fixed chunkAll/chunkBy to correctly propagate termination cause 

### DIFF
--- a/src/main/scala/scalaz/stream/process1.scala
+++ b/src/main/scala/scalaz/stream/process1.scala
@@ -67,7 +67,7 @@ object process1 {
    */
   def chunkBy[I](f: I => Boolean): Process1[I, Vector[I]] = {
     def go(acc: Vector[I], last: Boolean): Process1[I, Vector[I]] =
-      receive1Or[I,Vector[I]](emit(acc)) { i =>
+      receive1Or[I,Vector[I]](if (acc.nonEmpty) emit(acc) else halt) { i =>
         val chunk = acc :+ i
         val cur = f(i)
         if (!cur && last) emit(chunk) ++ go(Vector(), false)
@@ -552,7 +552,7 @@ object process1 {
   /** Throws any input exceptions and passes along successful results. */
   def rethrow[A]: Process1[Throwable \/ A, A] =
     id[Throwable \/ A].flatMap {
-      case -\/(err) => throw err
+      case -\/(err) => Process.fail(err)
       case \/-(a)   => emit(a)
     }
 

--- a/src/test/scala/scalaz/stream/CauseSpec.scala
+++ b/src/test/scala/scalaz/stream/CauseSpec.scala
@@ -4,6 +4,7 @@ import Cause._
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
 
+import scalaz.-\/
 import scalaz.concurrent.Task
 import scalaz.stream.Process._
 import scalaz.syntax.equal._
@@ -551,4 +552,12 @@ class CauseSpec extends Properties("cause") {
 
     (fromPipe.get == Kill) && (fromTee.get == Kill) && (fromWye.get == Kill)
   }
+
+
+  property("chunkall.once.propagate.exception.when.empty") = protect {
+    val source:Process[Task,Int] = fail(Bwahahaa)
+    source.chunkAll.once.attempt().runLog.run ?= Vector(-\/(Bwahahaa))
+  }
+
+
 }


### PR DESCRIPTION
The `chunkBy` implementation caused together with `once` to effectively swallow termination causes. The test demonstrates that.