### PR TITLE
Add compress.deflate, compress.inflate, Chunk.toArray

### DIFF
--- a/core/src/main/scala/fs2/compress.scala
+++ b/core/src/main/scala/fs2/compress.scala
@@ -1,0 +1,89 @@
+package fs2
+
+import java.util.zip.{DataFormatException, Deflater, Inflater}
+import fs2.Stream.Handle
+
+import scala.annotation.tailrec
+import scala.collection.mutable.ArrayBuffer
+
+object compress {
+  /**
+    * Returns a `Process1` that deflates (compresses) its input elements using
+    * a `java.util.zip.Deflater` with the parameters `level`, `nowrap` and `strategy`.
+    * @param level the compression level (0-9)
+    * @param nowrap if true then use GZIP compatible compression
+    * @param bufferSize size of the internal buffer that is used by the
+    *                   compressor. Default size is 32 KB.
+    * @param strategy compression strategy -- see `java.util.zip.Deflater` for details
+    */
+  def deflate(level: Int = Deflater.DEFAULT_COMPRESSION,
+              nowrap: Boolean = false,
+              bufferSize: Int = 1024 * 32,
+              strategy: Int = Deflater.DEFAULT_STRATEGY): Process1[Byte, Byte] =
+    _ pull { _.awaitNonempty flatMap { step =>
+      val deflater = new Deflater(level, nowrap)
+      deflater.setStrategy(strategy)
+      val buffer = new Array[Byte](bufferSize)
+      _deflate_step(deflater, buffer)(step)
+    }}
+  private def _deflate_step(deflater: Deflater, buffer: Array[Byte]): Step[Chunk[Byte], Handle[Pure, Byte]] => Pull[Pure, Byte, Handle[Pure, Byte]] = {
+    case c #: h =>
+      deflater.setInput(c.toArray)
+      val result = _deflate_collect(deflater, buffer, ArrayBuffer.empty, false).toArray
+      Pull.output(Chunk.bytes(result)) >> _deflate_handle(deflater, buffer)(h)
+  }
+  private def _deflate_handle(deflater: Deflater, buffer: Array[Byte]): Handle[Pure, Byte] => Pull[Pure, Byte, Handle[Pure, Byte]] =
+    _.awaitNonempty flatMap _deflate_step(deflater, buffer) or _deflate_finish(deflater, buffer)
+  @tailrec
+  private def _deflate_collect(deflater: Deflater, buffer: Array[Byte], acc: ArrayBuffer[Byte], fin: Boolean): ArrayBuffer[Byte] = {
+    if ((fin && deflater.finished) || (!fin && deflater.needsInput)) acc
+    else {
+      val count = deflater deflate buffer
+      _deflate_collect(deflater, buffer, acc ++ buffer.iterator.take(count), fin)
+    }
+  }
+  private def _deflate_finish(deflater: Deflater, buffer: Array[Byte]): Pull[Pure, Byte, Nothing] = {
+    deflater.setInput(Array.empty)
+    deflater.finish()
+    val result = _deflate_collect(deflater, buffer, ArrayBuffer.empty, true).toArray
+    deflater.end()
+    Pull.output(Chunk.bytes(result)) >> Pull.done
+  }
+
+  /**
+    * Returns a `Process1` that inflates (decompresses) its input elements using
+    * a `java.util.zip.Inflater` with the parameter `nowrap`.
+    * @param nowrap if true then support GZIP compatible compression
+    * @param bufferSize size of the internal buffer that is used by the
+    *                   decompressor. Default size is 32 KB.
+    */
+  def inflate(nowrap: Boolean = false,
+              bufferSize: Int = 1024 * 32): Process1[Byte, Byte] =
+    _ pull { _.awaitNonempty flatMap { case c #: h =>
+      val inflater = new Inflater(nowrap)
+      val buffer = new Array[Byte](bufferSize)
+      inflater.setInput(c.toArray)
+      val result = _inflate_collect(inflater, buffer, ArrayBuffer.empty).toArray
+      Pull.output(Chunk.bytes(result)) >> _inflate_handle(inflater, buffer)(h)
+    }}
+  private def _inflate_step(inflater: Inflater, buffer: Array[Byte]): Step[Chunk[Byte], Handle[Pure, Byte]] => Pull[Pure, Byte, Handle[Pure, Byte]] = {
+    case c #: h =>
+      inflater.setInput(c.toArray)
+      val result = _inflate_collect(inflater, buffer, ArrayBuffer.empty).toArray
+      Pull.output(Chunk.bytes(result)) >> _inflate_handle(inflater, buffer)(h)
+  }
+  private def _inflate_handle(inflater: Inflater, buffer: Array[Byte]): Handle[Pure, Byte] => Pull[Pure, Byte, Handle[Pure, Byte]] =
+    _.awaitNonempty flatMap _inflate_step(inflater, buffer) or _inflate_finish(inflater)
+  @tailrec
+  private def _inflate_collect(inflater: Inflater, buffer: Array[Byte], acc: ArrayBuffer[Byte]): ArrayBuffer[Byte] = {
+    if (inflater.finished || inflater.needsInput) acc
+    else {
+      val count = inflater inflate buffer
+      _inflate_collect(inflater, buffer, acc ++ buffer.iterator.take(count))
+    }
+  }
+  private def _inflate_finish(inflater: Inflater): Pull[Pure, Nothing, Nothing] = {
+    if (!inflater.finished) Pull.fail(new DataFormatException("Insufficient data"))
+    else { inflater.end(); Pull.done }
+  }
+}

