### PR TITLE
Topic/si prompt finalize

### DIFF
--- a/core/src/main/scala/fs2/Pull.scala
+++ b/core/src/main/scala/fs2/Pull.scala
@@ -1,7 +1,8 @@
 package fs2
 
-import fs2.util.{Free,RealSupertype,Sub1}
 import Pull._
+import StreamCore.Token
+import fs2.util.{Free,RealSupertype,Sub1}
 
 class Pull[+F[_],+O,+R](private[fs2] val get: Free[P[F,O]#f,Option[Either[Throwable,R]]]) extends PullOps[F,O,R] {
 
@@ -84,6 +85,10 @@ object Pull extends Pulls[Pull] with PullDerived with pull1 {
 
   def outputs[F[_],O](s: Stream[F,O]): Pull[F,O,Unit] =
     new Pull(Free.eval[P[F,O]#f,Unit](PF.Output(s.get)).map(_ => Some(Right(()))))
+
+  private[fs2]
+  def release(ts: List[Token]): Pull[Nothing,Nothing,Unit] =
+    outputs(Stream.mk(StreamCore.release(ts).drain))
 
   def pure[R](r: R): Pull[Nothing,Nothing,R] =
     new Pull(Free.pure(Some(Right(r))))

--- a/core/src/main/scala/fs2/internal/LinkedMap.scala
+++ b/core/src/main/scala/fs2/internal/LinkedMap.scala
@@ -44,6 +44,8 @@ private[fs2] class LinkedMap[K,+V](
 
   def unorderedEntries: Iterable[(K,V)] = entries.mapValues(_._1)
 
+  def orderedEntries: Iterable[(K,V)] = keys zip values
+
   /** The keys of this map, in the order they were added. */
   def keys: Iterable[K] = insertionOrder.values
 

--- a/core/src/main/scala/fs2/internal/Resources.scala
+++ b/core/src/main/scala/fs2/internal/Resources.scala
@@ -43,10 +43,10 @@ class Resources[T,R](tokens: Ref[(Status, LinkedMap[T, Option[R]])], val name: S
    * Returns `None` if any resources are in process of being acquired.
    */
   @annotation.tailrec
-  final def closeAll: Option[List[R]] = tokens.access match {
+  final def closeAll: Option[List[(T,R)]] = tokens.access match {
     case ((open,m),update) =>
       val totallyDone = m.values.forall(_ != None)
-      def rs = m.values.collect { case Some(r) => r }.toList
+      def rs = m.orderedEntries.collect { case (t,Some(r)) => (t,r) }.toList
       def m2 = if (!totallyDone) m else LinkedMap.empty[T,Option[R]]
       if (!update((if (totallyDone) Closed else Closing, m2))) closeAll
       else if (totallyDone) Some(rs)

--- a/core/src/test/scala/fs2/async/ChannelSpec.scala
+++ b/core/src/test/scala/fs2/async/ChannelSpec.scala
@@ -23,12 +23,30 @@ object ChannelSpec extends Properties("async.channel") {
   def trace[F[_],A](msg: String)(s: Stream[F,A]) = s mapChunks { a => println(msg + ": " + a.toList); a }
 
   property("sanity-test") = protect { // (s: PureStream[Int]) =>
-    val s = Stream.constant(1)
+    val s = Stream.range(0,100)
     val s2 = s.covary[Task].flatMap { i => Stream.emit(i).onFinalize(Task.delay { println(s"finalizing $i")}) }
     val q = async.unboundedQueue[Task,Int].run
     // q.enqueue1(0).run
     // run { s2 }
-    run { (trace("s2")(s2) merge trace("q")(q.dequeue)).take(10) }
+    run { merge2(trace("s2")(s2), trace("q")(q.dequeue)).take(10) }
+    // ( (trace("s2")(s2) merge trace("q")(q.dequeue)).take(10) ).runTrace(Trace.Off).run.run
     true
+  }
+
+  import Async.Future
+  def merge2[F[_]:Async,A](a: Stream[F,A], a2: Stream[F,A]): Stream[F,A] = {
+    type FS = Future[F,Stream[F,A]] // Option[Step[Chunk[A],Stream[F,A]]]]
+    def go(fa: FS, fa2: FS): Stream[F,A] = (fa race fa2).stream.flatMap {
+      case Left(sa) => sa.uncons.flatMap {
+        case Some(hd #: sa) => Stream.chunk(hd) ++ (sa.fetchAsync flatMap (go(_,fa2)))
+        case None => println("left stream terminated"); fa2.stream.flatMap(identity)
+      }
+      case Right(sa2) => sa2.uncons.flatMap {
+        case Some(hd #: sa2) => Stream.chunk(hd) ++ (sa2.fetchAsync flatMap (go(fa,_)))
+        case None => println("right stream terminated"); fa.stream.flatMap(identity)
+      }
+    }
+    a.fetchAsync flatMap { fa =>
+    a2.fetchAsync flatMap { fa2 => go(fa, fa2) }}
   }
 }


### PR DESCRIPTION
Finalizers now getting called promptly, even in async contexts. Issue is that an async step may try to release a resource token that it doesn't have in its local resources map. Made two fixes:

1. Any such releases are recorded as leftovers; these leftover releases propagate 'outward' until hitting a resources map that has the resource.
2. When the async step is _forced_, we copy any of its locally allocated resources to the parent resources map.

Together, these cover the case where one async step acquires a resource, and the next async step releases it. 