### PR TITLE
Fix to Pull.eval that would allow exceptions to go uncaught

### DIFF
--- a/core/src/main/scala/fs2/Stream.scala
+++ b/core/src/main/scala/fs2/Stream.scala
@@ -388,7 +388,7 @@ object Stream extends Streams[Stream] with StreamDerived {
       Pull.onError(Sub1.substStream(s)._step0(rights).map {
         // keep the error handler in scope as we traverse the stream `s`
         case Step(hd,tl) =>
-             Step(hd, new Handle(List(), Stream.onError(tl.stream)(Sub1.substStreamF(handle))))
+             Step(hd, new Handle(tl.buffer, Stream.onError(tl.stream)(Sub1.substStreamF(handle))))
       }) { err =>
         Pull.suspend { Sub1.substStreamF(handle).apply(err)._step0(rights) }
       }

--- a/core/src/main/scala/fs2/StreamOps.scala
+++ b/core/src/main/scala/fs2/StreamOps.scala
@@ -17,6 +17,9 @@ trait StreamOps[+F[_],+A] extends Process1Ops[F,A] /* with TeeOps[F,A] with WyeO
   def ++[F2[_],B>:A](p2: => Stream[F2,B])(implicit R: RealSupertype[A,B], S: Sub1[F,F2]): Stream[F2,B] =
     Stream.append(Sub1.substStream(self), p2)
 
+  def attempt: Stream[F,Either[Throwable,A]] =
+    self.map(Right(_)).onError(e => Stream.emit(Left(e)))
+
   def append[F2[_],B>:A](p2: => Stream[F2,B])(implicit R: RealSupertype[A,B], S: Sub1[F,F2]): Stream[F2,B] =
     Stream.append(Sub1.substStream(self), p2)
 

--- a/core/src/test/scala/fs2/StreamSpec.scala
+++ b/core/src/test/scala/fs2/StreamSpec.scala
@@ -67,12 +67,18 @@ object StreamSpec extends Properties("Stream") {
     s2.onError(_ => Stream.empty) ==? run(s.get)
   }
 
-  property("onError (2)") = secure {
+  property("onError (2)") = protect {
     (Stream.fail(Err) onError { _ => Stream.emit(1) }) === Vector(1)
   }
 
-  property("onError (3)") = secure {
+  property("onError (3)") = protect {
     (Stream.emit(1) ++ Stream.fail(Err) onError { _ => Stream.emit(1) }) === Vector(1,1)
+  }
+
+  property("onError (4)") = protect {
+    Stream.eval(Task.delay(throw Err)).map(Right(_)).onError(t => Stream.emit(Left(t)))
+          .take(1)
+          .runLog.run.run ?= Vector(Left(Err))
   }
 
   property("range") = protect {


### PR DESCRIPTION
Caught by @mpilquist. This test previously failed:

```Scala
  property("onError (4)") = protect {
    Stream.eval(Task.delay(throw Err)).map(Right(_)).onError(t => Stream.emit(Left(t)))
          .take(1)
          .runLog.run.run ?= Vector(Left(Err))
  }
```

Now it passes. Also added `Stream.attempt` convenience function.