--- a/core/src/test/scala/fs2/ChunkSpec.scala
+++ b/core/src/test/scala/fs2/ChunkSpec.scala
@@ -1,0 +1,157 @@
+package fs2
+
+import fs2.Chunk.{Longs, Doubles, Bytes, Booleans}
+import fs2.TestUtil._
+import org.scalacheck.Prop._
+import org.scalacheck.{Gen, Arbitrary, Properties}
+
+import scala.reflect.ClassTag
+
+object ChunkSpec extends Properties("chunk") {
+
+  implicit val arbBooleanChunk: Arbitrary[Chunk[Boolean]] = Arbitrary {
+    for {
+      n <- Gen.choose(0, 100)
+      values <- Gen.containerOfN[Array, Boolean](n, Arbitrary.arbBool.arbitrary)
+      offset <- Gen.choose(0, n)
+      sz <- Gen.choose(0, n - offset)
+    } yield new Booleans(values, offset, sz)
+  }
+
+  implicit val arbByteChunk: Arbitrary[Chunk[Byte]] = Arbitrary {
+    for {
+      n <- Gen.choose(0, 100)
+      values <- Gen.containerOfN[Array, Byte](n, Arbitrary.arbByte.arbitrary)
+      offset <- Gen.choose(0, n)
+      sz <- Gen.choose(0, n - offset)
+    } yield new Bytes(values, offset, sz)
+  }
+
+  implicit val arbDoubleChunk: Arbitrary[Chunk[Double]] = Arbitrary {
+    for {
+      n <- Gen.choose(0, 100)
+      values <- Gen.containerOfN[Array, Double](n, Arbitrary.arbDouble.arbitrary)
+      offset <- Gen.choose(0, n)
+      sz <- Gen.choose(0, n - offset)
+    } yield new Doubles(values, offset, sz)
+  }
+
+  implicit val arbLongChunk: Arbitrary[Chunk[Long]] = Arbitrary {
+    for {
+      n <- Gen.choose(0, 100)
+      values <- Gen.containerOfN[Array, Long](n, Arbitrary.arbLong.arbitrary)
+      offset <- Gen.choose(0, n)
+      sz <- Gen.choose(0, n - offset)
+    } yield new Longs(values, offset, sz)
+  }
+
+  private def checkSize[A](c: Chunk[A]): Boolean =
+    c.size == c.toVector.size
+
+  property("size.boolean") = forAll { c: Chunk[Boolean] => checkSize(c) }
+  property("size.byte") = forAll { c: Chunk[Byte] => checkSize(c) }
+  property("size.double") = forAll { c: Chunk[Double] => checkSize(c) }
+  property("size.long") = forAll { c: Chunk[Long] => checkSize(c) }
+  property("size.unspecialized") = forAll { c: Chunk[Int] => checkSize(c) }
+
+  private def checkTake[A](c: Chunk[A], n: Int): Boolean =
+    c.take(n).toVector == c.toVector.take(n)
+
+  property("take.boolean") = forAll { (c: Chunk[Boolean], n: SmallNonnegative) => checkTake(c, n.get) }
+  property("take.byte") = forAll { (c: Chunk[Byte], n: SmallNonnegative) => checkTake(c, n.get) }
+  property("take.double") = forAll {(c: Chunk[Double], n: SmallNonnegative) => checkTake(c, n.get) }
+  property("take.long") = forAll { (c: Chunk[Long], n: SmallNonnegative) => checkTake(c, n.get) }
+  property("take.unspecialized") = forAll { (c: Chunk[Int], n: SmallNonnegative) => checkTake(c, n.get) }
+
+  private def checkDrop[A](c: Chunk[A], n: Int): Boolean =
+    c.drop(n).toVector == c.toVector.drop(n)
+
+  property("drop.boolean") = forAll { (c: Chunk[Boolean], n: SmallNonnegative) => checkDrop(c, n.get) }
+  property("drop.byte") = forAll { (c: Chunk[Byte], n: SmallNonnegative) => checkDrop(c, n.get) }
+  property("drop.double") = forAll {(c: Chunk[Double], n: SmallNonnegative) => checkDrop(c, n.get) }
+  property("drop.long") = forAll { (c: Chunk[Long], n: SmallNonnegative) => checkDrop(c, n.get) }
+  property("drop.unspecialized") = forAll { (c: Chunk[Int], n: SmallNonnegative) => checkDrop(c, n.get) }
+
+  private def checkUncons[A](c: Chunk[A]): Boolean = {
+    if (c.toVector.isEmpty)
+      c.uncons.isEmpty
+    else
+      c.uncons.contains((c(0), c.drop(1)))
+  }
+
+  property("uncons.boolean") = forAll { c: Chunk[Boolean] => checkUncons(c) }
+  property("uncons.byte") = forAll { c: Chunk[Byte] => checkUncons(c) }
+  property("uncons.double") = forAll { c: Chunk[Double] => checkUncons(c) }
+  property("uncons.long") = forAll { c: Chunk[Long] => checkUncons(c) }
+  property("uncons.unspecialized") = forAll { c: Chunk[Int] => checkUncons(c) }
+
+  private def checkIsEmpty[A](c: Chunk[A]): Boolean =
+    c.isEmpty == c.toVector.isEmpty
+
+  property("isempty.boolean") = forAll { c: Chunk[Boolean] => checkIsEmpty(c) }
+  property("isempty.byte") = forAll { c: Chunk[Byte] => checkIsEmpty(c) }
+  property("isempty.double") = forAll { c: Chunk[Double] => checkIsEmpty(c) }
+  property("isempty.long") = forAll { c: Chunk[Long] => checkIsEmpty(c) }
+  property("isempty.unspecialized") = forAll { c: Chunk[Int] => checkIsEmpty(c) }
+
+  private def checkFilter[A](c: Chunk[A], pred: A => Boolean): Boolean =
+    c.filter(pred).toVector == c.toVector.filter(pred)
+
+  property("filter.boolean") = forAll { c: Chunk[Boolean] =>
+    val predicate = (b: Boolean) => !b
+    checkFilter(c, predicate)
+  }
+  property("filter.byte") = forAll { c: Chunk[Byte] =>
+    val predicate = (b: Byte) => b < 0
+    checkFilter(c, predicate)
+  }
+  property("filter.double") = forAll { c: Chunk[Double] =>
+    val predicate = (i: Double) => i - i.floor < 0.5
+    checkFilter(c, predicate)
+  }
+  property("filter.long") = forAll { (c: Chunk[Long], n: SmallPositive) =>
+    val predicate = (i: Long) => i % n.get == 0
+    checkFilter(c, predicate)
+  }
+  property("filter.unspecialized") = forAll { (c: Chunk[Int], n: SmallPositive) =>
+    val predicate = (i: Int) => i % n.get == 0
+    checkFilter(c, predicate)
+  }
+
+  private def checkFoldLeft[A, B](c: Chunk[A], z: B)(f: (B, A) => B): Boolean =
+    c.foldLeft(z)(f) == c.toVector.foldLeft(z)(f)
+
+  property("foldleft.boolean") = forAll { c: Chunk[Boolean] =>
+    val f = (b: Boolean) => if (b) 1 else 0
+    checkFoldLeft(c, 0L)(_ + f(_))
+  }
+  property("foldleft.byte") = forAll { c: Chunk[Byte] =>
+    checkFoldLeft(c, 0L)(_ + _.toLong)
+  }
+  property("foldleft.double") = forAll { c: Chunk[Double] => checkFoldLeft(c, 0.0)(_ + _) }
+  property("foldleft.long") = forAll { c: Chunk[Long] => checkFoldLeft(c, 0L)(_ + _) }
+  property("foldleft.unspecialized") = forAll { c: Chunk[Int] => checkFoldLeft(c, 0L)(_ + _) }
+
+  private def checkFoldRight[A, B](c: Chunk[A], z: B)(f: (A, B) => B): Boolean =
+    c.foldRight(z)(f) == c.toVector.foldRight(z)(f)
+
+  property("foldright.boolean") = forAll { c: Chunk[Boolean] =>
+    val f = (b: Boolean) => if (b) 1 else 0
+    checkFoldRight(c, 0L)(f(_) + _)
+  }
+  property("foldright.byte") = forAll { c: Chunk[Byte] =>
+    checkFoldRight(c, 0L)(_.toLong + _)
+  }
+  property("foldright.double") = forAll { c: Chunk[Double] => checkFoldRight(c, 0.0)(_ + _) }
+  property("foldright.long") = forAll { c: Chunk[Long] => checkFoldRight(c, 0L)(_ + _) }
+  property("foldright.unspecialized") = forAll { c: Chunk[Int] => checkFoldRight(c, 0L)(_ + _) }
+
+  private def checkToArray[A: ClassTag](c: Chunk[A]): Boolean =
+    c.toArray.toVector == c.toVector
+
+  property("toarray.boolean") = forAll { c: Chunk[Boolean] => checkToArray(c) }
+  property("toarray.byte") = forAll { c: Chunk[Byte] => checkToArray(c) }
+  property("toarray.double") = forAll { c: Chunk[Double] => checkToArray(c) }
+  property("toarray.long") = forAll { c: Chunk[Long] => checkToArray(c) }
+  property("toarray.unspecialized") = forAll { c: Chunk[Int] => checkToArray(c) }
+}

