### PR TITLE
Added several convenience functions

### DIFF
--- a/src/main/scala/fs2/pull1.scala
+++ b/src/main/scala/fs2/pull1.scala
@@ -12,6 +12,10 @@ private[fs2] trait pull1 {
   def await[F[_],I]: Handle[F,I] => Pull[F,Nothing,Step[Chunk[I],Handle[F,I]]] =
     _.await
 
+  /** Await the next available nonempty `Chunk`. */
+  def awaitNonempty[F[_],I]: Handle[F,I] => Pull[F,Nothing,Step[Chunk[I],Handle[F,I]]] =
+    receive { case s@(hd #: tl) => if (hd.isEmpty) awaitNonempty(tl) else Pull.pure(s) }
+
   /** Await a single element from the `Handle`. */
   def await1[F[_],I]: Handle[F,I] => Pull[F,Nothing,Step[I,Handle[F,I]]] =
     _.await1
@@ -78,7 +82,15 @@ private[fs2] trait pull1 {
 
   /** Write all inputs to the output of the returned `Pull`. */
   def echo[F[_],I]: Handle[F,I] => Pull[F,I,Nothing] =
-    receive { case chunk #: h => Pull.output(chunk) >> echo(h) }
+    h => echo1(h) flatMap (echo)
+
+  /** Read a single element from the input and emit it to the output. Returns the new `Handle`. */
+  def echo1[F[_],I]: Handle[F,I] => Pull[F,I,Handle[F,I]] =
+    receive1 { case i #: h => Pull.output1(i) >> Pull.pure(h) }
+
+  /** Read the next available chunk from the input and emit it to the output. Returns the new `Handle`. */
+  def echoChunk[F[_],I]: Handle[F,I] => Pull[F,I,Handle[F,I]] =
+    receive { case c #: h => Pull.output(c) >> Pull.pure(h) }
 
   /** Like `[[awaitN]]`, but leaves the buffered input unconsumed. */
   def fetchN[F[_],I](n: Int): Handle[F,I] => Pull[F,Nothing,Handle[F,I]] =

--- a/src/main/scala/fs2/pull1.scala
+++ b/src/main/scala/fs2/pull1.scala
@@ -82,7 +82,7 @@ private[fs2] trait pull1 {
 
   /** Write all inputs to the output of the returned `Pull`. */
   def echo[F[_],I]: Handle[F,I] => Pull[F,I,Nothing] =
-    h => echo1(h) flatMap (echo)
+    h => echoChunk(h) flatMap (echo)
 
   /** Read a single element from the input and emit it to the output. Returns the new `Handle`. */
   def echo1[F[_],I]: Handle[F,I] => Pull[F,I,Handle[F,I]] =


### PR DESCRIPTION
Implemented `Pull.awaitNonempty` (obtains the next nonempty `Chunk`), `Pull.echo1` and `Pull.echoChunk`. Also some convenient aliases for `receive1`, `receive`, `echo1`, and `echoChunk` on `Handle`. And added `repeatPull2`, analogous to `repeatPull`, useful for building `Tee` values.

No unit tests, but let's just start using these in new definitions and feel free to update old ones to get some ambient testing. I think the `echo`, `echo1`, and `echoChunk` will be particularly useful in various tee and wye definitions.