### PR TITLE
Fix memory leak in `LinkedMap` implementation

### DIFF
--- a/core/src/main/scala/fs2/internal/LinkedMap.scala
+++ b/core/src/main/scala/fs2/internal/LinkedMap.scala
@@ -17,7 +17,9 @@ private[fs2] class LinkedMap[K,+V](
   def get(k: K): Option[V] = entries.get(k).map(_._1)
 
   /** Insert an entry into this map, overriding any previous entry for the given `K`. */
-  def updated[V2>:V](k: K, v: V2): LinkedMap[K,V2] =
+  def updated[V2>:V](k: K, v: V2): LinkedMap[K,V2] = (this - k).updated_(k, v)
+
+  private def updated_[V2>:V](k: K, v: V2): LinkedMap[K,V2] =
     new LinkedMap(entries.updated(k, (v,nextID)), insertionOrder.updated(nextID, k), nextID+1)
 
   def edit[V2>:V](k: K, f: Option[V2] => Option[V2]): LinkedMap[K,V2] =
@@ -48,7 +50,7 @@ private[fs2] class LinkedMap[K,+V](
 
   def isEmpty = entries.isEmpty
 
-  def size = entries.size
+  def size = entries.size max insertionOrder.size
 
   override def toString = "{ " + (keys zip values).mkString("  ") +" }"
 }

--- a/core/src/main/scala/fs2/internal/Resources.scala
+++ b/core/src/main/scala/fs2/internal/Resources.scala
@@ -20,6 +20,7 @@ private[fs2] class Resources[T,R](tokens: Ref[(Status, LinkedMap[T, Option[R]])]
   def isClosed: Boolean = tokens.get._1 == Closed
   def isClosing: Boolean = { val t = tokens.get._1; t == Closing || t == Closed }
   def isEmpty: Boolean = tokens.get._2.isEmpty
+  def size: Int = tokens.get._2.size
 
   /**
    * Close this `Resources` and return all acquired resources.

--- a/core/src/test/scala/fs2/ResourceTrackerSanityTest.scala
+++ b/core/src/test/scala/fs2/ResourceTrackerSanityTest.scala
@@ -1,0 +1,15 @@
+package fs2
+
+import fs2.util.Task
+
+/**
+ * Sanity test - not run as part of unit tests, but this should run forever
+ * at constant memory.
+ */
+object ResourceTrackerSanityTest extends App {
+
+   val big = Stream.constant(1).flatMap { n =>
+      Stream.bracket(Task.delay(()))(_ => Stream.emits(List(1, 2, 3)), _ => Task.delay(()))
+   }
+   big.run.run.run
+}


### PR DESCRIPTION
This fixes a memory leak reported by @mpilquist in the following code:

```Scala
   val big = Stream.constant(1).flatMap { n =>
      Stream.bracket(Task.delay(()))(_ => Stream.emits(List(1, 2, 3)), _ => Task.delay(()))
   }
   big.run.run.run
```

(this is now checked in as `ResourceTrackerSanityTest.scala` in the tests. Just as a standalone main for now, though if anyone would like to automate the test somehow that would be great.)

Issue was that `LinkedMap.updated` was not first removing the old key (if it existed), so a bunch of deleted keys were being accumulated in `insertionOrder`.