### PR TITLE
Support for Scalaz 7.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 sbt_args: -J-Dproject.version=travis-SNAPSHOT
 scala:
   - 2.11.7
-  - 2.12.0-M2
+  - 2.12.0-M3
 jdk:
   # - oraclejdk7
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,11 @@ cache:
   directories:
     - $HOME/.ivy2
     - $HOME/.sbt
+env:
+  matrix:
+    - SCALAZ_VERSION="7.1.4"
+    - SCALAZ_VERSION="7.2.0"
+before_script:
+  - sed -i -e "s/scalazVersion = \".*\"/scalazVersion = \"${SCALAZ_VERSION}\"/" build.sbt
 script:
   - sbt ++$TRAVIS_SCALA_VERSION "testOnly fs2.*"

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ git.formattedShaVersion := {
 
 scalaVersion := "2.11.7"
 
-crossScalaVersions := Seq("2.11.7", "2.12.0-M2")
+crossScalaVersions := Seq("2.11.7", "2.12.0-M3")
 
 val scalazVersion = "7.2.0"
 

--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,8 @@ scalaVersion := "2.11.7"
 
 crossScalaVersions := Seq("2.11.7", "2.12.0-M2")
 
+val scalazVersion = "7.2.0"
+
 scalacOptions ++= Seq(
   "-feature",
   "-deprecation",
@@ -46,11 +48,11 @@ scalacOptions in (Compile, doc) ++= Seq(
 resolvers ++= Seq(Resolver.sonatypeRepo("releases"), Resolver.sonatypeRepo("snapshots"))
 
 libraryDependencies ++= Seq(
-  "org.scalaz" %% "scalaz-core" % "7.1.4",
-  "org.scalaz" %% "scalaz-concurrent" % "7.1.4",
+  "org.scalaz" %% "scalaz-core" % scalazVersion,
+  "org.scalaz" %% "scalaz-concurrent" % scalazVersion,
   "org.scodec" %% "scodec-bits" % "1.0.9",
-  "org.scalaz" %% "scalaz-scalacheck-binding" % "7.1.4" % "test",
-  "org.scalacheck" %% "scalacheck" % "1.12.5" % "test"
+  "org.scalaz" %% "scalaz-scalacheck-binding" % scalazVersion % Test,
+  "org.scalacheck" %% "scalacheck" % "1.12.5" % Test
 )
 
 sonatypeProfileName := "org.scalaz"

--- a/build.sbt
+++ b/build.sbt
@@ -50,10 +50,16 @@ resolvers ++= Seq(Resolver.sonatypeRepo("releases"), Resolver.sonatypeRepo("snap
 libraryDependencies ++= Seq(
   "org.scalaz" %% "scalaz-core" % scalazVersion,
   "org.scalaz" %% "scalaz-concurrent" % scalazVersion,
-  "org.scodec" %% "scodec-bits" % "1.0.9",
   "org.scalaz" %% "scalaz-scalacheck-binding" % scalazVersion % Test,
   "org.scalacheck" %% "scalacheck" % "1.12.5" % Test
 )
+libraryDependencies <+= scalaVersion { sv =>
+  if (sv.startsWith("2.11")) {
+    "org.scodec" %% "scodec-bits" % "1.0.11"
+  } else {
+    "org.scodec" %% "scodec-bits" % "1.0.12"
+  }
+}
 
 sonatypeProfileName := "org.scalaz"
 


### PR DESCRIPTION
#502

For supporting both Scalaz 7.1.4 and 7.2.0, I left deprecated warnings deliberately.

On Travis CI, build with Scalaz 7.1.4 and 7.2.0　respectively.
https://travis-ci.org/zaneli/fs2/builds/96025264