### PR TITLE
Added failing tests for merge and join

### DIFF
--- a/core/src/test/scala/fs2/TestUtil.scala
+++ b/core/src/test/scala/fs2/TestUtil.scala
@@ -3,11 +3,14 @@ package fs2
 import fs2.util.{Sub1,Task}
 import org.scalacheck.{Arbitrary, Gen}
 
+import scala.concurrent.duration._
+
 object TestUtil {
 
   implicit val S = Strategy.fromExecutionContext(scala.concurrent.ExecutionContext.global)
 
   def run[A](s: Stream[Task,A]): Vector[A] = s.runLog.run.run
+  def runFor[A](timeout:FiniteDuration = 3.seconds)(s: Stream[Task,A]): Vector[A] = s.runLog.run.runFor(timeout)
 
   def throws[A](err: Throwable)(s: Stream[Task,A]): Boolean =
     s.runLog.run.attemptRun match {


### PR DESCRIPTION
Added tests that currently fails for merge and join. Discovered them when starting to work with queue. 
@pchiusano hence both combinators fails, I think the problems is that none of them has the way to signal interruption correctly. Maybe you have some ideas how to fix that. Not sure if the fix will be easy, wondering if change to low level combinators won't be necessary.  