--- a/core/src/test/scala/fs2/CompressSpec.scala
+++ b/core/src/test/scala/fs2/CompressSpec.scala
@@ -1,0 +1,38 @@
+package fs2
+
+import fs2.Stream._
+import fs2.TestUtil._
+import org.scalacheck.Prop._
+import org.scalacheck.Properties
+
+import compress._
+
+object CompressSpec extends Properties("compress") {
+
+  def getBytes(s: String): Array[Byte] =
+    s.getBytes
+
+  property("deflate.empty input") = protect {
+    Stream.empty[Pure, Byte].pipe(deflate()).toVector.isEmpty
+  }
+
+  property("inflate.empty input") = protect {
+    Stream.empty[Pure, Byte].pipe(inflate()).toVector.isEmpty
+  }
+
+  property("deflate |> inflate ~= id") = forAll { (s: PureStream[Byte]) =>
+    s.get ==? s.get.pipe(compress.deflate()).pipe(compress.inflate()).toVector
+  }
+
+  property("deflate.compresses input") = protect {
+    val uncompressed = getBytes(
+      """"
+        |"A type system is a tractable syntactic method for proving the absence
+        |of certain program behaviors by classifying phrases according to the
+        |kinds of values they compute."
+        |-- Pierce, Benjamin C. (2002). Types and Programming Languages""")
+    val compressed = Stream.chunk(Chunk.bytes(uncompressed)).pipe(deflate(9)).toVector
+
+    compressed.length < uncompressed.length
+  }
+}

