### PR TITLE
Fixed Chunk.equals for compare with other type

### DIFF
--- a/core/src/main/scala/fs2/Chunk.scala
+++ b/core/src/main/scala/fs2/Chunk.scala
@@ -52,7 +52,7 @@ trait Chunk[+A] { self =>
     def next = { val result = apply(i); i += 1; result }
   }
   override def toString = toList.mkString("Chunk(", ", ", ")")
-  override def equals(a: Any) = a.asInstanceOf[Chunk[A]].toList == toList
+  override def equals(a: Any) = a.isInstanceOf[Chunk[_]] && a.asInstanceOf[Chunk[_]].toList == toList
   override def hashCode = iterator.toStream.hashCode
 }
 


### PR DESCRIPTION
* before

```scala
scala> Chunk.singleton(1) == Chunk.singleton(1)
res0: Boolean = true

scala> Chunk.singleton(1) == Chunk.singleton(2)
res1: Boolean = false

scala> Chunk.singleton(1) == Chunk.singleton("a")
res2: Boolean = false

scala> Chunk.singleton(1) == List(1)
java.lang.ClassCastException: scala.collection.immutable.$colon$colon cannot be cast to fs2.Chunk
  at fs2.Chunk$class.equals(Chunk.scala:55)
  at fs2.Chunk$$anon$3.equals(Chunk.scala:70)
  ... 43 elided

scala> Chunk.singleton(1) == 1
java.lang.ClassCastException: java.lang.Integer cannot be cast to fs2.Chunk
  at fs2.Chunk$class.equals(Chunk.scala:55)
  at fs2.Chunk$$anon$3.equals(Chunk.scala:70)
  ... 43 elided
```

* after
```scala
scala> Chunk.singleton(1) == Chunk.singleton(1)
res0: Boolean = true

scala> Chunk.singleton(1) == Chunk.singleton(2)
res1: Boolean = false

scala> Chunk.singleton(1) == Chunk.singleton("a")
res2: Boolean = false

scala> Chunk.singleton(1) == List(1)
res3: Boolean = false

scala> Chunk.singleton(1) == 1
res4: Boolean = false
```