### PR TITLE
Automated release process; configured for publishing snapshots and releases to Sonatype

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ lazy val contributors = Seq(
 )
 
 lazy val commonSettings = Seq(
-  organization := "fs2",
+  organization := "co.fs2",
   scalaVersion := "2.11.7",
   scalacOptions ++= Seq(
     "-feature",

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,16 @@
 val ReleaseTag = """^release/([\d\.]+a?)$""".r
 
+lazy val contributors = Seq(
+  "pchiusano" -> "Paul Chiusano",
+  "pchlupacek" -> "Pavel Chlupáček",
+  "alissapajer" -> "Alissa Pajer",
+  "djspiewak" -> "Daniel Spiewak",
+  "fthomas" -> "Frank Thomas",
+  "runarorama" -> "Rúnar Ó. Bjarnason",
+  "jedws" -> "Jed Wesley-Smith",
+  "mpilquist" -> "Michael Pilquist"
+)
+
 lazy val commonSettings = Seq(
   organization := "fs2",
   scalaVersion := "2.11.7",
@@ -24,7 +35,7 @@ lazy val commonSettings = Seq(
     import fs2.util._
   """,
   doctestWithDependencies := false
-) ++ testSettings ++ scaladocSettings ++ gitSettings
+) ++ testSettings ++ scaladocSettings ++ publishingSettings ++ releaseSettings
 
 lazy val testSettings = Seq(
   parallelExecution in Test := false,
@@ -42,23 +53,50 @@ lazy val scaladocSettings = Seq(
   autoAPIMappings := true
 )
 
-lazy val gitSettings = Seq(
-  git.baseVersion := "0.9",
-  git.gitTagToVersionNumber := {
-    case ReleaseTag(version) => Some(version)
-    case _ => None
+lazy val publishingSettings = Seq(
+  publishTo := {
+    val nexus = "https://oss.sonatype.org/"
+    if (version.value.trim.endsWith("SNAPSHOT"))
+      Some("snapshots" at nexus + "content/repositories/snapshots")
+    else
+      Some("releases" at nexus + "service/local/staging/deploy/maven2")
   },
-  git.formattedShaVersion := {
-    val suffix = git.makeUncommittedSignifierSuffix(git.gitUncommittedChanges.value, git.uncommittedSignifier.value)
-
-    git.gitHeadCommit.value map { _.substring(0, 7) } map { sha =>
-      git.baseVersion.value + "-" + sha + suffix
+  publishMavenStyle := true,
+  pomIncludeRepository := { _ => false },
+  pomExtra := {
+    <url>https://github.com/functional-streams-for-scala/fs2</url>
+    <scm>
+      <url>git@github.com:functional-streams-for-scala/fs2.git</url>
+      <connection>scm:git:git@github.com:functional-streams-for-scala/fs2.git</connection>
+    </scm>
+    <developers>
+      {for ((name, username) <- contributors) yield
+      <developer>
+        <id>{username}</id>
+        <name>{name}</name>
+        <url>http://github.com/{username}</url>
+      </developer>
+      }
+    </developers>
+  },
+  pomPostProcess := { node =>
+    import scala.xml._
+    import scala.xml.transform._
+    def stripIf(f: Node => Boolean) = new RewriteRule {
+      override def transform(n: Node) =
+        if (f(n)) NodeSeq.Empty else n
     }
+    val stripTestScope = stripIf { n => n.label == "dependency" && (n \ "scope").text == "test" }
+    new RuleTransformer(stripTestScope).transform(node)(0)
   }
 )
 
+lazy val releaseSettings = Seq(
+  releaseCrossBuild := true,
+  releasePublishArtifactsAction := PgpKeys.publishSigned.value
+)
+
 lazy val root = project.in(file(".")).
-  enablePlugins(GitVersioning).
   settings(commonSettings).
   settings(
     publish := (),
@@ -68,22 +106,22 @@ lazy val root = project.in(file(".")).
   aggregate(core, io, benchmark)
 
 lazy val core = project.in(file("core")).
-  enablePlugins(GitVersioning).
   settings(commonSettings).
   settings(
-   name := "fs2-core"
+    name := "fs2-core"
   )
 
 lazy val io = project.in(file("io")).
-  enablePlugins(GitVersioning).
   settings(commonSettings).
   settings(
-   name := "fs2-io"
+    name := "fs2-io"
   ).dependsOn(core % "compile->compile;test->test")
 
 lazy val benchmark = project.in(file("benchmark")).
-  enablePlugins(GitVersioning).
   settings(commonSettings).
   settings(
-   name := "fs2-benchmark"
+    name := "fs2-benchmark",
+    publish := (),
+    publishLocal := (),
+    publishArtifact := false
   ).dependsOn(io)

--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,7 @@ lazy val publishingSettings = Seq(
       <connection>scm:git:git@github.com:functional-streams-for-scala/fs2.git</connection>
     </scm>
     <developers>
-      {for ((name, username) <- contributors) yield
+      {for ((username, name) <- contributors) yield
       <developer>
         <id>{username}</id>
         <name>{name}</name>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,6 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.6.0")
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.4")
-
-addSbtPlugin("com.github.tkawachi" % "sbt-doctest" % "0.3.3")
-
-// release stuff
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.5.0")
-
+addSbtPlugin("com.github.tkawachi" % "sbt-doctest" % "0.3.5")
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.7.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.7")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.9.0-SNAPSHOT"


### PR DESCRIPTION
This PR sets the build up to publish snapshots and releases to Sonatype. It uses sbt-release to automate the release process, besides the final Sonatype staging repository closure/release step. Publishing snapshots to Sonatype's snapshot repository is done via `+publish-signed`. Releasing a stable build is done via `release` and then `sonatypeReleaseAll`. Instead of the last step, Sonatype's OSS Nexus UI can be used to close and release the staging repository created by the release step.

The generated POMs *should* pass Sonatype's validation rules, as I based the configuration off the scodec build. We won't know until we try to build a release though.

Note that this PR removes git based versioning in favor of snapshot versioning. I realize this may be controversial, though I think it is important to publish real snapshots to Sonatype (and I did discuss this with @pchiusano today). Note that fs2 is not publishing to bintray at all. Hence, any non-snapshot version strings require Sonatype repository closure/release steps.

I think we could add git-based versioning back in the future if anyone feels strongly about publishing "stable snapshots" in addition to the normal/unstable snapshots. Alternatively, we could also publish stable snapshots using milestone and rc qualifiers (e.g., `0.9.0-M1`, `0.9.0-RC1`), which seems more common in Central than git versioning. Also, sbt-release supports milestone/rc qualifiers out of the box -- there's no special integration effort required.

/cc @djspiewak