### PR TITLE
Formalized tracing support in the interpreter

### DIFF
--- a/core/src/main/scala/fs2/Stream.scala
+++ b/core/src/main/scala/fs2/Stream.scala
@@ -23,6 +23,9 @@ abstract class Stream[+F[_],+O] extends StreamOps[F,O] { self =>
   override final def runFold[O2](z: O2)(f: (O2,O) => O2): Free[F,O2] =
     get.runFold(z)(f)
 
+  override final def runFoldTrace[O2](t: Trace)(z: O2)(f: (O2,O) => O2): Free[F,O2] =
+    get.runFoldTrace(t)(z)(f)
+
   final def step: Pull[F,Nothing,Step[Chunk[O],Handle[F,O]]] =
     Pull.evalScope(get.step).flatMap {
       case None => Pull.done
@@ -104,6 +107,9 @@ object Stream extends Streams[Stream] with StreamDerived {
 
   def runFold[F[_], A, B](p: Stream[F,A], z: B)(f: (B, A) => B): Free[F,B] =
     p.runFold(z)(f)
+
+  def runFoldTrace[F[_], A, B](t: Trace)(p: Stream[F,A], z: B)(f: (B, A) => B): Free[F,B] =
+    p.runFoldTrace(t)(z)(f)
 
   def scope[F[_],O](s: Stream[F,O]): Stream[F,O] =
     Stream.mk { StreamCore.scope { s.get } }

--- a/core/src/main/scala/fs2/StreamOps.scala
+++ b/core/src/main/scala/fs2/StreamOps.scala
@@ -119,8 +119,14 @@ trait StreamOps[+F[_],+A] extends Process1Ops[F,A] /* with TeeOps[F,A] with WyeO
   def run:Free[F,Unit] =
     Stream.runFold(self,())((_,_) => ())
 
+  def runTrace(t: Trace):Free[F,Unit] =
+    Stream.runFoldTrace(t)(self,())((_,_) => ())
+
   def runFold[B](z: B)(f: (B,A) => B): Free[F,B] =
     Stream.runFold(self, z)(f)
+
+  def runFoldTrace[B](t: Trace)(z: B)(f: (B,A) => B): Free[F,B] =
+    Stream.runFoldTrace(t)(self, z)(f)
 
   def runLog: Free[F,Vector[A]] =
     Stream.runFold(self, Vector.empty[A])(_ :+ _)

--- a/core/src/main/scala/fs2/Streams.scala
+++ b/core/src/main/scala/fs2/Streams.scala
@@ -81,5 +81,6 @@ trait Streams[Stream[+_[_],+_]] { self =>
   // evaluation
 
   def runFold[F[_],A,B](p: Stream[F,A], z: B)(f: (B,A) => B): Free[F,B]
+  def runFoldTrace[F[_],A,B](t: Trace)(p: Stream[F,A], z: B)(f: (B,A) => B): Free[F,B]
 }
 

--- a/core/src/main/scala/fs2/Trace.scala
+++ b/core/src/main/scala/fs2/Trace.scala
@@ -1,0 +1,18 @@
+package fs2
+
+trait Trace {
+  def enabled: Boolean
+  def apply(msg: String): Unit
+}
+
+object Trace {
+  object Stdout extends Trace {
+    val enabled = true
+    def apply(msg: String) = println(msg)
+  }
+  object Off extends Trace {
+    val enabled = false
+    def apply(msg: String) = ()
+  }
+}
+

--- a/core/src/main/scala/fs2/fs2.scala
+++ b/core/src/main/scala/fs2/fs2.scala
@@ -1,11 +1,5 @@
 package object fs2 {
 
-  private[fs2] def trace(msg: => String): Unit = ()
-  private[fs2] class NamedFunction1[-A, +B](f: A => B, name: String) extends (A => B) {
-    def apply(a: A) = f(a)
-    override def toString = s"<$name>"
-  }
-
   type Process1[-I,+O] = process1.Process1[I,O]
   type Tee[-I,-I2,+O] = tee.Tee[I,I2,O]
   type Wye[F[_],-I,-I2,+O] = wye.Wye[F,I,I2,O]


### PR DESCRIPTION
I can't say I'm enamored with this solution, but I think it would be valuable to support tracing without recompiling FS2. Open to suggestions on how better to implement this. I wanted tracing to have as little overhead as possible -- this implementation results in a invokevirtual call and a branch on each step through the interpreter, which is negligible performance wise.