### PR TITLE
Fix publishing of fs2-io module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,8 @@ lazy val commonSettings = Seq(
 lazy val testSettings = Seq(
   parallelExecution in Test := false,
   logBuffered in Test := false,
-  testOptions in Test += Tests.Argument("-verbosity", "2")
+  testOptions in Test += Tests.Argument("-verbosity", "2"),
+  publishArtifact in Test := true
 )
 
 lazy val scaladocSettings = Seq(


### PR DESCRIPTION
Without this change, "sbt publish-local" fails on the io module with errors like:

    [warn]  ::::::::::::::::::::::::::::::::::::::::::::::
    [warn]  ::          UNRESOLVED DEPENDENCIES         ::
    [warn]  ::::::::::::::::::::::::::::::::::::::::::::::
    [warn]  :: fs2#fs2-core_2.11;0.9-287e0d4: configuration not public in fs2#fs2-core_2.11;0.9-287e0d4: 'test'. It was required from fs2#fs2-io_2.11;0.9-287e0d4 test
    [warn]  ::::::::::::::::::::::::::::::::::::::::::::::
    [warn]
    [warn]  Note: Unresolved dependencies path:
    [warn]          fs2:fs2-core_2.11:0.9-287e0d4
    [warn]            +- fs2:fs2-io_2.11:0.9-287e0d4
