### PR TITLE
Queue-based implementation of concurrent.join

### DIFF
--- a/core/src/main/scala/fs2/async/mutable/Queue.scala
+++ b/core/src/main/scala/fs2/async/mutable/Queue.scala
@@ -141,4 +141,26 @@ object Queue {
         def available: immutable.Signal[F, Int] = Signal.constant(0)
       }
     }}
+
+  /** Like `Queue.synchronous`, except that an enqueue or offer of `None` will never block. */
+  def synchronousNoneTerminated[F[_],A](implicit F: Async[F]): F[Queue[F,Option[A]]] =
+    F.bind(Semaphore(0)) { permits =>
+    F.map(unbounded[F,Option[A]]) { q =>
+      new Queue[F,Option[A]] {
+        def upperBound: Option[Int] = Some(0)
+        def enqueue1(a: Option[A]): F[Unit] = a match {
+          case None => q.enqueue1(None)
+          case _ => F.bind(permits.decrement) { _ => q.enqueue1(a) }
+        }
+        def offer1(a: Option[A]): F[Boolean] = a match {
+          case None => q.offer1(None)
+          case _ => F.bind(permits.tryDecrement) { b => if (b) q.offer1(a) else F.pure(false) }
+        }
+        def dequeue1: F[Option[A]] =
+          F.bind(permits.increment) { _ => q.dequeue1 }
+        def size = q.size
+        def full: immutable.Signal[F, Boolean] = Signal.constant(true)
+        def available: immutable.Signal[F, Int] = Signal.constant(0)
+      }
+    }}
 }

--- a/core/src/test/scala/fs2/ConcurrentSpec.scala
+++ b/core/src/test/scala/fs2/ConcurrentSpec.scala
@@ -38,7 +38,7 @@ object ConcurrentSpec extends Properties("concurrent") {
     run { s1.get }.toSet
   }
 
-  property("join (3)") = protect { println("starting join(3)"); forAll { (s1: PureStream[PureStream[Int]], n: SmallPositive) =>
+  property("join (3)") = protect { forAll { (s1: PureStream[PureStream[Int]], n: SmallPositive) =>
     run { concurrent.join(n.get)(s1.get.map(_.get.covary[Task]).covary[Task]) }.toSet ?=
     run { s1.get.flatMap(_.get) }.toSet
   }}

--- a/core/src/test/scala/fs2/ConcurrentSpec.scala
+++ b/core/src/test/scala/fs2/ConcurrentSpec.scala
@@ -38,10 +38,10 @@ object ConcurrentSpec extends Properties("concurrent") {
     run { s1.get }.toSet
   }
 
-  property("join (3)") = forAll { (s1: PureStream[PureStream[Int]], n: SmallPositive) =>
+  property("join (3)") = protect { println("starting join(3)"); forAll { (s1: PureStream[PureStream[Int]], n: SmallPositive) =>
     run { concurrent.join(n.get)(s1.get.map(_.get.covary[Task]).covary[Task]) }.toSet ?=
     run { s1.get.flatMap(_.get) }.toSet
-  }
+  }}
 
   property("merge (left/right failure)") = forAll { (s1: PureStream[Int], f: Failure) =>
     try { run (s1.get merge f.get); false }

--- a/core/src/test/scala/fs2/ResourceSafetySpec.scala
+++ b/core/src/test/scala/fs2/ResourceSafetySpec.scala
@@ -117,6 +117,7 @@ object ResourceSafetySpec extends Properties("ResourceSafety") {
       if (allowFailure) f.map(f => spuriousFail(bracket(c)(s.get), f)).getOrElse(bracket(c)(s.get))
       else bracket(c)(s.get)
     })
+    swallow { run { concurrent.join(n.get)(s2).take(10) }}
     swallow { run { concurrent.join(n.get)(s2) }}
     c.get ?= 0L
   }


### PR DESCRIPTION
Note: based on #582 and #581 
Note: don't merge yet, it doesn't work

This uses @pchlupacek's suggestion [here](https://github.com/functional-streams-for-scala/fs2/pull/577#issuecomment-211028139). It's not quite working yet, though. The join(3) test currently hangs for some reason. Good news is that once this is working, it will fix that linear performance problem spotted by @pchlupacek, where we have to scan all open streams to do a cancellation of the losing steps.

Basic idea here is pretty simple - just have the inner streams dump to a synchronous queue. Each is also controlled by an interrupt signal which is set to true when the outer stream terminates, which should ensure that their finalizers get run. But there are various edge cases to think through, and I apparently goofed something up.

More eyeballs on this appreciated, I won't have a chance to take a closer look until next week I think.

@pchlupacek or @mpilquist there might be a totally different, simpler implementation, so feel free to ignore this one or just use it for inspiration. Using `Async.start` is a good way to spawn running of the inner streams, though, I think any queue-based solution will have that somewhere.