### PR TITLE
Fix race condition in AsyncExt[Task] 

### DIFF
--- a/core/src/main/scala/fs2/util/Task.scala
+++ b/core/src/main/scala/fs2/util/Task.scala
@@ -304,8 +304,9 @@ object Task extends Instances {
         else { val r = result; S { cb(r) } }
 
       case Msg.Set(r) =>
-        if (modified) waitingModify + (new MsgId{} -> delayedSet(r) _)
-        else {
+        if (modified) {
+          waitingModify = waitingModify + (new MsgId{} -> delayedSet(r) _)
+        } else {
           if (result eq null) {
             waiting.values.foreach(cb => S { cb(r) })
             waiting = Map.empty
@@ -315,8 +316,9 @@ object Task extends Instances {
         }
 
       case mod@Msg.Modify(cb,idf) =>
-        if (modified || (result eq null)) waitingModify + (idf() -> cb)
-        else {
+        if (modified || (result eq null)) {
+          waitingModify = waitingModify + (idf() -> cb)
+        } else {
          modified = true
          val r = result
          S { cb(r) }

--- a/core/src/test/scala/fs2/async/SemaphoreSpec.scala
+++ b/core/src/test/scala/fs2/async/SemaphoreSpec.scala
@@ -1,0 +1,18 @@
+package fs2
+package async
+
+import TestUtil._
+import fs2.util.Task
+import org.scalacheck.Prop._
+import org.scalacheck._
+
+object SemaphoreSpec extends Properties("SemaphoreSpec") {
+
+  property("decrement n synchronously") = forAll { (s: PureStream[Int], n: Int) =>
+    val n0 = ((n.abs % 20) + 1).abs
+    println(s"decrement semaphore($n0) $n0 times test")
+    Stream.eval(async.mutable.Semaphore[Task](n0)).flatMap { s =>
+      Stream.emits(0 until n0).evalMap { _ => s.decrement }.drain ++ Stream.eval(s.available)
+    } === Vector(0)
+  }
+}


### PR DESCRIPTION
I noticed some flaky behavior when using the new queue implementation. After some discussion with @pchiusano, I decided to write some tests for Semaphore. This exposed a bug in Semaphore, which Paul fixed, but even after that fix, I was still experiencing deadlocks with the SemaphoreSpec in this PR. The deadlocks were caused by 2 bugs in AsyncExt[Task], where the waitingModify map was being updated as if it was a mutable map. After fixing, both the semaphore and the queue tests pass.