### PR TITLE
Add async read/write based on NIO

### DIFF
--- a/core/src/main/scala/fs2/PullDerived.scala
+++ b/core/src/main/scala/fs2/PullDerived.scala
@@ -2,6 +2,15 @@ package fs2
 
 trait PullDerived { self: fs2.Pull.type =>
 
+  /**
+   * Acquire a resource within a `Pull`. The cleanup action will be run at the end
+   * of the `.run` scope which executes the returned `Pull`.
+   */
+  def acquire[F[_],R](r: F[R])(cleanup: R => F[Unit]): Pull[F,Nothing,R] =
+    Stream.bracket(r)(Stream.emit, cleanup).open.flatMap { h => h.await1.flatMap {
+      case r #: _ => Pull.pure(r)
+    }}
+
   def map[F[_],W,R0,R](p: Pull[F,W,R0])(f: R0 => R): Pull[F,W,R] =
     flatMap(p)(f andThen pure)
 

--- a/core/src/main/scala/fs2/util/Free.scala
+++ b/core/src/main/scala/fs2/util/Free.scala
@@ -171,5 +171,6 @@ object Free {
   new Monad[({ type f[x] = Free[F,x]})#f] {
     def pure[A](a: A) = Pure(a)
     def bind[A,B](a: Free[F,A])(f: A => Free[F,B]) = a flatMap f
+    def suspend[A](a: => A): Free[F, A] = Free.suspend(Free.pure(a))
   }
 }

--- a/core/src/main/scala/fs2/util/Monad.scala
+++ b/core/src/main/scala/fs2/util/Monad.scala
@@ -4,6 +4,7 @@ trait Monad[F[_]] extends Functor[F] {
   def map[A,B](a: F[A])(f: A => B): F[B] = bind(a)(f andThen (pure))
   def bind[A,B](a: F[A])(f: A => F[B]): F[B]
   def pure[A](a: A): F[A]
+  def suspend[A](a: => A): F[A]
 
   def traverse[A,B](v: Seq[A])(f: A => F[B]): F[Vector[B]] =
     v.reverse.foldLeft(pure(Vector.empty[B])) {

--- a/core/src/main/scala/fs2/util/Task.scala
+++ b/core/src/main/scala/fs2/util/Task.scala
@@ -417,6 +417,7 @@ private[fs2] trait Instances1 {
     def attempt[A](t: Task[A]) = t.attempt
     def pure[A](a: A) = Task.now(a)
     def bind[A,B](a: Task[A])(f: A => Task[B]): Task[B] = a flatMap f
+    def suspend[A](a: => A) = Task.delay(a)
   }
 }
 
@@ -433,6 +434,7 @@ private[fs2] trait Instances extends Instances1 {
     def setFree[A](q: Ref[A])(a: Free[Task, A]): Task[Unit] = q.setFree(a)
     def bind[A, B](a: Task[A])(f: (A) => Task[B]): Task[B] = a flatMap f
     def pure[A](a: A): Task[A] = Task.now(a)
+    def suspend[A](a: => A): Task[A] = Task.delay(a)
     def fail[A](err: Throwable): Task[A] = Task.fail(err)
     def attempt[A](fa: Task[A]): Task[Either[Throwable, A]] = fa.attempt
   }

--- a/io/src/main/scala/fs2/io/file/FileHandle.scala
+++ b/io/src/main/scala/fs2/io/file/FileHandle.scala
@@ -1,0 +1,82 @@
+package fs2.io.file
+
+import fs2.Chunk
+
+trait FileHandle[F[_]] {
+  type Lock
+
+  /**
+    * Close the `FileHandle`.
+    */
+  def close(): F[Unit]
+
+  /**
+    * Force any updates for the underlying file to storage.
+    * @param metaData If true, also attempts to force file metadata updates to storage.
+    */
+  def force(metaData: Boolean): F[Unit]
+
+  /**
+    * Acquire an exclusive lock on the underlying file.
+    * @return a lock object which can be used to unlock the file.
+    */
+  def lock: F[Lock]
+
+  /**
+    * Acquire a lock on the specified region of the underlying file.
+    * @param position the start of the region to lock.
+    * @param size the size of the region to lock.
+    * @param shared to request a shared lock across process boundaries (may be converted to an exclusive lock on some operating systems).
+    * @return a lock object which can be used to unlock the region.
+    */
+  def lock(position: Long, size: Long, shared: Boolean): F[Lock]
+
+  /**
+    * Read the specified number of bytes at a particular offset.
+    * @param numBytes the number of bytes to read.
+    * @param offset the offset from the start of the file.
+    * @return a number of bytes from the file (at most, numBytes in size).
+    */
+  def read(numBytes: Int, offset: Long): F[Option[Chunk[Byte]]]
+
+  /**
+    * Report the current size of the file.
+    * @return the size of the file.
+    */
+  def size: F[Long]
+
+  /**
+    * Truncate the underlying file to the specified size.
+    * @param size the size of the file after truncation.
+    */
+  def truncate(size: Long): F[Unit]
+
+  /**
+    * Attempt to acquire an exclusive lock on the underlying file.
+    * @return if the lock could be acquired, a lock object which can be used to unlock the file.
+    */
+  def tryLock: F[Option[Lock]]
+
+  /**
+    * Attempt to acquire a lock on the specified region of the underlying file.
+    * @param position the start of the region to lock.
+    * @param size the size of the region to lock.
+    * @param shared to request a shared lock across process boundaries (may be converted to an exclusive lock on some operating systems).
+    * @return if the lock could be acquired, a lock object which can be used to unlock the region.
+    */
+  def tryLock(position: Long, size: Long, shared: Boolean): F[Option[Lock]]
+
+  /**
+    * Unlock the (exclusive or regional) lock represented by the supplied `Lock`.
+    * @param lock the lock object which represents the locked file or region.
+    */
+  def unlock(lock: Lock): F[Unit]
+
+  /**
+    * Write the specified bytes at a particular offset.
+    * @param bytes the bytes to write to the `FileHandle`.
+    * @param offset the offset at which to write the bytes.
+    * @return the number of bytes written.
+    */
+  def write(bytes: Chunk[Byte], offset: Long): F[Int]
+}

--- a/io/src/main/scala/fs2/io/file/package.scala
+++ b/io/src/main/scala/fs2/io/file/package.scala
@@ -1,0 +1,215 @@
+package fs2.io
+
+import java.nio.ByteBuffer
+import java.nio.channels.{AsynchronousFileChannel, CompletionHandler, FileChannel, FileLock}
+import java.nio.file.{OpenOption, Path, StandardOpenOption}
+
+import fs2.Stream.Handle
+import fs2._
+import fs2.util.Monad
+
+package object file {
+
+  /**
+    * Provides a handler for NIO methods which require a `java.nio.channels.CompletionHandler` instance.
+    */
+  private[fs2] def asyncCompletionHandler[F[_], O](f: CompletionHandler[O, Null] => F[Unit])(implicit F: Async[F], S: Strategy): F[O] = {
+    F.async[O] { cb =>
+      f(new CompletionHandler[O, Null] {
+        override def completed(result: O, attachment: Null): Unit = S(cb(Right(result)))
+        override def failed(exc: Throwable, attachment: Null): Unit = S(cb(Left(exc)))
+      })
+    }
+  }
+
+  /**
+    * Creates a `FileHandle[F]` from a `java.nio.channels.AsynchronousFileChannel`.
+    *
+    * Uses a `java.nio.Channels.CompletionHandler` to handle callbacks from IO operations.
+    */
+  private[fs2] def fromAsynchronousFileChannel[F[_]](chan: AsynchronousFileChannel)(implicit F: Async[F], S: Strategy): FileHandle[F] = {
+    new FileHandle[F] {
+      type Lock = FileLock
+
+      override def close(): F[Unit] =
+        F.suspend(chan.close())
+
+      override def force(metaData: Boolean): F[Unit] =
+        F.suspend(chan.force(metaData))
+
+      override def lock: F[Lock] =
+        asyncCompletionHandler[F, Lock](f => F.pure(chan.lock(null, f)))
+
+      override def lock(position: Long, size: Long, shared: Boolean): F[Lock] =
+        asyncCompletionHandler[F, Lock](f => F.pure(chan.lock(position, size, shared, null, f)))
+
+      override def read(numBytes: Int, offset: Long): F[Option[Chunk[Byte]]] = {
+        val buf = ByteBuffer.allocate(numBytes)
+        F.bind(
+          asyncCompletionHandler[F, Integer](f => F.pure(chan.read(buf, offset, null, f))))(
+          len => F.pure {
+            if (len < 0) None else if (len == 0) Some(Chunk.empty) else Some(Chunk.bytes(buf.array.take(len)))
+          }
+        )
+      }
+
+      override def size: F[Long] =
+        F.suspend(chan.size)
+
+      override def truncate(size: Long): F[Unit] =
+        F.suspend { chan.truncate(size); () }
+
+      override def tryLock: F[Option[Lock]] =
+        F.map(F.suspend(chan.tryLock()))(Option.apply)
+
+      override def tryLock(position: Long, size: Long, shared: Boolean): F[Option[Lock]] =
+        F.map(F.suspend(chan.tryLock(position, size, shared)))(Option.apply)
+
+      override def unlock(f: Lock): F[Unit] =
+        F.suspend(f.release())
+
+      override def write(bytes: Chunk[Byte], offset: Long): F[Int] =
+        F.map(
+          asyncCompletionHandler[F, Integer](f => F.pure(chan.write(ByteBuffer.wrap(bytes.toArray), offset, null, f))))(
+          i => i.toInt
+        )
+    }
+  }
+
+  /**
+    * Creates a `FileHandle[F]` from a `java.nio.channels.FileChannel`.
+    */
+  private[fs2] def fromFileChannel[F[_]](chan: FileChannel)(implicit F: Monad[F]): FileHandle[F] = {
+    new FileHandle[F] {
+      type Lock = FileLock
+
+      override def close(): F[Unit] =
+        F.suspend(chan.close())
+
+      override def force(metaData: Boolean): F[Unit] =
+        F.suspend(chan.force(metaData))
+
+      override def lock: F[Lock] =
+        F.suspend(chan.lock)
+
+      override def lock(position: Long, size: Long, shared: Boolean): F[Lock] =
+        F.suspend(chan.lock(position, size, shared))
+
+      override def read(numBytes: Int, offset: Long): F[Option[Chunk[Byte]]] = {
+        val buf = ByteBuffer.allocate(numBytes)
+        F.bind(
+          F.suspend(chan.read(buf, offset)))(len => F.pure {
+          if (len < 0) None else if (len == 0) Some(Chunk.empty) else Some(Chunk.bytes(buf.array.take(len)))
+        }
+        )
+      }
+
+      override def size: F[Long] =
+        F.suspend(chan.size)
+
+      override def truncate(size: Long): F[Unit] =
+        F.suspend { chan.truncate(size); () }
+
+      override def tryLock: F[Option[Lock]] =
+        F.suspend(Option(chan.tryLock()))
+
+      override def tryLock(position: Long, size: Long, shared: Boolean): F[Option[Lock]] =
+        F.suspend(Option(chan.tryLock(position, size, shared)))
+
+      override def unlock(f: Lock): F[Unit] =
+        F.suspend(f.release())
+
+      override def write(bytes: Chunk[Byte], offset: Long): F[Int] =
+        F.suspend(chan.write(ByteBuffer.wrap(bytes.toArray), offset))
+    }
+  }
+
+  //
+  // Stream constructors
+  //
+
+  /**
+    * Reads all data synchronously from the file at the specified `java.nio.file.Path`.
+    */
+  def readAll[F[_]](path: Path, chunkSize: Int)(implicit F: Monad[F]): Stream[F, Byte] =
+    open(path, List(StandardOpenOption.READ)).flatMap(readAllFromFileHandle(chunkSize)).run
+
+  /**
+    * Reads all data asynchronously from the file at the specified `java.nio.file.Path`.
+    */
+  def readAllAsync[F[_]](path: Path, chunkSize: Int)(implicit F: Async[F], S: Strategy): Stream[F, Byte] =
+    openAsync(path, List(StandardOpenOption.READ)).flatMap(readAllFromFileHandle(chunkSize)).run
+
+  //
+  // Stream transducers
+  //
+
+  /**
+    * Writes all data synchronously to the file at the specified `java.nio.file.Path`.
+    *
+    * Adds the WRITE flag to any other `OpenOption` flags specified. By default, also adds the CREATE flag.
+    */
+  def writeAll[F[_]](path: Path, flags: Seq[StandardOpenOption] = List(StandardOpenOption.CREATE))(implicit F: Monad[F]): Sink[F, Byte] =
+    s => (for {
+      in <- s.open
+      out <- open(path, StandardOpenOption.WRITE :: flags.toList)
+      _ <- _writeAll0(in, out, 0)
+    } yield ()).run
+
+  /**
+    * Writes all data asynchronously to the file at the specified `java.nio.file.Path`.
+    *
+    * Adds the WRITE flag to any other `OpenOption` flags specified. By default, also adds the CREATE flag.
+    */
+  def writeAllAsync[F[_]](path: Path, flags: Seq[StandardOpenOption] = List(StandardOpenOption.CREATE))(implicit F: Async[F], S: Strategy): Sink[F, Byte] =
+    s => (for {
+      in <- s.open
+      out <- openAsync(path, StandardOpenOption.WRITE :: flags.toList)
+      _ <- _writeAll0(in, out, 0)
+    } yield ()).run
+
+  private def _writeAll0[F[_]](in: Handle[F, Byte], out: FileHandle[F], offset: Long)(implicit F: Monad[F]): Pull[F, Nothing, Unit] = for {
+    hd #: tail <- in.await
+    _ <- _writeAll1(hd, out, offset)
+    next <- _writeAll0(tail, out, offset + hd.size)
+  } yield next
+
+  private def _writeAll1[F[_]](buf: Chunk[Byte], out: FileHandle[F], offset: Long)(implicit F: Monad[F]): Pull[F, Nothing, Unit] =
+    Pull.eval(out.write(buf, offset)) flatMap { (written: Int) =>
+      if (written >= buf.size)
+        Pull.pure(())
+      else
+        _writeAll1(buf.drop(written), out, offset + written)
+    }
+
+  //
+  // Pull constructors
+  //
+
+  /**
+    * Given a `FileHandle[F]`, creates a `Pull` which reads all data from the associated file.
+    */
+  private[fs2] def readAllFromFileHandle[F[_]](chunkSize: Int)(h: FileHandle[F]): Pull[F, Byte, Unit] =
+    _readAllFromFileHandle0(chunkSize, 0)(h)
+
+  private def _readAllFromFileHandle0[F[_]](chunkSize: Int, offset: Long)(h: FileHandle[F]): Pull[F, Byte, Unit] = for {
+    res <- Pull.eval(h.read(chunkSize, offset))
+    next <- res.fold[Pull[F, Byte, Unit]](Pull.done)(o => Pull.output(o) >> _readAllFromFileHandle0(chunkSize, offset + o.size)(h))
+  } yield next
+
+  /**
+    * Creates a `Pull` which allows synchronous file operations against the file at the specified `java.nio.file.Path`.
+    *
+    * The `Pull` closes the acquired `java.nio.channels.FileChannel` when it is done.
+    */
+  def open[F[_]](path: Path, flags: Seq[OpenOption])(implicit F: Monad[F]): Pull[F, Nothing, FileHandle[F]] =
+    Pull.acquire(F.suspend(fromFileChannel(FileChannel.open(path, flags: _*))))(_.close())
+
+  /**
+    * Creates a `Pull` which allows asynchronous file operations against the file at the specified `java.nio.file.Path`.
+    *
+    * The `Pull` closes the acquired `java.nio.channels.AsynchronousFileChannel` when it is done.
+    */
+  def openAsync[F[_]](path: Path, flags: Seq[OpenOption])(implicit F: Async[F], S: Strategy): Pull[F, Nothing, FileHandle[F]] =
+    Pull.acquire(F.suspend(fromAsynchronousFileChannel(AsynchronousFileChannel.open(path, flags: _*))))(_.close())
+}


### PR DESCRIPTION
@pchiusano This is an early stab at implementing some NIO-based file I/O. Feedback welcome on: style, API, general approach.

Generally:
 - `file.open` provides a `Pull` containing a single `AsynchronousFileChannel`.
 - `file.readAsync`, `file.writeAsync` take a `AsynchronousFileChannel` and read/write from/to it asynchronously, given an `Async` instance.
 - `file.readAllAsync` makes use of `file.open` and `file.readAsync` to read a full file as a `Stream`.

I've never been that convinced that being able to provide the buffer size as a streaming input was that useful, so it's not in this version.

(`Monad.suspend` is also in the tcp rework, and seems essential given the cleanup code in `Stream.bracket` is created before any work is done)