### PR TITLE
Adds takeRight & tail to Process1

### DIFF
--- a/core/src/main/scala/fs2/Process1.scala
+++ b/core/src/main/scala/fs2/Process1.scala
@@ -198,7 +198,7 @@ object process1 {
 
   /** Emits the last `n` elements of the input. */
   def takeRight[F[_],I](n: Long): Stream[F,I] => Stream[F,I] =
-    _ pull Pull.takeRight(n)
+    _ pull { h => Pull.takeRight(n)(h).flatMap(is => Pull.output(Chunk.indexedSeq(is))) }
 
   /** Emit the longest prefix of the input for which all elements test true according to `f`. */
   def takeWhile[F[_],I](f: I => Boolean): Stream[F,I] => Stream[F,I] =

--- a/core/src/main/scala/fs2/Process1.scala
+++ b/core/src/main/scala/fs2/Process1.scala
@@ -188,6 +188,10 @@ object process1 {
   def sum[F[_],I](implicit ev: Numeric[I]): Stream[F,I] => Stream[F,I] =
     fold(ev.zero)(ev.plus)
 
+  /** Emits all elements of the input except the first one. */
+  def tail[F[_],I]: Stream[F,I] => Stream[F,I] =
+    drop(1)
+
   /** Emit the first `n` elements of the input `Handle` and return the new `Handle`. */
   def take[F[_],I](n: Long): Stream[F,I] => Stream[F,I] =
     _ pull Pull.take(n)

--- a/core/src/main/scala/fs2/Process1.scala
+++ b/core/src/main/scala/fs2/Process1.scala
@@ -196,6 +196,10 @@ object process1 {
   def take[F[_],I](n: Long): Stream[F,I] => Stream[F,I] =
     _ pull Pull.take(n)
 
+  /** Emits the last `n` elements of the input. */
+  def takeRight[F[_],I](n: Long): Stream[F,I] => Stream[F,I] =
+    _ pull Pull.takeRight(n)
+
   /** Emit the longest prefix of the input for which all elements test true according to `f`. */
   def takeWhile[F[_],I](f: I => Boolean): Stream[F,I] => Stream[F,I] =
     _ pull Pull.takeWhile(f)

--- a/core/src/main/scala/fs2/Process1Ops.scala
+++ b/core/src/main/scala/fs2/Process1Ops.scala
@@ -74,6 +74,9 @@ trait Process1Ops[+F[_],+O] { self: Stream[F,O] =>
   /** Alias for `self pipe [[process1.sum]](f)`. */
   def sum[O2 >: O : Numeric]: Stream[F,O2] = self pipe process1.sum
 
+  /** Alias for `self pipe [[process1.tail]]`. */
+  def tail: Stream[F,O] = self pipe process1.tail
+
   /** Alias for `self pipe [[process1.take]](n)`. */
   def take(n: Long): Stream[F,O] = self pipe process1.take(n)
 

--- a/core/src/main/scala/fs2/Process1Ops.scala
+++ b/core/src/main/scala/fs2/Process1Ops.scala
@@ -80,6 +80,9 @@ trait Process1Ops[+F[_],+O] { self: Stream[F,O] =>
   /** Alias for `self pipe [[process1.take]](n)`. */
   def take(n: Long): Stream[F,O] = self pipe process1.take(n)
 
+  /** Alias for `self pipe [[process1.takeRight]]`. */
+  def takeRight(n: Long): Stream[F,O] = self pipe process1.takeRight(n)
+
   /** Alias for `self pipe [[process1.takeWhile]]`. */
   def takeWhile(p: O => Boolean): Stream[F,O] = self pipe process1.takeWhile(p)
 

--- a/core/src/main/scala/fs2/pull1.scala
+++ b/core/src/main/scala/fs2/pull1.scala
@@ -183,6 +183,24 @@ private[fs2] trait pull1 {
       case chunk #: h => Pull.output(chunk) >> take(n - chunk.size.toLong)(h)
     }
 
+  /** Emits the last `n` elements of the input. */
+  def takeRight[F[_],I](n: Long): Handle[F,I] => Pull[F,I,Handle[F,I]]  = {
+    val i = if (n <= Int.MaxValue) n.toInt else Int.MaxValue
+    def go(acc: Vector[I]): Handle[F,I] => Pull[F,I,Handle[F,I]] = {
+      h => Pull.awaitN(i, true)(h).optional.flatMap {
+        case None => acc.headOption.map { hd =>
+          acc.tail.foldLeft(Pull.output1(hd))(_ >> Pull.output1(_)) as Handle.empty
+        } getOrElse Pull.pure(h)
+        case Some(cs #: h) =>
+          val vector = cs.toVector.flatMap(_.toVector)
+          go(acc.drop(vector.length) ++ vector)(h)
+      }
+    }
+
+    if (n <= 0) h => Pull.pure(h)
+    else h => Pull.awaitN(i, true)(h).flatMap { case cs #: h => go(cs.toVector.flatMap(_.toVector))(h) }
+  }
+
   /**
    * Emit the elements of the input `Handle` until the predicate `p` fails,
    * and return the new `Handle`. If nonempty, the returned `Handle` will have

--- a/core/src/test/scala/fs2/Process1Spec.scala
+++ b/core/src/test/scala/fs2/Process1Spec.scala
@@ -196,6 +196,11 @@ object Process1Spec extends Properties("process1") {
     s.get.take(n) ==? run(s.get).take(n)
   }
 
+  property("takeRight") = forAll { (s: PureStream[Int], negate: Boolean, n0: SmallNonnegative) =>
+    val n = if (negate) -n0.get else n0.get
+    s.get.takeRight(n) ==? run(s.get).takeRight(n)
+  }
+
   property("takeWhile") = forAll { (s: PureStream[Int], n: SmallNonnegative) =>
     val set = run(s.get).take(n.get).toSet
     s.get.pipe(takeWhile(set)) ==? run(s.get).takeWhile(set)

--- a/core/src/test/scala/fs2/Process1Spec.scala
+++ b/core/src/test/scala/fs2/Process1Spec.scala
@@ -217,6 +217,10 @@ object Process1Spec extends Properties("process1") {
     s.get.scan1(f) ==? v.headOption.fold(Vector.empty[Int])(h => v.drop(1).scanLeft(h)(f))
   }
 
+  property("tail") = forAll { (s: PureStream[Int]) =>
+    s.get.tail ==? run(s.get).drop(1)
+  }
+
   property("take.chunks") = secure {
     val s = Stream(1, 2) ++ Stream(3, 4)
     s.pipe(take(3)).pipe(chunks).map(_.toVector) ==? Vector(Vector(1, 2), Vector(3))


### PR DESCRIPTION
My approach for takeRight was to use an accumulator of `Vector[I]` and `awaitN` to slide through the Stream. Once the Stream is exhausted the accumulator is written to output. Is there a better way to output a `Vector[I]` other than the foldLeft approach I took?