### PR TITLE
Removed unnecessary "testOnly" on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,3 @@ cache:
   directories:
     - $HOME/.ivy2
     - $HOME/.sbt
-script:
-  - sbt ++$TRAVIS_SCALA_VERSION "testOnly fs2.*"


### PR DESCRIPTION
Now, old scalaz package test has been removed, so `"testOnly fs2.*"` designation is unnecessary.

Compare
https://travis-ci.org/functional-streams-for-scala/fs2/jobs/96390258#L801
with
https://travis-ci.org/functional-streams-for-scala/fs2/jobs/96461525#L806