--- a/core/src/test/scala/fs2/Process1Spec.scala
+++ b/core/src/test/scala/fs2/Process1Spec.scala
@@ -85,19 +85,19 @@ object Process1Spec extends Properties("process1") {
 
   property("filter (2)") = forAll { (s: PureStream[Double]) =>
     val predicate = (i: Double) => i - i.floor < 0.5
-    val s2 = s.get.mapChunks(c => Chunk.doubles(c.iterator.toArray[Double]))
+    val s2 = s.get.mapChunks(c => Chunk.doubles(c.toArray))
     s2.filter(predicate) ==? run(s2).filter(predicate)
   }
 
   property("filter (3)") = forAll { (s: PureStream[Byte]) =>
     val predicate = (b: Byte) => b < 0
-    val s2 = s.get.mapChunks(c => Chunk.bytes(c.iterator.toArray[Byte]))
+    val s2 = s.get.mapChunks(c => Chunk.bytes(c.toArray))
     s2.filter(predicate) ==? run(s2).filter(predicate)
   }
 
   property("filter (4)") = forAll { (s: PureStream[Boolean]) =>
     val predicate = (b: Boolean) => !b
-    val s2 = s.get.mapChunks(c => Chunk.booleans(c.iterator.toArray[Boolean]))
+    val s2 = s.get.mapChunks(c => Chunk.booleans(c.toArray))
     s2.filter(predicate) ==? run(s2).filter(predicate)
   }
 


### PR DESCRIPTION
I suspect this will need some discussion before being added:

I tried using `Chunk[Byte]` instead of `ByteVector`. The variance on `toArray` was annoying :)
Also, it seems that `Byte` values can easily be de-optimized, e.g. if I want an `Either[DataFormatException, Byte]`. Perhaps this should work on the `Chunk[Byte]` level instead? But then there's not a huge amount of benefit to the wrapping of `ByteVector`?

This will need to either return that `Either` I mentioned above, or it will throw exceptions -- if so, it shouldn't have a `Pure` effect, but `F: Catchable`? Is there a particular pattern you'd like here?