### PR TITLE
Implement nonblocking version of `Ref`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ lazy val testSettings = Seq(
   parallelExecution in Test := false,
   logBuffered in Test := false,
   testOptions in Test += Tests.Argument("-verbosity", "2"),
-  testOptions in Test += Tests.Argument("-minSuccessfulTests", "100"),
+  testOptions in Test += Tests.Argument("-minSuccessfulTests", "500"),
   publishArtifact in Test := true
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -42,6 +42,7 @@ lazy val testSettings = Seq(
   parallelExecution in Test := false,
   logBuffered in Test := false,
   testOptions in Test += Tests.Argument("-verbosity", "2"),
+  testOptions in Test += Tests.Argument("-minSuccessfulTests", "100"),
   publishArtifact in Test := true
 )
 

--- a/core/src/main/scala/fs2/Stream.scala
+++ b/core/src/main/scala/fs2/Stream.scala
@@ -81,9 +81,10 @@ trait Stream[+F[_],+W] extends StreamOps[F,W] {
       // The `doCleanup = false` disables the default behavior of `runFold`, which is
       // to run any finalizers not yet run when reaching end of stream
       val free: Free[F2,Option[Out]] = s._runFold0(doCleanup = false, resources, Stack.empty[F2,Out])(f, None)
-      val checkInterrupt = () =>
-        if (resources.isClosed) Some(Stream.Interrupted)
-        else None
+      val checkInterrupt = () => None
+        // if (resources.isClosed) Some(Stream.Interrupted)
+        // else None
+      // this is not quite right, might interrupt when about to run a finalizer
       val runStep: F2[Either[Throwable,Option[Out]]] =
         F2.bind(F2.attempt(free.runInterruptible(checkInterrupt))) { e =>
           F2.map(F2.setPure(gate)(()))(_ => e)

--- a/core/src/main/scala/fs2/Stream.scala
+++ b/core/src/main/scala/fs2/Stream.scala
@@ -81,12 +81,8 @@ trait Stream[+F[_],+W] extends StreamOps[F,W] {
       // The `doCleanup = false` disables the default behavior of `runFold`, which is
       // to run any finalizers not yet run when reaching end of stream
       val free: Free[F2,Option[Out]] = s._runFold0(doCleanup = false, resources, Stack.empty[F2,Out])(f, None)
-      val checkInterrupt = () => None
-        // if (resources.isClosed) Some(Stream.Interrupted)
-        // else None
-      // this is not quite right, might interrupt when about to run a finalizer
       val runStep: F2[Either[Throwable,Option[Out]]] =
-        F2.bind(F2.attempt(free.runInterruptible(checkInterrupt))) { e =>
+        F2.bind(F2.attempt(free.run)) { e =>
           F2.map(F2.setPure(gate)(()))(_ => e)
         }
       // We create a single `Token` that will cover any resources allocated by `runStep`

--- a/core/src/main/scala/fs2/Stream.scala
+++ b/core/src/main/scala/fs2/Stream.scala
@@ -1,7 +1,7 @@
 package fs2
 
 import collection.immutable.LongMap
-import fs2.internal.{ConcurrentLinkedMap,LinkedSet,Trampoline}
+import fs2.internal.{Resources,LinkedSet,Trampoline}
 import fs2.util._
 import fs2.Async.Future
 
@@ -15,10 +15,10 @@ trait Stream[+F[_],+W] extends StreamOps[F,W] {
   def isEmpty: Boolean = false
 
   def runFold[O](g: (O,W) => O)(z: O): Free[F, O] =
-    _runFold0(true, ConcurrentLinkedMap.empty[Token,F[Unit]], Stream.Stack.empty[F,W])(g, z)
+    _runFold0(true, Resources.empty[Token,F[Unit]], Stream.Stack.empty[F,W])(g, z)
 
   protected final def _runFold0[F2[_],O,W2>:W,W3](
-    doCleanup: Boolean, tracked: ConcurrentLinkedMap[Token,F2[Unit]], k: Stack[F2,W2,W3])(
+    doCleanup: Boolean, tracked: Resources[Token,F2[Unit]], k: Stack[F2,W2,W3])(
     g: (O,W3) => O, z: O)(implicit S: Sub1[F,F2]): Free[F2, O] =
     Free.pure(()) flatMap { _ => // trampoline after every step, catch exceptions
       try _runFold1(doCleanup, tracked, k)(g, z)
@@ -34,7 +34,7 @@ trait Stream[+F[_],+W] extends StreamOps[F,W] {
    *     proof that `W2 == W3`, and can fold `g` over any emits.
    */
   protected def _runFold1[F2[_],O,W2>:W,W3](
-    doCleanup: Boolean, tracked: ConcurrentLinkedMap[Token,F2[Unit]], k: Stack[F2,W2,W3])(
+    doCleanup: Boolean, tracked: Resources[Token,F2[Unit]], k: Stack[F2,W2,W3])(
     g: (O,W3) => O, z: O)(implicit S: Sub1[F,F2]): Free[F2, O]
 
   private[fs2]
@@ -74,7 +74,7 @@ trait Stream[+F[_],+W] extends StreamOps[F,W] {
               .onError(err => Stream.emit(Left(err)))
       // We run `s2`, recording all resources it allocates to the mutable `resources` map
       // Note that we record _only_ the newly allocated resources for _this step_
-      val resources = ConcurrentLinkedMap.empty[Token,F2[Unit]]
+      val resources = Resources.empty[Token,F2[Unit]]
       val f = (o: Option[OutE], o2: OutE) => Some(o2)
       // The `doCleanup = false` disables the default behavior of `runFold`, which is
       // to run any finalizers not yet run when reaching end of stream
@@ -82,8 +82,15 @@ trait Stream[+F[_],+W] extends StreamOps[F,W] {
       val runStep: F2[Option[OutE]] = free.run
       // We create a single `Token` that will covers any resources allocated by `runStep`
       val rootToken = new Token()
-      // The cleanup action waits until `gate` is set above, then runs finalizers in `resources`
-      val rootCleanup: F2[Unit] = F2.bind(F2.get(gate)) { _ => Stream.runCleanup(resources).run }
+      // The cleanup action runs immediately if no resources are now being
+      // acquired, otherwise it waits until the step is done
+      val rootCleanup: F2[Unit] = F2.bind(F2.pure(())) { _ =>
+        resources.closeAll match {
+          case (cleanups, moreRunning) =>
+            if (!moreRunning) Stream.runCleanup(cleanups).run
+            else F2.bind(F2.get(gate)) { _ => Stream.runCleanup(resources).run }
+        }
+      }
       // Track the root token with `rootCleanup` as associated cleanup action
       Pull.track(rootToken) >>
       Pull.acquire(rootToken, F2.pure(()), (u:Unit) => rootCleanup) >>
@@ -114,12 +121,13 @@ object Stream extends Streams[Stream] with StreamDerived {
 
   private[fs2] class Token()
   private[fs2] def token: Token = new Token()
+  case object Interrupted extends Throwable
 
   def chunk[F[_],W](c: Chunk[W]) = new Stream[F,W] { self =>
     override def isEmpty = c.isEmpty
 
     def _runFold1[F2[_],O,W2>:W,W3](
-      doCleanup: Boolean, tracked: ConcurrentLinkedMap[Token,F2[Unit]], k: Stack[F2,W2,W3])(
+      doCleanup: Boolean, tracked: Resources[Token,F2[Unit]], k: Stack[F2,W2,W3])(
       g: (O,W3) => O, z: O)(implicit S: Sub1[F,F2]): Free[F2,O]
       =
       k (
@@ -177,7 +185,7 @@ object Stream extends Streams[Stream] with StreamDerived {
   def fail[F[_]](err: Throwable): Stream[F,Nothing] = new Stream[F,Nothing] { self =>
     type W = Nothing
     def _runFold1[F2[_],O,W2>:Nothing,W3](
-      doCleanup: Boolean, tracked: ConcurrentLinkedMap[Token,F2[Unit]], k: Stack[F2,W2,W3])(
+      doCleanup: Boolean, tracked: Resources[Token,F2[Unit]], k: Stack[F2,W2,W3])(
       g: (O,W3) => O, z: O)(implicit S: Sub1[F,F2]): Free[F2,O]
       =
       k (
@@ -205,7 +213,7 @@ object Stream extends Streams[Stream] with StreamDerived {
 
   def eval[F[_],W](f: F[W]): Stream[F,W] = new Stream[F,W] {
     def _runFold1[F2[_],O,W2>:W,W3](
-      doCleanup: Boolean, tracked: ConcurrentLinkedMap[Token,F2[Unit]], k: Stack[F2,W2,W3])(
+      doCleanup: Boolean, tracked: Resources[Token,F2[Unit]], k: Stack[F2,W2,W3])(
       g: (O,W3) => O, z: O)(implicit S: Sub1[F,F2]): Free[F2, O]
       =
       Free.attemptEval(S(f)) flatMap {
@@ -225,7 +233,7 @@ object Stream extends Streams[Stream] with StreamDerived {
 
   override def map[F[_],W0,W](s: Stream[F,W0])(f: W0 => W) = new Stream[F,W] {
     def _runFold1[F2[_],O,W2>:W,W3](
-      doCleanup: Boolean, tracked: ConcurrentLinkedMap[Token,F2[Unit]], k: Stack[F2,W2,W3])(
+      doCleanup: Boolean, tracked: Resources[Token,F2[Unit]], k: Stack[F2,W2,W3])(
       g: (O,W3) => O, z: O)(implicit S: Sub1[F,F2]): Free[F2,O]
       =
       Free.suspend {
@@ -251,7 +259,7 @@ object Stream extends Streams[Stream] with StreamDerived {
 
   def flatMap[F[_],W0,W](s: Stream[F,W0])(f: W0 => Stream[F,W]) = new Stream[F,W] {
     def _runFold1[F2[_],O,W2>:W,W3](
-      doCleanup: Boolean, tracked: ConcurrentLinkedMap[Token,F2[Unit]], k: Stack[F2,W2,W3])(
+      doCleanup: Boolean, tracked: Resources[Token,F2[Unit]], k: Stack[F2,W2,W3])(
       g: (O,W3) => O, z: O)(implicit S: Sub1[F,F2]): Free[F2,O]
       =
       Free.suspend {
@@ -280,7 +288,7 @@ object Stream extends Streams[Stream] with StreamDerived {
 
   def append[F[_],W](s: Stream[F,W], s2: => Stream[F,W]) = new Stream[F,W] {
     def _runFold1[F2[_],O,W2>:W,W3](
-      doCleanup: Boolean, tracked: ConcurrentLinkedMap[Token,F2[Unit]], k: Stack[F2,W2,W3])(
+      doCleanup: Boolean, tracked: Resources[Token,F2[Unit]], k: Stack[F2,W2,W3])(
       g: (O,W3) => O, z: O)(implicit S: Sub1[F,F2]): Free[F2,O]
       =
       s._runFold0[F2,O,W2,W3](doCleanup, tracked, k.pushAppend(() => Sub1.substStream(s2)))(g,z)
@@ -297,17 +305,23 @@ object Stream extends Streams[Stream] with StreamDerived {
   private[fs2] def acquire[F[_],W](id: Token, r: F[W], cleanup: W => F[Unit]):
   Stream[F,W] = new Stream[F,W] {
     def _runFold1[F2[_],O,W2>:W,W3](
-      doCleanup: Boolean, tracked: ConcurrentLinkedMap[Token,F2[Unit]], k: Stack[F2,W2,W3])(
+      doCleanup: Boolean, tracked: Resources[Token,F2[Unit]], k: Stack[F2,W2,W3])(
       g: (O,W3) => O, z: O)(implicit S: Sub1[F,F2]): Free[F2,O]
       =
-      Free.eval(S(r)) flatMap { r =>
-        try
-          emit(r)._runFold0[F2,O,W2,W3](doCleanup, tracked updated (id, S(cleanup(r))), k)(g,z)
+      if (tracked.startAcquire(id)) Free.eval(S(r)) flatMap { r =>
+        try {
+          val c = S(cleanup(r))
+          if (tracked.finishAcquire(id, c))
+            emit(r)._runFold0[F2,O,W2,W3](doCleanup, tracked, k)(g,z)
+          else
+            fail(Interrupted)._runFold0[F2,O,W2,W3](doCleanup, tracked, k)(g,z)
+        }
         catch { case t: Throwable =>
           fail(new RuntimeException("producing resource cleanup action failed", t))
           ._runFold0[F2,O,W2,W3](doCleanup, tracked, k)(g,z)
         }
       }
+      else fail(Interrupted)._runFold0[F2,O,W2,W3](doCleanup, tracked, k)(g,z)
 
     def _step1[F2[_],W2>:W](rights: List[Stream[F2,W2]])(implicit S: Sub1[F,F2])
       : Pull[F2,Nothing,Step[Chunk[W2],Handle[F2,W2]]]
@@ -324,12 +338,12 @@ object Stream extends Streams[Stream] with StreamDerived {
   private[fs2] def release(id: Token): Stream[Nothing,Nothing] = new Stream[Nothing,Nothing] {
     type W = Nothing
     def _runFold1[F2[_],O,W2>:W,W3](
-      doCleanup: Boolean, tracked: ConcurrentLinkedMap[Token,F2[Unit]], k: Stack[F2,W2,W3])(
+      doCleanup: Boolean, tracked: Resources[Token,F2[Unit]], k: Stack[F2,W2,W3])(
       g: (O,W3) => O, z: O)(implicit S: Sub1[Nothing,F2]): Free[F2,O]
       =
-      tracked.get(id).map(eval).getOrElse(Stream.emit(())).flatMap { (u: Unit) =>
+      tracked.close(id).map(eval).getOrElse(Stream.emit(())).flatMap { (u: Unit) =>
         empty[F2,W2]
-      }._runFold0(doCleanup, tracked.removed(id), k)(g, z)
+      }._runFold0(doCleanup, tracked, k)(g, z)
 
     def _step1[F2[_],W2>:W](rights: List[Stream[F2,W2]])(implicit S: Sub1[Nothing,F2])
       : Pull[F2,Nothing,Step[Chunk[W2],Handle[F2,W2]]]
@@ -341,7 +355,7 @@ object Stream extends Streams[Stream] with StreamDerived {
 
   def onError[F[_],W](s: Stream[F,W])(handle: Throwable => Stream[F,W]) = new Stream[F,W] {
     def _runFold1[F2[_],O,W2>:W,W3](
-      doCleanup: Boolean, tracked: ConcurrentLinkedMap[Token,F2[Unit]], k: Stack[F2,W2,W3])(
+      doCleanup: Boolean, tracked: Resources[Token,F2[Unit]], k: Stack[F2,W2,W3])(
       g: (O,W3) => O, z: O)(implicit S: Sub1[F,F2]): Free[F2,O]
       = {
         val handle2: Throwable => Stream[F2,W] = handle andThen (Sub1.substStream(_))
@@ -374,7 +388,7 @@ object Stream extends Streams[Stream] with StreamDerived {
    */
   def suspend[F[_],W](self: => Stream[F,W]): Stream[F,W] = new Stream[F,W] {
     def _runFold1[F2[_],O,W2>:W,W3](
-      doCleanup: Boolean, tracked: ConcurrentLinkedMap[Token,F2[Unit]], k: Stack[F2,W2,W3])(
+      doCleanup: Boolean, tracked: Resources[Token,F2[Unit]], k: Stack[F2,W2,W3])(
       g: (O,W3) => O, z: O)(implicit S: Sub1[F,F2]): Free[F2,O]
       = self._runFold0(doCleanup, tracked, k)(g, z)
 
@@ -427,9 +441,17 @@ object Stream extends Streams[Stream] with StreamDerived {
     def empty[F[_],W]: Handle[F,W] = new Handle(List(), Stream.empty)
   }
 
-  private def runCleanup[F[_]](l: ConcurrentLinkedMap[Token,F[Unit]]): Free[F,Unit] =
-    l.values.foldLeft[Free[F,Unit]](Free.pure(()))((tl,hd) =>
-      Free.eval(hd) flatMap { _ => tl } )
+  private def runCleanup[F[_]](l: Resources[Token,F[Unit]]): Free[F,Unit] =
+    l.closeAll match {
+      case (l, moreRunning) if !moreRunning => runCleanup(l)
+      case _ => sys.error("internal FS2 error: cannot run cleanup actions while resources are being acquired")
+    }
+
+  private def runCleanup[F[_]](cleanups: Iterable[F[Unit]]): Free[F,Unit] =
+    // note - run cleanup actions in LIFO order, later actions run first
+    cleanups.foldLeft[Free[F,Unit]](Free.pure(()))(
+      (tl,hd) => Free.eval(hd) flatMap { _ => tl }
+    )
 
   private def concatRight[F[_],W](s: List[Stream[F,W]]): Stream[F,W] =
     if (s.isEmpty) empty

--- a/core/src/main/scala/fs2/Stream.scala
+++ b/core/src/main/scala/fs2/Stream.scala
@@ -81,8 +81,11 @@ trait Stream[+F[_],+W] extends StreamOps[F,W] {
       // The `doCleanup = false` disables the default behavior of `runFold`, which is
       // to run any finalizers not yet run when reaching end of stream
       val free: Free[F2,Option[Out]] = s._runFold0(doCleanup = false, resources, Stack.empty[F2,Out])(f, None)
+      val checkInterrupt = () =>
+        if (resources.isClosed) Some(Stream.Interrupted)
+        else None
       val runStep: F2[Either[Throwable,Option[Out]]] =
-        F2.bind(F2.attempt(free.run)) { e =>
+        F2.bind(F2.attempt(free.runInterruptible(checkInterrupt))) { e =>
           F2.map(F2.setPure(gate)(()))(_ => e)
         }
       // We create a single `Token` that will cover any resources allocated by `runStep`

--- a/core/src/main/scala/fs2/Stream.scala
+++ b/core/src/main/scala/fs2/Stream.scala
@@ -22,7 +22,7 @@ trait Stream[+F[_],+W] extends StreamOps[F,W] {
     g: (O,W3) => O, z: O)(implicit S: Sub1[F,F2]): Free[F2, O] =
     Free.pure(()) flatMap { _ => // trampoline after every step, catch exceptions
       try _runFold1(doCleanup, tracked, k)(g, z)
-      catch { case t: Throwable => Stream.fail(t)._runFold1(doCleanup, tracked, k)(g,z) }
+      catch { case t: Throwable => Stream.fail(t)._runFold0(doCleanup, tracked, k)(g,z) }
     }
 
   /**
@@ -190,7 +190,7 @@ object Stream extends Streams[Stream] with StreamDerived {
       =
       k (
         (segments,eq) => segments match {
-          case List() => empty[F2,W2]._runFold1(doCleanup, tracked, k)(g,z) flatMap { _ => Free.fail(err) }
+          case List() => empty[F2,W2]._runFold0(doCleanup, tracked, k)(g,z) flatMap { _ => Free.fail(err) }
           case _ =>
             val (hd, tl) = Stack.fail(segments)(err)
             val g2 = Eq.subst[({ type f[x] = (O,x) => O })#f, W3, W2](g)(eq.flip)

--- a/core/src/main/scala/fs2/concurrent.scala
+++ b/core/src/main/scala/fs2/concurrent.scala
@@ -15,10 +15,8 @@ object concurrent {
     : Pull[F,O,Unit] =
       // A) Nothing's open; block to obtain a new open stream
       if (open.isEmpty) s.await1.flatMap { case sh #: s =>
-        sh.open.flatMap { sh => sh.await.optional.flatMap {
-          case Some(step) =>
-            go(s, onlyOpen, open :+ Future.pure(P.pure(step): Pull[F,Nothing,Step[Chunk[O],Handle[F,O]]]))
-          case None => go(s, onlyOpen, open)
+        sh.open.flatMap { sh => sh.awaitAsync.flatMap { f =>
+          go(s, onlyOpen, open :+ f)
         }}
       }
       // B) We have too many things open, or `s` is exhausted so we only consult `open`
@@ -40,7 +38,8 @@ object concurrent {
         nextS <- s.await1Async
         elementOrNewStream <- Future.race(open).race(nextS).force
         u <- elementOrNewStream match {
-          case Left(winner) => winner.get.optional.flatMap {
+          case Left(winner) =>
+            winner.get.optional.flatMap {
             case None => go(s, onlyOpen, winner.delete)
             case Some(out #: h) =>
               P.output(out) >> h.awaitAsync.flatMap { next => go(s, onlyOpen, winner.replace(next)) }

--- a/core/src/main/scala/fs2/internal/Future.scala
+++ b/core/src/main/scala/fs2/internal/Future.scala
@@ -117,7 +117,7 @@ private[fs2] sealed abstract class Future[+A] {
       , timeoutInMillis, TimeUnit.MILLISECONDS)
 
       runAsyncInterruptibly(a => if(done.compareAndSet(false,true)) cb(Right(a)), cancel)
-    }
+    } (Strategy.sequential)
 
   def timed(timeout: Duration)(implicit S: ScheduledExecutorService):
     Future[Either[Throwable,A]] = timed(timeout.toMillis)
@@ -144,8 +144,8 @@ private[fs2] object Future {
 
   def suspend[A](f: => Future[A]): Future[A] = Suspend(() => f)
 
-  def async[A](listen: (A => Unit) => Unit): Future[A] =
-    Async((cb: A => Trampoline[Unit]) => listen { a => cb(a).run })
+  def async[A](listen: (A => Unit) => Unit)(implicit S: Strategy): Future[A] =
+    Async((cb: A => Trampoline[Unit]) => listen { a => S { cb(a).run } })
 
   /** Create a `Future` that will evaluate `a` using the given `ExecutorService`. */
   def apply[A](a: => A)(implicit S: Strategy): Future[A] = Async { cb =>

--- a/core/src/main/scala/fs2/internal/LinkedMap.scala
+++ b/core/src/main/scala/fs2/internal/LinkedMap.scala
@@ -20,6 +20,18 @@ private[fs2] class LinkedMap[K,+V](
   def updated[V2>:V](k: K, v: V2): LinkedMap[K,V2] =
     new LinkedMap(entries.updated(k, (v,nextID)), insertionOrder.updated(nextID, k), nextID+1)
 
+  def edit[V2>:V](k: K, f: Option[V2] => Option[V2]): LinkedMap[K,V2] =
+    entries.get(k) match {
+      case None => f(None) match {
+        case None => this - k
+        case Some(v) => updated(k, v)
+      }
+      case Some((v,id)) => f(Some(v)) match {
+        case None => this - k
+        case Some(v) => new LinkedMap(entries.updated(k, (v,id)), insertionOrder, nextID)
+      }
+    }
+
   /** Remove this key from this map. */
   def -(k: K) = new LinkedMap(
     entries - k,

--- a/core/src/main/scala/fs2/internal/LinkedMap.scala
+++ b/core/src/main/scala/fs2/internal/LinkedMap.scala
@@ -38,6 +38,8 @@ private[fs2] class LinkedMap[K,+V](
     entries.get(k).map { case (_,id) => insertionOrder - id }.getOrElse(insertionOrder),
     nextID)
 
+  def unorderedEntries: Iterable[(K,V)] = entries.mapValues(_._1)
+
   /** The keys of this map, in the order they were added. */
   def keys: Iterable[K] = insertionOrder.values
 

--- a/core/src/main/scala/fs2/internal/LinkedMap.scala
+++ b/core/src/main/scala/fs2/internal/LinkedMap.scala
@@ -48,6 +48,8 @@ private[fs2] class LinkedMap[K,+V](
 
   def isEmpty = entries.isEmpty
 
+  def size = entries.size
+
   override def toString = "{ " + (keys zip values).mkString("  ") +" }"
 }
 

--- a/core/src/main/scala/fs2/internal/LinkedMap.scala
+++ b/core/src/main/scala/fs2/internal/LinkedMap.scala
@@ -47,6 +47,8 @@ private[fs2] class LinkedMap[K,+V](
   def values: Iterable[V] = keys.flatMap(k => entries.get(k).toList.map(_._1))
 
   def isEmpty = entries.isEmpty
+
+  override def toString = "{ " + (keys zip values).mkString("  ") +" }"
 }
 
 private[fs2] object LinkedMap {

--- a/core/src/main/scala/fs2/internal/Ref.scala
+++ b/core/src/main/scala/fs2/internal/Ref.scala
@@ -50,6 +50,8 @@ private[fs2] class Ref[A](id: AtomicLong, ref: AtomicReference[A]) {
     if (id.compareAndSet(expected, expected+1)) { ref.set(a); true }
     else false
   }
+
+  override def toString = "Ref { "+ref.get.toString+" }"
 }
 
 object Ref {

--- a/core/src/main/scala/fs2/internal/Ref.scala
+++ b/core/src/main/scala/fs2/internal/Ref.scala
@@ -13,7 +13,7 @@ private[fs2] class Ref[A](id: AtomicLong, ref: AtomicReference[A]) {
    * for updating the value. The setter may noop (in which case `false`
    * is returned) if another concurrent call to `access` uses its
    * setter first. Once it has noop'd or been used once, a setter
-   * never succeed again.
+   * never succeeds again.
    */
   def access: (A, A => Boolean) = {
     val s = set(id.get)

--- a/core/src/main/scala/fs2/internal/Ref.scala
+++ b/core/src/main/scala/fs2/internal/Ref.scala
@@ -68,6 +68,7 @@ private[fs2] class Ref[A](id: AtomicLong, ref: AtomicReference[A], lock: ReadWri
   override def toString = "Ref { "+ref.get.toString+" }"
 }
 
+private[fs2]
 object Ref {
 
   class ReadWriteSpinLock(readers: AtomicLong) { // readers = -1 means writer has lock

--- a/core/src/main/scala/fs2/internal/Ref.scala
+++ b/core/src/main/scala/fs2/internal/Ref.scala
@@ -2,32 +2,57 @@ package fs2.internal
 
 import java.util.concurrent.atomic._
 
-/** A reference which may be updated atomically, without use of `==` on `A`. */
+/**
+ * A reference which may be updated transactionally, without
+ * use of `==` on `A`.
+ */
 private[fs2] class Ref[A](id: AtomicLong, ref: AtomicReference[A]) {
+
+  /**
+   * Obtain a snapshot of the current value, and a setter
+   * for updating the value. The setter may noop (in which case `false`
+   * is returned) if another concurrent call to `access` uses its
+   * setter first. Once it has noop'd or been used once, a setter
+   * never succeed again.
+   */
   def access: (A, A => Boolean) = {
     val s = set(id.get)
     // from this point forward, only one thread may write `ref`
     (ref.get, s)
   }
   def get: A = ref.get
-  def modify(f: A => A): Boolean = tryModify(f andThen (Some(_)))
 
-  /** Like `modify`, but `f` may choose not to modify. */
-  def tryModify(f: A => Option[A]): Boolean = access match {
+  /**
+   * Attempt a single transactional update, returning `false`
+   * if the set loses due to contention.
+   */
+  def modify1(f: A => A): Boolean = possiblyModify1(f andThen (Some(_)))
+
+  /**
+   * Transactionally modify the value.
+   * `f` may be called multiple times, until this modification wins
+   * the race with any concurrent modifications.
+   */
+  @annotation.tailrec
+  final def modify(f: A => A): Unit =
+    if (!modify1(f)) modify(f)
+
+  /**
+   * Like `modify`, but `f` may choose not to modify. Unlike
+   * just using `modify1(identity)`, if `f` returns `None` this
+   * generates no contention.
+   */
+  def possiblyModify1(f: A => Option[A]): Boolean = access match {
     case (a, set) => f(a).map(set).getOrElse(false)
   }
 
-  /** Like `tryModify`, but retry if failure due to contention. */
-  @annotation.tailrec
-  final def repeatedlyTryModify(f: A => Option[A]): Boolean = access match {
-    case (a, set) => f(a) match {
-      case None => false
-      case Some(a) => set(a) || repeatedlyTryModify(f)
-    }
-  }
   private def set(expected: Long): A => Boolean = a => {
     if (id.compareAndSet(expected, expected+1)) { ref.set(a); true }
     else false
   }
 }
 
+object Ref {
+  def apply[A](a: A): Ref[A] =
+    new Ref(new AtomicLong(0), new AtomicReference(a))
+}

--- a/core/src/main/scala/fs2/internal/Ref.scala
+++ b/core/src/main/scala/fs2/internal/Ref.scala
@@ -3,11 +3,13 @@ package fs2.internal
 import java.util.concurrent.atomic._
 import java.util.concurrent.locks.ReentrantLock
 
+import Ref._
+
 /**
  * A reference which may be updated transactionally, without
  * use of `==` on `A`.
  */
-private[fs2] class Ref[A](id: AtomicLong, ref: AtomicReference[A], lock: ReentrantLock) {
+private[fs2] class Ref[A](id: AtomicLong, ref: AtomicReference[A], lock: ReadWriteSpinLock) {
 
   /**
    * Obtain a snapshot of the current value, and a setter
@@ -17,22 +19,24 @@ private[fs2] class Ref[A](id: AtomicLong, ref: AtomicReference[A], lock: Reentra
    * never succeeds again.
    */
   def access: (A, A => Boolean) = {
-    lock.lock
-    try {
-      val i = id.get
-      val s = set(i)
-      // from this point forward, only one thread may write `ref`
-      (ref.get, s)
-    } finally { lock.unlock }
+    lock.startRead
+    val i = id.get
+    val a = ref.get
+    lock.finishRead
+    val s = set(i)
+    // from this point forward, only one thread may write `ref`
+    (a, s)
   }
 
   private def set(expected: Long): A => Boolean = a => {
-    lock.lock
-    try {
-      if (id.compareAndSet(expected, expected+1)) { ref.set(a); true }
-      else false
+    id.get == expected && {
+      lock.startWrite // don't bother acquiring lock if no chance of succeeding
+      try {
+        if (id.compareAndSet(expected, expected+1)) { ref.set(a); true }
+        else false
+      }
+      finally { lock.finishWrite }
     }
-    finally { lock.unlock }
   }
 
   def get: A = ref.get
@@ -65,6 +69,40 @@ private[fs2] class Ref[A](id: AtomicLong, ref: AtomicReference[A], lock: Reentra
 }
 
 object Ref {
+
+  class ReadWriteSpinLock(readers: AtomicLong) { // readers = -1 means writer has lock
+
+    /** Increment the reader count. Fails only due to contention with a writer. */
+    @annotation.tailrec
+    final def tryStartRead: Boolean = {
+      val cur = readers.get
+      if (cur >= 0) {
+        if (!readers.compareAndSet(cur,cur+1)) tryStartRead
+        else true
+      }
+      else false // lost due to writer contention
+    }
+
+    /** Decrement the reader count, possibly unblocking waiting writers
+     *  if the count is now 0. */
+    final def finishRead: Unit = { readers.decrementAndGet; () }
+
+    /** Repeatedly [[tryStartRead]] until it succeeds. */
+    @annotation.tailrec
+    final def startRead: Unit = if (!tryStartRead) startRead
+
+    /** Try obtaining the write lock, failing only due to other writer contention. */
+    private final def tryStartWrite: Boolean = readers.compareAndSet(0,-1)
+
+    /** Obtain the write lock. */
+    @annotation.tailrec
+    final def startWrite: Unit = if (!tryStartWrite) startWrite
+
+    /** Release the write lock, unblocking both readers and other writers. */
+    final def finishWrite: Boolean = readers.compareAndSet(-1,0)
+  }
+
   def apply[A](a: A): Ref[A] =
-    new Ref(new AtomicLong(0), new AtomicReference(a), new ReentrantLock())
+    new Ref(new AtomicLong(0), new AtomicReference(a),
+            new ReadWriteSpinLock(new AtomicLong(0)))
 }

--- a/core/src/main/scala/fs2/internal/Ref.scala
+++ b/core/src/main/scala/fs2/internal/Ref.scala
@@ -17,8 +17,8 @@ private[fs2] class Ref[A](id: AtomicLong, ref: AtomicReference[A], lock: Reentra
    * never succeeds again.
    */
   def access: (A, A => Boolean) = {
+    lock.lock
     try {
-      lock.lock
       val i = id.get
       val s = set(i)
       // from this point forward, only one thread may write `ref`
@@ -27,8 +27,8 @@ private[fs2] class Ref[A](id: AtomicLong, ref: AtomicReference[A], lock: Reentra
   }
 
   private def set(expected: Long): A => Boolean = a => {
+    lock.lock
     try {
-      lock.lock
       if (id.compareAndSet(expected, expected+1)) { ref.set(a); true }
       else false
     }

--- a/core/src/main/scala/fs2/internal/Ref.scala
+++ b/core/src/main/scala/fs2/internal/Ref.scala
@@ -1,0 +1,33 @@
+package fs2.internal
+
+import java.util.concurrent.atomic._
+
+/** A reference which may be updated atomically, without use of `==` on `A`. */
+private[fs2] class Ref[A](id: AtomicLong, ref: AtomicReference[A]) {
+  def access: (A, A => Boolean) = {
+    val s = set(id.get)
+    // from this point forward, only one thread may write `ref`
+    (ref.get, s)
+  }
+  def get: A = ref.get
+  def modify(f: A => A): Boolean = tryModify(f andThen (Some(_)))
+
+  /** Like `modify`, but `f` may choose not to modify. */
+  def tryModify(f: A => Option[A]): Boolean = access match {
+    case (a, set) => f(a).map(set).getOrElse(false)
+  }
+
+  /** Like `tryModify`, but retry if failure due to contention. */
+  @annotation.tailrec
+  final def repeatedlyTryModify(f: A => Option[A]): Boolean = access match {
+    case (a, set) => f(a) match {
+      case None => false
+      case Some(a) => set(a) || repeatedlyTryModify(f)
+    }
+  }
+  private def set(expected: Long): A => Boolean = a => {
+    if (id.compareAndSet(expected, expected+1)) { ref.set(a); true }
+    else false
+  }
+}
+

--- a/core/src/main/scala/fs2/internal/Resources.scala
+++ b/core/src/main/scala/fs2/internal/Resources.scala
@@ -1,26 +1,14 @@
 package fs2.internal
 
-import Resources.Status
-import Status._
+private[fs2] class Resources[T,R](tokens: Ref[(Boolean, LinkedMap[T, Option[R]])]) {
 
-private[fs2] class Resources[T,R](tokens: Ref[(Boolean, LinkedMap[T, Status[R]])]) {
+  // implementation notes - `Some(r)` in the `LinkedMap`
+  // represents an acquired resource, and `None` represents
+  // a resource in the process of being acquired
+  // The `Boolean` indicates whether this resources is open
 
-  def isClosed(t: T): Boolean = tokens.get._2.get(t).isEmpty
-
-  /**
-   * Mark the token `t` as being in the `Open` state.
-   * This must be done before any calls to `startAcquire`
-   * for `t`.
-   */
-  @annotation.tailrec
-  final def open(t: T): Unit = tokens.access match {
-    case ((isOpen,m),update) => m.get(t) match {
-      case None =>
-        if (!update((isOpen,m.edit(t, _ => Some(Open))))) open(t)
-      case Some(t) =>
-        sys.error("open of already open token: " + t)
-    }
-  }
+  def isOpen: Boolean = tokens.get._1
+  def isClosed: Boolean = !isOpen
 
   /**
    * Close this `Resources` and return all acquired resources.
@@ -31,40 +19,47 @@ private[fs2] class Resources[T,R](tokens: Ref[(Boolean, LinkedMap[T, Status[R]])
   @annotation.tailrec
   final def closeAll: (List[R], Boolean) = tokens.access match {
     case ((open,m),update) =>
-      val rs = m.values.collect { case Acquired(r) => r }.toList
-      val anyAcquiring = m.values.exists(_ == Acquiring)
+      val rs = m.values.collect { case Some(r) => r }.toList
+      val anyAcquiring = m.values.exists(_ == None)
       val m2 = m.unorderedEntries.foldLeft(m) { (m,kv) =>
         kv._2 match {
-          case Acquiring => m
-          case _ => m - kv._1
+          case None => m
+          case Some(_) => m - kv._1
         }
       }
       if (!update((false, m2))) closeAll
       else (rs, !anyAcquiring)
   }
 
+  /**
+   * Close `t`, returning any associated acquired resource.
+   * Returns `None` if `t` is being acquired or `t` is
+   * not present in this `Resources`.
+   */
   @annotation.tailrec
   final def close(t: T): Option[R] = tokens.access match {
     case ((open,m),update) => m.get(t) match {
-      case None => None // pattern matching so this can be tailrec
-      case Some(Acquired(r)) =>
+      case None => None // note: not flatMap so can be tailrec
+      case Some(Some(r)) => // close of an acquired resource
         if (update((open, m-t))) Some(r)
         else close(t)
-      case Some(Open) =>
-        if (update((open,m-t))) None
-        else close(t)
-      case Some(Acquiring) => None
+      case Some(None) => None // close of any acquiring resource fails
     }
   }
 
+  /**
+   * Start acquiring `t`.
+   * Returns `None` if `t` is being acquired or `t` is
+   * not present in this `Resources`.
+   */
   @annotation.tailrec
   final def startAcquire(t: T): Boolean = tokens.access match {
     case ((open,m), update) =>
       m.get(t) match {
-        case Some(_) if open =>
-          update(open -> m.edit(t, _ => Some(Acquiring))) ||
-          startAcquire(t) // retry on contention
-        case _ => false // fail permanently if already closed
+        case Some(r) => sys.error("startAcquire on already used token: "+(t -> r))
+        case None => open && {
+          update(open -> m.edit(t, _ => Some(None))) || startAcquire(t)
+        }
       }
   }
 
@@ -72,10 +67,10 @@ private[fs2] class Resources[T,R](tokens: Ref[(Boolean, LinkedMap[T, Status[R]])
   final def finishAcquire(t: T, r: R): Unit = tokens.access match {
     case ((open,m), update) =>
       m.get(t) match {
-        case Some(Acquiring) =>
-          if (!update(open -> m.edit(t, _ => Some(Acquired(r)))))
+        case Some(None) =>
+          if (!update(open -> m.edit(t, _ => Some(Some(r)))))
             finishAcquire(t,r) // retry on contention
-        case r => sys.error("expected Acquiring status, got: " + r)
+        case r => sys.error("expected acquiring status, got: " + r)
       }
   }
 }
@@ -84,14 +79,4 @@ private[fs2] object Resources {
 
   def empty[T,R]: Resources[T,R] =
     new Resources[T,R](Ref(true -> LinkedMap.empty))
-
-  sealed trait Status[+V]
-  object Status {
-    /** Indicates a resource is in the process of being acquired for this path. */
-    case object Acquiring extends Status[Nothing]
-    /** Indicates the path is open, but no resources are associated with it. */
-    case object Open extends Status[Nothing]
-    /** The path is open, and there is an associated cleanup action. */
-    case class Acquired[V](cleanup: V) extends Status[V]
-  }
 }

--- a/core/src/main/scala/fs2/internal/Resources.scala
+++ b/core/src/main/scala/fs2/internal/Resources.scala
@@ -1,0 +1,102 @@
+package fs2.internal
+
+import Resources.{Status,Trie}
+import Status._
+
+private[fs2] class Resources[T,R](tokens: Ref[Trie[T, Status[R]]]) {
+
+  def isClosed(path: Seq[T]): Boolean = tokens.get.get(path).isEmpty
+
+  @annotation.tailrec
+  final def open(path: Seq[T]): Boolean = tokens.access match {
+    case (m,update) => m.get(path) match {
+      case None =>
+        update(m.edit(path, Open, _ => Open)) || open(path)
+      case Some(t) =>
+        sys.error("open of already open path: " + path)
+    }
+  }
+
+  @annotation.tailrec
+  final def close(path: Seq[T]): Option[Vector[R]] = tokens.access match {
+    case (m,update) => m.subtree(path) match {
+      case None => Some(Vector.empty)
+      case Some(t) =>
+        def trimmed = t.values.collect { case Status.Acquired(v) => v }.toVector
+        def hasAcquires = t.values.collect { case Status.Acquiring => () }.nonEmpty
+        // fail permanently if any resources are being currently acquired
+        if (hasAcquires) None
+        else if (update(m.trim(path))) Some(trimmed)
+        // retry if failure due to contention
+        else close(path)
+    }
+  }
+
+  @annotation.tailrec
+  final def startAcquire(path: Seq[T]): Boolean = tokens.access match { case (m,update) =>
+    m.get(path) match {
+      case None => false // fail permanently if already closed
+      case Some(_) => update(m.edit(path, Open, _ => Acquiring)) ||
+                      startAcquire(path) // retry on contention
+    }
+  }
+
+  @annotation.tailrec
+  final def finishAcquire(path: Vector[T], r: R): Boolean = tokens.access match { case (m,update) =>
+    m.get(path) match {
+      case None => sys.error("finish acquire called on closed path: " + path)
+      case Some(sub) => update {
+        m.edit(path, Status.Open, _ => Status.Acquired(r))
+      } || finishAcquire(path, r) // retry on contention
+    }
+  }
+}
+
+private[fs2] object Resources {
+
+  trait Status[+V]
+  object Status {
+    /** Indicates a resource is in the process of being acquired for this path. */
+    case object Acquiring extends Status[Nothing]
+    /** Indicates the path is open, but no resources are associated with it. */
+    case object Open extends Status[Nothing]
+    /** The path is open, and there is an associated cleanup action. */
+    case class Acquired[V](cleanup: V) extends Status[V]
+  }
+
+  case class Trie[K,V](value: V, children: LinkedMap[K,Trie[K,V]]) {
+    def subtree(s: Seq[K]): Option[Trie[K,V]] =
+      s.foldLeft(Some(this): Option[Trie[K,V]]) { (cur,k) =>
+        cur.flatMap { cur => cur.children.get(k) }
+      }
+    /** Cut off subtrees that are prefixed by `s`, including `s`. */
+    def trim(s: Seq[K]): Trie[K,V] = s match {
+      case Seq() => this
+      case Seq(hd, tl@_*) =>
+        Trie(value, children.edit(hd, sub => sub.map(_.trim(tl))))
+    }
+
+    /**
+     * Insert `s` into this `Trie`. If internal nodes must be created,
+     * to create a leaf node with a path of `s`, they are given the value
+     * `spine`. The leaf node created by this edit will have a value `leaf(spine)`.
+     */
+    def edit(s: Seq[K], spine: V, leaf: V => V): Trie[K,V] = s match {
+      case Seq() => Trie(leaf(value), LinkedMap.empty)
+      case Seq(hd, tl@_*) =>
+        val children2 = children.edit(
+          hd,
+          sub => Some { sub.getOrElse(Trie(spine, LinkedMap.empty[K,Trie[K,V]]))
+                           .edit(tl, spine, leaf) }
+        )
+        Trie(value, children2)
+    }
+
+    def get(s: Seq[K]): Option[V] = subtree(s).map(_.value)
+    def along(s: Seq[K]): List[V] = s match {
+      case Seq() => List(value)
+      case Seq(hd, tl@_*) => children.get(hd).map(t => value :: t.along(tl)).getOrElse(List())
+    }
+    def values: Stream[V] = children.values.toStream.flatMap(_.values) ++ Stream(value)
+  }
+}

--- a/core/src/main/scala/fs2/internal/Resources.scala
+++ b/core/src/main/scala/fs2/internal/Resources.scala
@@ -1,60 +1,91 @@
 package fs2.internal
 
-import Resources.{Status,Trie}
+import Resources.Status
 import Status._
 
-private[fs2] class Resources[T,R](tokens: Ref[Trie[T, Status[R]]]) {
+private[fs2] class Resources[T,R](tokens: Ref[(Boolean, LinkedMap[T, Status[R]])]) {
 
-  def isClosed(path: Seq[T]): Boolean = tokens.get.get(path).isEmpty
+  def isClosed(t: T): Boolean = tokens.get._2.get(t).isEmpty
 
+  /**
+   * Mark the token `t` as being in the `Open` state.
+   * This must be done before any calls to `startAcquire`
+   * for `t`.
+   */
   @annotation.tailrec
-  final def open(path: Seq[T]): Boolean = tokens.access match {
-    case (m,update) => m.get(path) match {
+  final def open(t: T): Unit = tokens.access match {
+    case ((isOpen,m),update) => m.get(t) match {
       case None =>
-        update(m.edit(path, Open, _ => Open)) || open(path)
+        if (!update((isOpen,m.edit(t, _ => Some(Open))))) open(t)
       case Some(t) =>
-        sys.error("open of already open path: " + path)
+        sys.error("open of already open token: " + t)
+    }
+  }
+
+  /**
+   * Close this `Resources` and return all acquired resources.
+   * The `Boolean` is `false` if there are any outstanding
+   * resources in the `Acquiring` state. After finishing,
+   * no calls to `startAcquire` will succeed.
+   */
+  @annotation.tailrec
+  final def closeAll: (List[R], Boolean) = tokens.access match {
+    case ((open,m),update) =>
+      val rs = m.values.collect { case Acquired(r) => r }.toList
+      val anyAcquiring = m.values.exists(_ == Acquiring)
+      val m2 = m.unorderedEntries.foldLeft(m) { (m,kv) =>
+        kv._2 match {
+          case Acquiring => m
+          case _ => m - kv._1
+        }
+      }
+      if (!update((false, m2))) closeAll
+      else (rs, !anyAcquiring)
+  }
+
+  @annotation.tailrec
+  final def close(t: T): Option[R] = tokens.access match {
+    case ((open,m),update) => m.get(t) match {
+      case None => None // pattern matching so this can be tailrec
+      case Some(Acquired(r)) =>
+        if (update((open, m-t))) Some(r)
+        else close(t)
+      case Some(Open) =>
+        if (update((open,m-t))) None
+        else close(t)
+      case Some(Acquiring) => None
     }
   }
 
   @annotation.tailrec
-  final def close(path: Seq[T]): Option[Vector[R]] = tokens.access match {
-    case (m,update) => m.subtree(path) match {
-      case None => Some(Vector.empty)
-      case Some(t) =>
-        def trimmed = t.values.collect { case Status.Acquired(v) => v }.toVector
-        def hasAcquires = t.values.collect { case Status.Acquiring => () }.nonEmpty
-        // fail permanently if any resources are being currently acquired
-        if (hasAcquires) None
-        else if (update(m.trim(path))) Some(trimmed)
-        // retry if failure due to contention
-        else close(path)
-    }
+  final def startAcquire(t: T): Boolean = tokens.access match {
+    case ((open,m), update) =>
+      m.get(t) match {
+        case Some(_) if open =>
+          update(open -> m.edit(t, _ => Some(Acquiring))) ||
+          startAcquire(t) // retry on contention
+        case _ => false // fail permanently if already closed
+      }
   }
 
   @annotation.tailrec
-  final def startAcquire(path: Seq[T]): Boolean = tokens.access match { case (m,update) =>
-    m.get(path) match {
-      case None => false // fail permanently if already closed
-      case Some(_) => update(m.edit(path, Open, _ => Acquiring)) ||
-                      startAcquire(path) // retry on contention
-    }
-  }
-
-  @annotation.tailrec
-  final def finishAcquire(path: Vector[T], r: R): Boolean = tokens.access match { case (m,update) =>
-    m.get(path) match {
-      case None => sys.error("finish acquire called on closed path: " + path)
-      case Some(sub) => update {
-        m.edit(path, Status.Open, _ => Status.Acquired(r))
-      } || finishAcquire(path, r) // retry on contention
-    }
+  final def finishAcquire(t: T, r: R): Unit = tokens.access match {
+    case ((open,m), update) =>
+      m.get(t) match {
+        case Some(Acquiring) =>
+          if (!update(open -> m.edit(t, _ => Some(Acquired(r)))))
+            finishAcquire(t,r) // retry on contention
+        case r => sys.error("expected Acquiring status, got: " + r)
+      }
   }
 }
 
 private[fs2] object Resources {
 
-  trait Status[+V]
+  def empty[T,R]: Resources[T,R] =
+    new Resources[T,R](Ref(true -> LinkedMap.empty))
+
+  sealed trait Status[+V]
   object Status {
     /** Indicates a resource is in the process of being acquired for this path. */
     case object Acquiring extends Status[Nothing]
@@ -62,41 +93,5 @@ private[fs2] object Resources {
     case object Open extends Status[Nothing]
     /** The path is open, and there is an associated cleanup action. */
     case class Acquired[V](cleanup: V) extends Status[V]
-  }
-
-  case class Trie[K,V](value: V, children: LinkedMap[K,Trie[K,V]]) {
-    def subtree(s: Seq[K]): Option[Trie[K,V]] =
-      s.foldLeft(Some(this): Option[Trie[K,V]]) { (cur,k) =>
-        cur.flatMap { cur => cur.children.get(k) }
-      }
-    /** Cut off subtrees that are prefixed by `s`, including `s`. */
-    def trim(s: Seq[K]): Trie[K,V] = s match {
-      case Seq() => this
-      case Seq(hd, tl@_*) =>
-        Trie(value, children.edit(hd, sub => sub.map(_.trim(tl))))
-    }
-
-    /**
-     * Insert `s` into this `Trie`. If internal nodes must be created,
-     * to create a leaf node with a path of `s`, they are given the value
-     * `spine`. The leaf node created by this edit will have a value `leaf(spine)`.
-     */
-    def edit(s: Seq[K], spine: V, leaf: V => V): Trie[K,V] = s match {
-      case Seq() => Trie(leaf(value), LinkedMap.empty)
-      case Seq(hd, tl@_*) =>
-        val children2 = children.edit(
-          hd,
-          sub => Some { sub.getOrElse(Trie(spine, LinkedMap.empty[K,Trie[K,V]]))
-                           .edit(tl, spine, leaf) }
-        )
-        Trie(value, children2)
-    }
-
-    def get(s: Seq[K]): Option[V] = subtree(s).map(_.value)
-    def along(s: Seq[K]): List[V] = s match {
-      case Seq() => List(value)
-      case Seq(hd, tl@_*) => children.get(hd).map(t => value :: t.along(tl)).getOrElse(List())
-    }
-    def values: Stream[V] = children.values.toStream.flatMap(_.values) ++ Stream(value)
   }
 }

--- a/core/src/main/scala/fs2/task.scala
+++ b/core/src/main/scala/fs2/task.scala
@@ -18,7 +18,7 @@ object task {
   }
 
   /** Convert a single use callback-y API to a single-element stream. */
-  def async1[O](register: (Either[Throwable,O] => Unit) => Unit): Stream[Task,O] =
+  def async1[O](register: (Either[Throwable,O] => Unit) => Unit)(implicit S: Strategy): Stream[Task,O] =
     Stream.eval(Task.async(register))
 
   // todo: I have a feeling that strictly returning an `Ack` will not

--- a/core/src/main/scala/fs2/util/Free.scala
+++ b/core/src/main/scala/fs2/util/Free.scala
@@ -7,10 +7,10 @@ sealed trait Free[+F[_],+A] {
   def flatMap[F2[x]>:F[x],B](f: A => Free[F2,B]): Free[F2,B] = Bind(this, f)
   def map[B](f: A => B): Free[F,B] = Bind(this, f andThen (Free.Pure(_)))
 
-  def runTranslateInterruptible[G[_],A2>:A](interrupt: () => Option[Throwable], g: F ~> G)(implicit G: Catchable[G]): G[A2] =
-    step._runTranslateInterruptible(interrupt, g)
+  def runTranslate[G[_],A2>:A](g: F ~> G)(implicit G: Catchable[G]): G[A2] =
+    step._runTranslate(g)
 
-  protected def _runTranslateInterruptible[G[_],A2>:A](interrupt: () => Option[Throwable], g: F ~> G)(implicit G: Catchable[G]): G[A2]
+  protected def _runTranslate[G[_],A2>:A](g: F ~> G)(implicit G: Catchable[G]): G[A2]
 
   def unroll[G[+_]](implicit G: Functor[G], S: Sub1[F,G])
   : Unroll[A, G[Free[F,A]]]
@@ -19,14 +19,8 @@ sealed trait Free[+F[_],+A] {
   protected def _unroll[G[+_]](implicit G: Functor[G], S: Sub1[F,G])
   : Trampoline[Unroll[A, G[Free[F,A]]]]
 
-  def runTranslate[G[_],A2>:A](g: F ~> G)(implicit G: Catchable[G]): G[A2] =
-    runTranslateInterruptible(() => None, g)
-
   def run[F2[x]>:F[x], A2>:A](implicit F2: Catchable[F2]): F2[A2] =
     (this: Free[F2,A2]).runTranslate(UF1.id)
-
-  def runInterruptible[F2[x]>:F[x], A2>:A](interrupt: () => Option[Throwable])(implicit F2: Catchable[F2]): F2[A2] =
-    (this: Free[F2,A2]).runTranslateInterruptible(interrupt, UF1.id)
 
   @annotation.tailrec
   private[fs2] final def step: Free[F,A] = this match {
@@ -51,36 +45,30 @@ object Free {
     pure(()) flatMap { _ => fa }
 
   private[fs2] case class Fail(err: Throwable) extends Free[Nothing,Nothing] {
-    def _runTranslateInterruptible[G[_],A2>:Nothing](interrupt: () => Option[Throwable], g: Nothing ~> G)(implicit G: Catchable[G]): G[A2] =
+    def _runTranslate[G[_],A2>:Nothing](g: Nothing ~> G)(implicit G: Catchable[G]): G[A2] =
       G.fail(err)
     def _unroll[G[+_]](implicit G: Functor[G], S: Sub1[Nothing,G])
     : Trampoline[Unroll[Nothing, G[Free[Nothing,Nothing]]]]
     = Trampoline.done { Unroll.Fail(err) }
   }
   private[fs2] case class Pure[A](a: A) extends Free[Nothing,A] {
-    def _runTranslateInterruptible[G[_],A2>:A](interrupt: () => Option[Throwable], g: Nothing ~> G)(implicit G: Catchable[G]): G[A2] =
+    def _runTranslate[G[_],A2>:A](g: Nothing ~> G)(implicit G: Catchable[G]): G[A2] =
       G.pure(a)
     def _unroll[G[+_]](implicit G: Functor[G], S: Sub1[Nothing,G])
     : Trampoline[Unroll[A, G[Free[Nothing,A]]]]
     = Trampoline.done { Unroll.Pure(a) }
   }
   private[fs2] case class Eval[F[_],A](fa: F[A]) extends Free[F,Either[Throwable,A]] {
-    def _runTranslateInterruptible[G[_],A2>:Either[Throwable,A]](interrupt: () => Option[Throwable], g: F ~> G)(implicit G: Catchable[G]): G[A2] =
-      interrupt() match {
-        case None => G.attempt { g(fa) }.asInstanceOf[G[A2]]
-        case Some(err) => G.fail(err)
-      }
+    def _runTranslate[G[_],A2>:Either[Throwable,A]](g: F ~> G)(implicit G: Catchable[G]): G[A2] =
+      G.attempt { g(fa) }.asInstanceOf[G[A2]]
 
     def _unroll[G[+_]](implicit G: Functor[G], S: Sub1[F,G])
     : Trampoline[Unroll[Either[Throwable,A], G[Free[F,Either[Throwable,A]]]]]
     = Trampoline.done { Unroll.Eval(G.map(S(fa))(a => Free.pure(Right(a)))) }
   }
   private[fs2] case class Bind[+F[_],R,A](r: Free[F,R], f: R => Free[F,A]) extends Free[F,A] {
-    def _runTranslateInterruptible[G[_],A2>:A](interrupt: () => Option[Throwable], g: F ~> G)(implicit G: Catchable[G]): G[A2] =
-      interrupt() match {
-        case Some(err) => G.fail(err)
-        case None => G.bind(r._runTranslateInterruptible(interrupt, g))(f andThen (_.runTranslateInterruptible(interrupt,g)))
-      }
+    def _runTranslate[G[_],A2>:A](g: F ~> G)(implicit G: Catchable[G]): G[A2] =
+      G.bind(r._runTranslate(g))(f andThen (_.runTranslate(g)))
     def _unroll[G[+_]](implicit G: Functor[G], S: Sub1[F,G])
     : Trampoline[Unroll[A, G[Free[F,A]]]]
     = Sub1.substFree(r) match {

--- a/core/src/test/scala/fs2/ConcurrentSpec.scala
+++ b/core/src/test/scala/fs2/ConcurrentSpec.scala
@@ -73,9 +73,10 @@ object ConcurrentSpec extends Properties("concurrent") {
       (concurrent.join(10)(Stream(full, hang)).take(1) === Vector(42)) &&
       (concurrent.join(10)(Stream(full, hang2)).take(1) === Vector(42)) &&
       (concurrent.join(10)(Stream(full, hang3)).take(1) === Vector(42)) &&
-      true
-      // todo: why does this hang?
-      // (concurrent.join(10)(Stream(hang3,hang2,full)).take(1) === Vector(42))
+      (concurrent.join(10)(Stream(hang3,hang2,full)).take(1) === Vector(42))
     }
+
+    def observe[A](msg: String, s: Stream[Task,A]) =
+      s.map { a => println(msg + ": " + a); a }
   }}
 }

--- a/core/src/test/scala/fs2/ConcurrentSpec.scala
+++ b/core/src/test/scala/fs2/ConcurrentSpec.scala
@@ -9,8 +9,6 @@ import org.scalacheck._
 
 object ConcurrentSpec extends Properties("concurrent") {
 
-  val x = implicitly[Strategy]
-
   property("either") = forAll { (s1: PureStream[Int], s2: PureStream[Int]) =>
     val shouldCompile = s1.get.either(s2.get.covary[Task])
     val es = run { s1.get.covary[Task].pipe2(s2.get)(wye.either) }

--- a/core/src/test/scala/fs2/ConcurrentSpec.scala
+++ b/core/src/test/scala/fs2/ConcurrentSpec.scala
@@ -1,7 +1,6 @@
 package fs2
 
 import TestUtil._
-import fs2.PlayGroundSpec._
 import fs2.util.Task
 import fs2.Stream.Handle
 import java.util.concurrent.atomic.AtomicLong

--- a/core/src/test/scala/fs2/TestUtil.scala
+++ b/core/src/test/scala/fs2/TestUtil.scala
@@ -7,7 +7,8 @@ import scala.concurrent.duration._
 
 object TestUtil {
 
-  implicit val S = Strategy.fromExecutionContext(scala.concurrent.ExecutionContext.global)
+  implicit val S = Strategy.fromFixedDaemonPool(8)
+  // implicit val S = Strategy.fromCachedDaemonPool("test-thread-worker")
 
   def run[A](s: Stream[Task,A]): Vector[A] = s.runLog.run.run
   def runFor[A](timeout:FiniteDuration = 3.seconds)(s: Stream[Task,A]): Vector[A] = s.runLog.run.runFor(timeout)

--- a/core/src/test/scala/fs2/internal/RefSpec.scala
+++ b/core/src/test/scala/fs2/internal/RefSpec.scala
@@ -1,0 +1,19 @@
+package fs2
+package internal
+
+import TestUtil._
+import org.scalacheck.Prop._
+import org.scalacheck._
+import java.util.concurrent.CountDownLatch
+
+object RefSpec extends Properties("Ref") {
+
+  property("modify") = forAll(Gen.choose(1,100)) { n =>
+    val ref = Ref(0)
+    val latch = new CountDownLatch(2)
+    S { (0 until n).foreach { _ => ref.modify(_ + 1) }; latch.countDown }
+    S { (0 until n).foreach { _ => ref.modify(_ - 1) }; latch.countDown }
+    latch.await
+    ref.get ?= 0
+  }
+}


### PR DESCRIPTION
This should be merged after #526. It replaces the use of `ReentrantLock` with [`Ref.ReadWriteSpinLock`](https://github.com/functional-streams-for-scala/fs2/blob/topic/redesign-fastref/core/src/main/scala/fs2/internal/Ref.scala#L73-L103).

@mpilquist WDYT?

There might be an even lower contention version of this, based on `LongAdder` to track the reader count, but I gave up trying to figure that out.