### PR TITLE
Make Stream.range more robust

### DIFF
--- a/core/src/main/scala/fs2/StreamDerived.scala
+++ b/core/src/main/scala/fs2/StreamDerived.scala
@@ -95,7 +95,12 @@ trait StreamDerived extends PipeDerived { self: fs2.Stream.type =>
    * `emits(start until stopExclusive)`.
    */
   def range[F[_]](start: Int, stopExclusive: Int, by: Int = 1): Stream[F,Int] =
-    unfold(start)(i => if (i < stopExclusive) Some((i, i + by)) else None)
+    unfold(start){i => 
+      if ((by > 0 && i < stopExclusive && start < stopExclusive) || 
+          (by < 0 && i > stopExclusive && start > stopExclusive)) 
+        Some((i, i + by))
+      else None
+    }
 
   /**
    * Lazily produce a sequence of nonoverlapping ranges, where each range

--- a/core/src/test/scala/fs2/StreamSpec.scala
+++ b/core/src/test/scala/fs2/StreamSpec.scala
@@ -84,7 +84,11 @@ object StreamSpec extends Properties("Stream") {
   property("range") = protect {
     Stream.range(0, 100).toList == List.range(0, 100) &&
       Stream.range(0, 1).toList == List.range(0, 1) &&
-      Stream.range(0, 0).toList == List.range(0, 0)
+      Stream.range(0, 0).toList == List.range(0, 0) &&
+      Stream.range(0, 101, 2).toList == List.range(0, 101, 2) &&
+      Stream.range(5,0, -1).toList == List.range(5,0,-1) &&
+      Stream.range(5,0, 1).toList == Nil &&
+      Stream.range(10, 50, 0).toList == Nil
   }
 
   property("ranges") = forAll(Gen.choose(1, 101)) { size =>


### PR DESCRIPTION
While porting the scalaz-streams docs to fs2 I found some unexpected behavior with step-sizes & `Stream.range`. Previously only a positive `by` was supported. 

I elected to return the empty list in failure situations, but I'm curious if you think there is a better solution.