### PR TITLE
Eliminate class of time/space leaks from internal use of nonstrict append

### DIFF
--- a/core/src/main/scala/fs2/Pull.scala
+++ b/core/src/main/scala/fs2/Pull.scala
@@ -141,7 +141,7 @@ object Pull extends Pulls[Pull] with PullDerived with pull1 with pull2 {
     def _run1[F2[_],W2>:W,R1>:R,R2](doCleanup: Boolean, tracked: LinkedSet[Token], k: Stack[F2,W2,R1,R2])(
       implicit S: Sub1[F,F2]): Stream[F2,W2]
       =
-      Sub1.substStream(s).append(pure(())._run1(doCleanup, tracked, k))
+      Stream.zppend(Sub1.substStream(s), pure(())._run0(doCleanup, tracked, k))
   }
 
   def or[F[_],W,R](p1: Pull[F,W,R], p2: => Pull[F,W,R]): Pull[F,W,R] = new Pull[F,W,R] {
@@ -216,7 +216,7 @@ object Pull extends Pulls[Pull] with PullDerived with pull1 with pull2 {
       empty.push(s)
   }
   private[fs2] def runCleanup(doCleanup: Boolean, s: LinkedSet[Token]): Stream[Nothing,Nothing] =
-    if (doCleanup) s.iterator.foldLeft(Stream.empty)((s,id) => Stream.append(Stream.release(id), s))
+    if (doCleanup) s.iterator.foldLeft(Stream.empty)((s,id) => Stream.zppend(Stream.release(id), s))
     else Stream.empty[Nothing,Nothing]
   private[fs2] def orRight[F[_],W,R](s: List[Pull[F,W,R]]): Pull[F,W,R] =
     s.reverse.foldLeft(done: Pull[F,W,R])((tl,hd) => or(hd,tl))

--- a/core/src/test/scala/fs2/MemorySanityChecks.scala
+++ b/core/src/test/scala/fs2/MemorySanityChecks.scala
@@ -25,3 +25,14 @@ object RepeatEvalSanityTest extends App {
   }
   Stream.repeatEval(Task.delay(1)).pipe(id).covary[Task].run.run.run
 }
+
+object AppendSanityTest extends App {
+  val src = Stream.constant(1).covary[Task] ++ Stream.empty
+  val prg = src.pull(Pull.echo)
+  prg.run.run.run
+}
+
+object OnCompleteSanityTest extends App {
+  Stream.constant(1).covary[Task].onComplete(Stream.empty).pull(Pull.echo)
+  .run.run.run
+}

--- a/core/src/test/scala/fs2/StreamPerformanceSpec.scala
+++ b/core/src/test/scala/fs2/StreamPerformanceSpec.scala
@@ -22,17 +22,19 @@ object StreamPerformanceSpec extends Properties("StreamPerformance") {
     Chunk.seq((0 until N) map emit).foldRight(empty: Stream[Pure,Int])(_ ++ _)
   )
 
-  property("left-associated ++") = secure { Ns.forall { N =>
+  property("left-associated ++") = protect { Ns.forall { N =>
+  logTime("left-associated ++ ("+N.toString+")") {
    (1 until N).map(emit).foldLeft(emit(0))(_ ++ _) ===
    Vector.range(0,N)
-  }}
+  }}}
 
-  property("right-associated ++") = secure { Ns.forall { N =>
+  property("right-associated ++") = protect { Ns.forall { N =>
+  logTime("right-associated ++ ("+N.toString+")") {
     Chunk.seq((0 until N).map(emit)).foldRight(empty: Stream[Pure,Int])(_ ++ _) ===
     Vector.range(0,N)
-  }}
+  }}}
 
-  property("left-associated flatMap 1") = secure {
+  property("left-associated flatMap 1") = protect {
     Ns.forall { N => logTime("left-associated flatMap 1 ("+N.toString+")") {
       (1 until N).map(emit).foldLeft(emit(0))(
         (acc,a) => acc flatMap { _ => a }) ===
@@ -40,7 +42,7 @@ object StreamPerformanceSpec extends Properties("StreamPerformance") {
     }}
   }
 
-  property("right-associated flatMap 1") = secure {
+  property("right-associated flatMap 1") = protect {
     Ns.forall { N => logTime("right-associated flatMap 1 ("+N.toString+")") {
       (1 until N).map(emit).reverse.foldLeft(emit(0))(
         (acc,a) => a flatMap { _ => acc }) ===
@@ -48,7 +50,7 @@ object StreamPerformanceSpec extends Properties("StreamPerformance") {
     }}
   }
 
-  property("left-associated flatMap 2") = secure {
+  property("left-associated flatMap 2") = protect {
     Ns.forall { N => logTime("left-associated flatMap 2 ("+N.toString+")") {
       (1 until N).map(emit).foldLeft(emit(0) ++ emit(1) ++ emit(2))(
         (acc,a) => acc flatMap { _ => a }) ===
@@ -56,14 +58,14 @@ object StreamPerformanceSpec extends Properties("StreamPerformance") {
     }}
   }
 
-  property("right-associated flatMap 1") = secure {
+  property("right-associated flatMap 1") = protect {
     Ns.forall { N => logTime("right-associated flatMap 1 ("+N.toString+")") {
       (1 until N).map(emit).reverse.foldLeft(emit(0) ++ emit(1) ++ emit(2))(
         (acc,a) => a flatMap { _ => acc }) === Vector(0,1,2)
     }}
   }
 
-  property("transduce (id)") = secure {
+  property("transduce (id)") = protect {
     Ns.forall { N => logTime("transduce (id) " + N) {
       (chunk(Chunk.seq(0 until N)): Stream[Task,Int]).repeatPull { (s: Handle[Task,Int]) =>
         for {
@@ -74,7 +76,7 @@ object StreamPerformanceSpec extends Properties("StreamPerformance") {
     }
   }
 
-  property("bracket + onError (1)") = secure { Ns.forall { N =>
+  property("bracket + onError (1)") = protect { Ns.forall { N =>
     val open = new AtomicInteger(0)
     val ok = new AtomicInteger(0)
     val bracketed = bracket(Task.delay { open.incrementAndGet })(


### PR DESCRIPTION
This gets rid of any FS2 interpreter internal use of the nonstrict append, which wraps its second argument in a `suspend`. We had a memory leak due to nesting of these suspends. I don't fully understand the bug but this just eliminates this class of errors as a possibility.

I feel like the best solution would be to use types to guarantee that we don't have `suspend { suspend { .. }}` or any nesting of `suspend`, which is redundant and inefficient. I'm not sure if there's a nice way to do this without a major overhaul though. Something to ponder for later, I think this fix is ok for now.