### PR TITLE
Ported ScalaCheck tests to ScalaTest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,8 @@ lazy val commonSettings = Seq(
   scalacOptions in (Compile, console) ~= {_.filterNot("-Ywarn-unused-import" == _)},
   scalacOptions in (Test, console) <<= (scalacOptions in (Compile, console)),
   libraryDependencies ++= Seq(
-    "org.scalacheck" %% "scalacheck" % "1.12.5" % "test"
+    "org.scalatest" %% "scalatest" % "3.0.0-M16-SNAP4" % "test",
+    "org.scalacheck" %% "scalacheck" % "1.13.1" % "test"
   ),
   scmInfo := Some(ScmInfo(url("https://github.com/functional-streams-for-scala/fs2"), "git@github.com:functional-streams-for-scala/fs2.git")),
   homepage := Some(url("https://github.com/functional-streams-for-scala/fs2")),
@@ -47,9 +48,7 @@ lazy val commonSettings = Seq(
 
 lazy val testSettings = Seq(
   parallelExecution in Test := false,
-  logBuffered in Test := false,
-  testOptions in Test += Tests.Argument("-verbosity", "2"),
-  testOptions in Test += Tests.Argument("-minSuccessfulTests", "25"),
+  testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
   publishArtifact in Test := true
 )
 

--- a/core/src/test/scala/fs2/ChunkSpec.scala
+++ b/core/src/test/scala/fs2/ChunkSpec.scala
@@ -1,157 +1,157 @@
 package fs2
 
 import fs2.Chunk.{Longs, Doubles, Bytes, Booleans}
-import fs2.TestUtil._
-import org.scalacheck.Prop._
-import org.scalacheck.{Gen, Arbitrary, Properties}
+import org.scalacheck.{Gen, Arbitrary}
 
 import scala.reflect.ClassTag
 
-object ChunkSpec extends Properties("chunk") {
+class ChunkSpec extends Fs2Spec {
 
-  implicit val arbBooleanChunk: Arbitrary[Chunk[Boolean]] = Arbitrary {
-    for {
-      n <- Gen.choose(0, 100)
-      values <- Gen.containerOfN[Array, Boolean](n, Arbitrary.arbBool.arbitrary)
-      offset <- Gen.choose(0, n)
-      sz <- Gen.choose(0, n - offset)
-    } yield new Booleans(values, offset, sz)
+  "Chunk" - {
+
+    implicit val arbBooleanChunk: Arbitrary[Chunk[Boolean]] = Arbitrary {
+      for {
+        n <- Gen.choose(0, 100)
+        values <- Gen.containerOfN[Array, Boolean](n, Arbitrary.arbBool.arbitrary)
+        offset <- Gen.choose(0, n)
+        sz <- Gen.choose(0, n - offset)
+      } yield new Booleans(values, offset, sz)
+    }
+
+    implicit val arbByteChunk: Arbitrary[Chunk[Byte]] = Arbitrary {
+      for {
+        n <- Gen.choose(0, 100)
+        values <- Gen.containerOfN[Array, Byte](n, Arbitrary.arbByte.arbitrary)
+        offset <- Gen.choose(0, n)
+        sz <- Gen.choose(0, n - offset)
+      } yield new Bytes(values, offset, sz)
+    }
+
+    implicit val arbDoubleChunk: Arbitrary[Chunk[Double]] = Arbitrary {
+      for {
+        n <- Gen.choose(0, 100)
+        values <- Gen.containerOfN[Array, Double](n, Arbitrary.arbDouble.arbitrary)
+        offset <- Gen.choose(0, n)
+        sz <- Gen.choose(0, n - offset)
+      } yield new Doubles(values, offset, sz)
+    }
+
+    implicit val arbLongChunk: Arbitrary[Chunk[Long]] = Arbitrary {
+      for {
+        n <- Gen.choose(0, 100)
+        values <- Gen.containerOfN[Array, Long](n, Arbitrary.arbLong.arbitrary)
+        offset <- Gen.choose(0, n)
+        sz <- Gen.choose(0, n - offset)
+      } yield new Longs(values, offset, sz)
+    }
+
+    def checkSize[A](c: Chunk[A]) = c.size shouldBe c.toVector.size
+
+    "size.boolean" in forAll { c: Chunk[Boolean] => checkSize(c) }
+    "size.byte" in forAll { c: Chunk[Byte] => checkSize(c) }
+    "size.double" in forAll { c: Chunk[Double] => checkSize(c) }
+    "size.long" in forAll { c: Chunk[Long] => checkSize(c) }
+    "size.unspecialized" in forAll { c: Chunk[Int] => checkSize(c) }
+
+    def checkTake[A](c: Chunk[A], n: Int) =
+      c.take(n).toVector shouldBe c.toVector.take(n)
+
+    "take.boolean" in forAll { (c: Chunk[Boolean], n: SmallNonnegative) => checkTake(c, n.get) }
+    "take.byte" in forAll { (c: Chunk[Byte], n: SmallNonnegative) => checkTake(c, n.get) }
+    "take.double" in forAll {(c: Chunk[Double], n: SmallNonnegative) => checkTake(c, n.get) }
+    "take.long" in forAll { (c: Chunk[Long], n: SmallNonnegative) => checkTake(c, n.get) }
+    "take.unspecialized" in forAll { (c: Chunk[Int], n: SmallNonnegative) => checkTake(c, n.get) }
+
+    def checkDrop[A](c: Chunk[A], n: Int) =
+      c.drop(n).toVector shouldBe c.toVector.drop(n)
+
+    "drop.boolean" in forAll { (c: Chunk[Boolean], n: SmallNonnegative) => checkDrop(c, n.get) }
+    "drop.byte" in forAll { (c: Chunk[Byte], n: SmallNonnegative) => checkDrop(c, n.get) }
+    "drop.double" in forAll {(c: Chunk[Double], n: SmallNonnegative) => checkDrop(c, n.get) }
+    "drop.long" in forAll { (c: Chunk[Long], n: SmallNonnegative) => checkDrop(c, n.get) }
+    "drop.unspecialized" in forAll { (c: Chunk[Int], n: SmallNonnegative) => checkDrop(c, n.get) }
+
+    def checkUncons[A](c: Chunk[A]) = assert {
+      if (c.toVector.isEmpty)
+        c.uncons.isEmpty
+      else
+        c.uncons.contains((c(0), c.drop(1)))
+    }
+
+    "uncons.boolean" in forAll { c: Chunk[Boolean] => checkUncons(c) }
+    "uncons.byte" in forAll { c: Chunk[Byte] => checkUncons(c) }
+    "uncons.double" in forAll { c: Chunk[Double] => checkUncons(c) }
+    "uncons.long" in forAll { c: Chunk[Long] => checkUncons(c) }
+    "uncons.unspecialized" in forAll { c: Chunk[Int] => checkUncons(c) }
+
+    def checkIsEmpty[A](c: Chunk[A]) =
+      c.isEmpty shouldBe c.toVector.isEmpty
+
+    "isempty.boolean" in forAll { c: Chunk[Boolean] => checkIsEmpty(c) }
+    "isempty.byte" in forAll { c: Chunk[Byte] => checkIsEmpty(c) }
+    "isempty.double" in forAll { c: Chunk[Double] => checkIsEmpty(c) }
+    "isempty.long" in forAll { c: Chunk[Long] => checkIsEmpty(c) }
+    "isempty.unspecialized" in forAll { c: Chunk[Int] => checkIsEmpty(c) }
+
+    def checkFilter[A](c: Chunk[A], pred: A => Boolean) =
+      c.filter(pred).toVector shouldBe c.toVector.filter(pred)
+
+    "filter.boolean" in forAll { c: Chunk[Boolean] =>
+      val predicate = (b: Boolean) => !b
+      checkFilter(c, predicate)
+    }
+    "filter.byte" in forAll { c: Chunk[Byte] =>
+      val predicate = (b: Byte) => b < 0
+      checkFilter(c, predicate)
+    }
+    "filter.double" in forAll { c: Chunk[Double] =>
+      val predicate = (i: Double) => i - i.floor < 0.5
+      checkFilter(c, predicate)
+    }
+    "filter.long" in forAll { (c: Chunk[Long], n: SmallPositive) =>
+      val predicate = (i: Long) => i % n.get == 0
+      checkFilter(c, predicate)
+    }
+    "filter.unspecialized" in forAll { (c: Chunk[Int], n: SmallPositive) =>
+      val predicate = (i: Int) => i % n.get == 0
+      checkFilter(c, predicate)
+    }
+
+    def checkFoldLeft[A, B](c: Chunk[A], z: B)(f: (B, A) => B) =
+      c.foldLeft(z)(f) shouldBe c.toVector.foldLeft(z)(f)
+
+    "foldleft.boolean" in forAll { c: Chunk[Boolean] =>
+      val f = (b: Boolean) => if (b) 1 else 0
+      checkFoldLeft(c, 0L)(_ + f(_))
+    }
+    "foldleft.byte" in forAll { c: Chunk[Byte] =>
+      checkFoldLeft(c, 0L)(_ + _.toLong)
+    }
+    "foldleft.double" in forAll { c: Chunk[Double] => checkFoldLeft(c, 0.0)(_ + _) }
+    "foldleft.long" in forAll { c: Chunk[Long] => checkFoldLeft(c, 0L)(_ + _) }
+    "foldleft.unspecialized" in forAll { c: Chunk[Int] => checkFoldLeft(c, 0L)(_ + _) }
+
+    def checkFoldRight[A, B](c: Chunk[A], z: B)(f: (A, B) => B) =
+      c.foldRight(z)(f) shouldBe c.toVector.foldRight(z)(f)
+
+    "foldright.boolean" in forAll { c: Chunk[Boolean] =>
+      val f = (b: Boolean) => if (b) 1 else 0
+      checkFoldRight(c, 0L)(f(_) + _)
+    }
+    "foldright.byte" in forAll { c: Chunk[Byte] =>
+      checkFoldRight(c, 0L)(_.toLong + _)
+    }
+    "foldright.double" in forAll { c: Chunk[Double] => checkFoldRight(c, 0.0)(_ + _) }
+    "foldright.long" in forAll { c: Chunk[Long] => checkFoldRight(c, 0L)(_ + _) }
+    "foldright.unspecialized" in forAll { c: Chunk[Int] => checkFoldRight(c, 0L)(_ + _) }
+
+    def checkToArray[A: ClassTag](c: Chunk[A]) =
+      c.toArray.toVector shouldBe c.toVector
+
+    "toarray.boolean" in forAll { c: Chunk[Boolean] => checkToArray(c) }
+    "toarray.byte" in forAll { c: Chunk[Byte] => checkToArray(c) }
+    "toarray.double" in forAll { c: Chunk[Double] => checkToArray(c) }
+    "toarray.long" in forAll { c: Chunk[Long] => checkToArray(c) }
+    "toarray.unspecialized" in forAll { c: Chunk[Int] => checkToArray(c) }
   }
-
-  implicit val arbByteChunk: Arbitrary[Chunk[Byte]] = Arbitrary {
-    for {
-      n <- Gen.choose(0, 100)
-      values <- Gen.containerOfN[Array, Byte](n, Arbitrary.arbByte.arbitrary)
-      offset <- Gen.choose(0, n)
-      sz <- Gen.choose(0, n - offset)
-    } yield new Bytes(values, offset, sz)
-  }
-
-  implicit val arbDoubleChunk: Arbitrary[Chunk[Double]] = Arbitrary {
-    for {
-      n <- Gen.choose(0, 100)
-      values <- Gen.containerOfN[Array, Double](n, Arbitrary.arbDouble.arbitrary)
-      offset <- Gen.choose(0, n)
-      sz <- Gen.choose(0, n - offset)
-    } yield new Doubles(values, offset, sz)
-  }
-
-  implicit val arbLongChunk: Arbitrary[Chunk[Long]] = Arbitrary {
-    for {
-      n <- Gen.choose(0, 100)
-      values <- Gen.containerOfN[Array, Long](n, Arbitrary.arbLong.arbitrary)
-      offset <- Gen.choose(0, n)
-      sz <- Gen.choose(0, n - offset)
-    } yield new Longs(values, offset, sz)
-  }
-
-  private def checkSize[A](c: Chunk[A]): Boolean =
-    c.size == c.toVector.size
-
-  property("size.boolean") = forAll { c: Chunk[Boolean] => checkSize(c) }
-  property("size.byte") = forAll { c: Chunk[Byte] => checkSize(c) }
-  property("size.double") = forAll { c: Chunk[Double] => checkSize(c) }
-  property("size.long") = forAll { c: Chunk[Long] => checkSize(c) }
-  property("size.unspecialized") = forAll { c: Chunk[Int] => checkSize(c) }
-
-  private def checkTake[A](c: Chunk[A], n: Int): Boolean =
-    c.take(n).toVector == c.toVector.take(n)
-
-  property("take.boolean") = forAll { (c: Chunk[Boolean], n: SmallNonnegative) => checkTake(c, n.get) }
-  property("take.byte") = forAll { (c: Chunk[Byte], n: SmallNonnegative) => checkTake(c, n.get) }
-  property("take.double") = forAll {(c: Chunk[Double], n: SmallNonnegative) => checkTake(c, n.get) }
-  property("take.long") = forAll { (c: Chunk[Long], n: SmallNonnegative) => checkTake(c, n.get) }
-  property("take.unspecialized") = forAll { (c: Chunk[Int], n: SmallNonnegative) => checkTake(c, n.get) }
-
-  private def checkDrop[A](c: Chunk[A], n: Int): Boolean =
-    c.drop(n).toVector == c.toVector.drop(n)
-
-  property("drop.boolean") = forAll { (c: Chunk[Boolean], n: SmallNonnegative) => checkDrop(c, n.get) }
-  property("drop.byte") = forAll { (c: Chunk[Byte], n: SmallNonnegative) => checkDrop(c, n.get) }
-  property("drop.double") = forAll {(c: Chunk[Double], n: SmallNonnegative) => checkDrop(c, n.get) }
-  property("drop.long") = forAll { (c: Chunk[Long], n: SmallNonnegative) => checkDrop(c, n.get) }
-  property("drop.unspecialized") = forAll { (c: Chunk[Int], n: SmallNonnegative) => checkDrop(c, n.get) }
-
-  private def checkUncons[A](c: Chunk[A]): Boolean = {
-    if (c.toVector.isEmpty)
-      c.uncons.isEmpty
-    else
-      c.uncons.contains((c(0), c.drop(1)))
-  }
-
-  property("uncons.boolean") = forAll { c: Chunk[Boolean] => checkUncons(c) }
-  property("uncons.byte") = forAll { c: Chunk[Byte] => checkUncons(c) }
-  property("uncons.double") = forAll { c: Chunk[Double] => checkUncons(c) }
-  property("uncons.long") = forAll { c: Chunk[Long] => checkUncons(c) }
-  property("uncons.unspecialized") = forAll { c: Chunk[Int] => checkUncons(c) }
-
-  private def checkIsEmpty[A](c: Chunk[A]): Boolean =
-    c.isEmpty == c.toVector.isEmpty
-
-  property("isempty.boolean") = forAll { c: Chunk[Boolean] => checkIsEmpty(c) }
-  property("isempty.byte") = forAll { c: Chunk[Byte] => checkIsEmpty(c) }
-  property("isempty.double") = forAll { c: Chunk[Double] => checkIsEmpty(c) }
-  property("isempty.long") = forAll { c: Chunk[Long] => checkIsEmpty(c) }
-  property("isempty.unspecialized") = forAll { c: Chunk[Int] => checkIsEmpty(c) }
-
-  private def checkFilter[A](c: Chunk[A], pred: A => Boolean): Boolean =
-    c.filter(pred).toVector == c.toVector.filter(pred)
-
-  property("filter.boolean") = forAll { c: Chunk[Boolean] =>
-    val predicate = (b: Boolean) => !b
-    checkFilter(c, predicate)
-  }
-  property("filter.byte") = forAll { c: Chunk[Byte] =>
-    val predicate = (b: Byte) => b < 0
-    checkFilter(c, predicate)
-  }
-  property("filter.double") = forAll { c: Chunk[Double] =>
-    val predicate = (i: Double) => i - i.floor < 0.5
-    checkFilter(c, predicate)
-  }
-  property("filter.long") = forAll { (c: Chunk[Long], n: SmallPositive) =>
-    val predicate = (i: Long) => i % n.get == 0
-    checkFilter(c, predicate)
-  }
-  property("filter.unspecialized") = forAll { (c: Chunk[Int], n: SmallPositive) =>
-    val predicate = (i: Int) => i % n.get == 0
-    checkFilter(c, predicate)
-  }
-
-  private def checkFoldLeft[A, B](c: Chunk[A], z: B)(f: (B, A) => B): Boolean =
-    c.foldLeft(z)(f) == c.toVector.foldLeft(z)(f)
-
-  property("foldleft.boolean") = forAll { c: Chunk[Boolean] =>
-    val f = (b: Boolean) => if (b) 1 else 0
-    checkFoldLeft(c, 0L)(_ + f(_))
-  }
-  property("foldleft.byte") = forAll { c: Chunk[Byte] =>
-    checkFoldLeft(c, 0L)(_ + _.toLong)
-  }
-  property("foldleft.double") = forAll { c: Chunk[Double] => checkFoldLeft(c, 0.0)(_ + _) }
-  property("foldleft.long") = forAll { c: Chunk[Long] => checkFoldLeft(c, 0L)(_ + _) }
-  property("foldleft.unspecialized") = forAll { c: Chunk[Int] => checkFoldLeft(c, 0L)(_ + _) }
-
-  private def checkFoldRight[A, B](c: Chunk[A], z: B)(f: (A, B) => B): Boolean =
-    c.foldRight(z)(f) == c.toVector.foldRight(z)(f)
-
-  property("foldright.boolean") = forAll { c: Chunk[Boolean] =>
-    val f = (b: Boolean) => if (b) 1 else 0
-    checkFoldRight(c, 0L)(f(_) + _)
-  }
-  property("foldright.byte") = forAll { c: Chunk[Byte] =>
-    checkFoldRight(c, 0L)(_.toLong + _)
-  }
-  property("foldright.double") = forAll { c: Chunk[Double] => checkFoldRight(c, 0.0)(_ + _) }
-  property("foldright.long") = forAll { c: Chunk[Long] => checkFoldRight(c, 0L)(_ + _) }
-  property("foldright.unspecialized") = forAll { c: Chunk[Int] => checkFoldRight(c, 0L)(_ + _) }
-
-  private def checkToArray[A: ClassTag](c: Chunk[A]): Boolean =
-    c.toArray.toVector == c.toVector
-
-  property("toarray.boolean") = forAll { c: Chunk[Boolean] => checkToArray(c) }
-  property("toarray.byte") = forAll { c: Chunk[Byte] => checkToArray(c) }
-  property("toarray.double") = forAll { c: Chunk[Double] => checkToArray(c) }
-  property("toarray.long") = forAll { c: Chunk[Long] => checkToArray(c) }
-  property("toarray.unspecialized") = forAll { c: Chunk[Int] => checkToArray(c) }
 }

--- a/core/src/test/scala/fs2/CompressSpec.scala
+++ b/core/src/test/scala/fs2/CompressSpec.scala
@@ -1,38 +1,38 @@
 package fs2
 
 import fs2.Stream._
-import fs2.TestUtil._
-import org.scalacheck.Prop._
-import org.scalacheck.Properties
 
 import compress._
 
-object CompressSpec extends Properties("compress") {
+class CompressSpec extends Fs2Spec {
 
   def getBytes(s: String): Array[Byte] =
     s.getBytes
 
-  property("deflate.empty input") = protect {
-    Stream.empty[Pure, Byte].through(deflate()).toVector.isEmpty
-  }
+  "Compress" - {
 
-  property("inflate.empty input") = protect {
-    Stream.empty[Pure, Byte].through(inflate()).toVector.isEmpty
-  }
+    "deflate.empty input" in {
+      assert(Stream.empty[Pure, Byte].through(deflate()).toVector.isEmpty)
+    }
 
-  property("deflate |> inflate ~= id") = forAll { (s: PureStream[Byte]) =>
-    s.get ==? s.get.through(compress.deflate()).through(compress.inflate()).toVector
-  }
+    "inflate.empty input" in {
+      assert(Stream.empty[Pure, Byte].through(inflate()).toVector.isEmpty)
+    }
 
-  property("deflate.compresses input") = protect {
-    val uncompressed = getBytes(
-      """"
-        |"A type system is a tractable syntactic method for proving the absence
-        |of certain program behaviors by classifying phrases according to the
-        |kinds of values they compute."
-        |-- Pierce, Benjamin C. (2002). Types and Programming Languages""")
-    val compressed = Stream.chunk(Chunk.bytes(uncompressed)).throughp(deflate(9)).toVector
+    "deflate |> inflate ~= id" in forAll { (s: PureStream[Byte]) =>
+      s.get.toVector shouldBe s.get.through(compress.deflate()).through(compress.inflate()).toVector
+    }
 
-    compressed.length < uncompressed.length
+    "deflate.compresses input" in {
+      val uncompressed = getBytes(
+        """"
+          |"A type system is a tractable syntactic method for proving the absence
+          |of certain program behaviors by classifying phrases according to the
+          |kinds of values they compute."
+          |-- Pierce, Benjamin C. (2002). Types and Programming Languages""")
+      val compressed = Stream.chunk(Chunk.bytes(uncompressed)).throughp(deflate(9)).toVector
+
+      compressed.length should be < uncompressed.length
+    }
   }
 }

--- a/core/src/test/scala/fs2/ConcurrentSpec.scala
+++ b/core/src/test/scala/fs2/ConcurrentSpec.scala
@@ -1,78 +1,76 @@
 package fs2
 
-import TestUtil._
 import fs2.util.Task
-import org.scalacheck.Prop._
-import org.scalacheck._
 
-object ConcurrentSpec extends Properties("concurrent") {
+class ConcurrentSpec extends Fs2Spec {
 
-  property("either") = forAll { (s1: PureStream[Int], s2: PureStream[Int]) =>
-    val shouldCompile = s1.get.either(s2.get.covary[Task])
-    val es = run { s1.get.covary[Task].through2(s2.get)(pipe2.either) }
-    (es.collect { case Left(i) => i } ?= run(s1.get)) &&
-    (es.collect { case Right(i) => i } ?= run(s2.get))
-  }
+  "concurrent" - {
 
-  property("merge") = forAll { (s1: PureStream[Int], s2: PureStream[Int]) =>
-    run { s1.get.merge(s2.get.covary[Task]) }.toSet ?=
-    (run(s1.get).toSet ++ run(s2.get).toSet)
-  }
-
-  property("merge (left/right identity)") = forAll { (s1: PureStream[Int]) =>
-    (run { s1.get.merge(Stream.empty.covary[Task]) } ?= run(s1.get)) &&
-    (run { Stream.empty.through2(s1.get.covary[Task])(pipe2.merge) } ?= run(s1.get))
-  }
-
-  property("merge/join consistency") = forAll { (s1: PureStream[Int], s2: PureStream[Int]) =>
-    run { s1.get.through2v(s2.get.covary[Task])(pipe2.merge) }.toSet ?=
-    run { concurrent.join(2)(Stream(s1.get.covary[Task], s2.get.covary[Task])) }.toSet
-  }
-
-  property("join (1)") = forAll { (s1: PureStream[Int]) =>
-    run { concurrent.join(1)(s1.get.covary[Task].map(Stream.emit)) } ?= run { s1.get }
-  }
-
-  property("join (2)") = forAll { (s1: PureStream[Int], n: SmallPositive) =>
-    run { concurrent.join(n.get)(s1.get.covary[Task].map(Stream.emit)) }.toSet ?=
-    run { s1.get }.toSet
-  }
-
-  property("join (3)") = protect { forAll { (s1: PureStream[PureStream[Int]], n: SmallPositive) =>
-    run { concurrent.join(n.get)(s1.get.map(_.get.covary[Task]).covary[Task]) }.toSet ?=
-    run { s1.get.flatMap(_.get) }.toSet
-  }}
-
-  property("merge (left/right failure)") = forAll { (s1: PureStream[Int], f: Failure) =>
-    try { run (s1.get merge f.get); false }
-    catch { case Err => true }
-  }
-
-  include { new Properties("hanging awaits") {
-    val full = Stream.constant[Task,Int](42)
-    val hang = Stream.repeatEval(Task.unforkedAsync[Unit] { cb => () }) // never call `cb`!
-    val hang2: Stream[Task,Nothing] = full.drain
-    val hang3: Stream[Task,Nothing] =
-      Stream.repeatEval[Task,Unit](Task.async { cb => cb(Right(())) }).drain
-
-    property("merge") = protect {
-      println("starting hanging await.merge...")
-      ( (full merge hang).take(1) === Vector(42) ) &&
-      ( (full merge hang2).take(1) === Vector(42) ) &&
-      ( (full merge hang3).take(1) === Vector(42) ) &&
-      ( (hang merge full).take(1) === Vector(42) ) &&
-      ( (hang2 merge full).take(1) === Vector(42) ) &&
-      ( (hang3 merge full).take(1) === Vector(42) )
-    }
-    property("join") = protect {
-      println("starting hanging await.join...")
-      (concurrent.join(10)(Stream(full, hang)).take(1) === Vector(42)) &&
-      (concurrent.join(10)(Stream(full, hang2)).take(1) === Vector(42)) &&
-      (concurrent.join(10)(Stream(full, hang3)).take(1) === Vector(42)) &&
-      (concurrent.join(10)(Stream(hang3,hang2,full)).take(1) === Vector(42))
+    "either" in forAll { (s1: PureStream[Int], s2: PureStream[Int]) =>
+      val shouldCompile = s1.get.either(s2.get.covary[Task])
+      val es = runLog { s1.get.covary[Task].through2(s2.get)(pipe2.either) }
+      es.collect { case Left(i) => i } shouldBe runLog(s1.get)
+      es.collect { case Right(i) => i } shouldBe runLog(s2.get)
     }
 
-    def observe[A](msg: String, s: Stream[Task,A]) =
-      s.map { a => println(msg + ": " + a); a }
-  }}
+    "merge" in forAll { (s1: PureStream[Int], s2: PureStream[Int]) =>
+      runLog { s1.get.merge(s2.get.covary[Task]) }.toSet shouldBe
+      (runLog(s1.get).toSet ++ runLog(s2.get).toSet)
+    }
+
+    "merge (left/right identity)" in forAll { (s1: PureStream[Int]) =>
+      runLog { s1.get.merge(Stream.empty.covary[Task]) } shouldBe runLog(s1.get)
+      runLog { Stream.empty.through2(s1.get.covary[Task])(pipe2.merge) } shouldBe runLog(s1.get)
+    }
+
+    "merge/join consistency" in forAll { (s1: PureStream[Int], s2: PureStream[Int]) =>
+      runLog { s1.get.through2v(s2.get.covary[Task])(pipe2.merge) }.toSet shouldBe
+      runLog { concurrent.join(2)(Stream(s1.get.covary[Task], s2.get.covary[Task])) }.toSet
+    }
+
+    "join (1)" in forAll { (s1: PureStream[Int]) =>
+      runLog { concurrent.join(1)(s1.get.covary[Task].map(Stream.emit)) } shouldBe runLog { s1.get }
+    }
+
+    "join (2)" in forAll { (s1: PureStream[Int], n: SmallPositive) =>
+      runLog { concurrent.join(n.get)(s1.get.covary[Task].map(Stream.emit)) }.toSet shouldBe
+      runLog { s1.get }.toSet
+    }
+
+    "join (3)" in forAll { (s1: PureStream[PureStream[Int]], n: SmallPositive) =>
+      runLog { concurrent.join(n.get)(s1.get.map(_.get.covary[Task]).covary[Task]) }.toSet shouldBe
+      runLog { s1.get.flatMap(_.get) }.toSet
+    }
+
+    "merge (left/right failure)" in forAll { (s1: PureStream[Int], f: Failure) =>
+      an[Err.type] should be thrownBy {
+        s1.get.merge(f.get).run.run.unsafeRun
+      }
+    }
+
+    "hanging awaits" - {
+
+      val full = Stream.constant[Task,Int](42)
+      val hang = Stream.repeatEval(Task.unforkedAsync[Unit] { cb => () }) // never call `cb`!
+      val hang2: Stream[Task,Nothing] = full.drain
+      val hang3: Stream[Task,Nothing] =
+        Stream.repeatEval[Task,Unit](Task.async { cb => cb(Right(())) }).drain
+
+      "merge" in {
+        runLog((full merge hang).take(1)) shouldBe Vector(42)
+        runLog((full merge hang2).take(1)) shouldBe Vector(42)
+        runLog((full merge hang3).take(1)) shouldBe Vector(42)
+        runLog((hang merge full).take(1)) shouldBe Vector(42)
+        runLog((hang2 merge full).take(1)) shouldBe Vector(42)
+        runLog((hang3 merge full).take(1)) shouldBe Vector(42)
+      }
+
+      "join" in {
+        runLog(concurrent.join(10)(Stream(full, hang)).take(1)) shouldBe Vector(42)
+        runLog(concurrent.join(10)(Stream(full, hang2)).take(1)) shouldBe Vector(42)
+        runLog(concurrent.join(10)(Stream(full, hang3)).take(1)) shouldBe Vector(42)
+        runLog(concurrent.join(10)(Stream(hang3,hang2,full)).take(1)) shouldBe Vector(42)
+      }
+    }
+  }
 }

--- a/core/src/test/scala/fs2/Fs2Spec.scala
+++ b/core/src/test/scala/fs2/Fs2Spec.scala
@@ -1,0 +1,16 @@
+package fs2
+
+import org.scalatest.{ Args, FreeSpec, Matchers, Status }
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+
+abstract class Fs2Spec extends FreeSpec with GeneratorDrivenPropertyChecks with Matchers with TestUtil {
+
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = 25, workers = 1)
+
+  override def runTest(testName: String, args: Args): Status = {
+    println("Starting " + testName)
+    try super.runTest(testName, args)
+    finally println("Finished " + testName)
+  }
+}

--- a/core/src/test/scala/fs2/Fs2Spec.scala
+++ b/core/src/test/scala/fs2/Fs2Spec.scala
@@ -1,9 +1,17 @@
 package fs2
 
 import org.scalatest.{ Args, FreeSpec, Matchers, Status }
+import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.time.SpanSugar._
 
-abstract class Fs2Spec extends FreeSpec with GeneratorDrivenPropertyChecks with Matchers with TestUtil {
+abstract class Fs2Spec extends FreeSpec
+  with GeneratorDrivenPropertyChecks
+  with Matchers
+  with TimeLimitedTests
+  with TestUtil {
+
+  val timeLimit = 1.minute
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     PropertyCheckConfiguration(minSuccessful = 25, workers = 1)

--- a/core/src/test/scala/fs2/Pipe2Spec.scala
+++ b/core/src/test/scala/fs2/Pipe2Spec.scala
@@ -1,174 +1,172 @@
 package fs2
 
 import fs2.util.Task
+import org.scalacheck.Gen
 
-import TestUtil._
+class Pipe2Spec extends Fs2Spec {
 
-import org.scalacheck.Prop._
-import org.scalacheck.{Gen, Properties}
+  "Pipe2" - {
 
-object Pipe2Spec extends Properties("pipe2") {
+    "zipWith left/right side infinite" in {
+      val ones = Stream.constant("1")
+      val p = Stream("A","B","C")
+      runLog(ones.zipWith(p)(_ + _)) shouldBe Vector("1A", "1B", "1C")
+      runLog(p.zipWith(ones)(_ + _)) shouldBe Vector("A1", "B1", "C1")
+    }
 
-  property("zipWith left/right side infinite") = protect {
-    val ones = Stream.constant("1")
-    val p = Stream("A","B","C")
-    ones.zipWith(p)(_ + _) ==? Vector("1A", "1B", "1C") &&
-      p.zipWith(ones)(_ + _) ==? Vector("A1", "B1", "C1")
-  }
-
-  property("zipWith both side infinite") = protect {
-    val ones = Stream.constant("1")
-    val as = Stream.constant("A")
-    ones.zipWith(as)(_ + _).take(3) ==? Vector("1A", "1A", "1A") &&
-      as.zipWith(ones)(_ + _).take(3) ==? Vector("A1", "A1", "A1")
-  }
-
-  property("zipAllWith left/right side infinite") = protect {
-    val ones = Stream.constant("1")
-    val p = Stream("A","B","C")
-    ones.through2p(p)(pipe2.zipAllWith("2","Z")(_ + _)).take(5) ==?
-        Vector("1A", "1B", "1C", "1Z", "1Z") &&
-      p.through2p(ones)(pipe2.zipAllWith("Z","2")(_ + _)).take(5) ==?
-        Vector("A1", "B1", "C1", "Z1", "Z1")
-  }
-
-  property("zipAllWith both side infinite") = protect {
-    val ones = Stream.constant("1")
-    val as = Stream.constant("A")
-    ones.through2p(as)(pipe2.zipAllWith("2", "Z")(_ + _)).take(3) ==?
-     Vector("1A", "1A", "1A") &&
-    as.through2p(ones)(pipe2.zipAllWith("Z", "2")(_ + _)).take(3) ==?
-     Vector("A1", "A1", "A1")
-  }
-
-  property("zip left/right side infinite") = protect {
-    val ones = Stream.constant("1")
-    val p = Stream("A","B","C")
-    ones.zip(p) ==? Vector("1" -> "A", "1" -> "B", "1" -> "C") &&
-      p.zip(ones) ==? Vector("A" -> "1", "B" -> "1", "C" -> "1")
-  }
-
-  property("zip both side infinite") = protect {
-    val ones = Stream.constant("1")
-    val as = Stream.constant("A")
-    ones.zip(as).take(3) ==? Vector("1" -> "A", "1" -> "A", "1" -> "A") &&
-      as.zip(ones).take(3) ==? Vector("A" -> "1", "A" -> "1", "A" -> "1")
-  }
-
-  property("zipAll left/right side infinite") = protect {
-    val ones = Stream.constant("1")
-    val p = Stream("A","B","C")
-    ones.through2p(p)(pipe2.zipAll("2","Z")).take(5) ==? Vector("1" -> "A", "1" -> "B", "1" -> "C", "1" -> "Z", "1" -> "Z") &&
-      p.through2p(ones)(pipe2.zipAll("Z","2")).take(5) ==? Vector("A" -> "1", "B" -> "1", "C" -> "1", "Z" -> "1", "Z" -> "1")
-  }
-
-  property("zipAll both side infinite") = protect {
-    val ones = Stream.constant("1")
-    val as = Stream.constant("A")
-    ones.through2p(as)(pipe2.zipAll("2", "Z")).take(3) ==? Vector("1" -> "A", "1" -> "A", "1" -> "A") &&
-      as.through2p(ones)(pipe2.zipAll("Z", "2")).take(3) ==? Vector("A" -> "1", "A" -> "1", "A" -> "1")
-  }
-
-  property("interleave left/right side infinite") = protect {
-    val ones = Stream.constant("1")
-    val p = Stream("A","B","C")
-    ones.interleave(p) ==? Vector("1", "A", "1", "B", "1", "C") &&
-      p.interleave(ones) ==? Vector("A", "1", "B", "1", "C", "1")
-  }
-
-  property("interleave both side infinite") = protect {
-    val ones = Stream.constant("1")
-    val as = Stream.constant("A")
-    ones.interleave(as).take(3) ==? Vector("1", "A", "1") &&
-      as.interleave(ones).take(3) ==? Vector("A", "1", "A")
-  }
-
-  property("interleaveAll left/right side infinite") = protect {
-    val ones = Stream.constant("1")
-    val p = Stream("A","B","C")
-    ones.interleaveAll(p).take(9) ==? Vector("1", "A", "1", "B", "1", "C", "1", "1", "1") &&
-      p.interleaveAll(ones).take(9) ==? Vector("A", "1", "B", "1", "C", "1", "1", "1", "1")
-  }
-
-  property("interleaveAll both side infinite") = protect {
-    val ones = Stream.constant("1")
-    val as = Stream.constant("A")
-    ones.interleaveAll(as).take(3) ==? Vector("1", "A", "1") &&
-      as.interleaveAll(ones).take(3) ==? Vector("A", "1", "A")
-  }
-
-  // Uses a small scope to avoid using time to generate too large streams and not finishing
-  property("interleave is equal to interleaveAll on infinite streams (by step-indexing)") = protect {
-    forAll(Gen.choose(0,100)) { (n : Int) =>
+    "zipWith both side infinite" in {
       val ones = Stream.constant("1")
       val as = Stream.constant("A")
-      ones.interleaveAll(as).take(n).toVector == ones.interleave(as).take(n).toVector
+      runLog(ones.zipWith(as)(_ + _).take(3)) shouldBe Vector("1A", "1A", "1A")
+      runLog(as.zipWith(ones)(_ + _).take(3)) shouldBe Vector("A1", "A1", "A1")
     }
-  }
 
-  property("either") = forAll { (s1: PureStream[Int], s2: PureStream[Int]) =>
-    val shouldCompile = s1.get.either(s2.get.covary[Task])
-    val es = run { s1.get.covary[Task].through2(s2.get)(pipe2.either) }
-    (es.collect { case Left(i) => i } ?= run(s1.get)) &&
-    (es.collect { case Right(i) => i } ?= run(s2.get))
-  }
-
-  property("merge") = forAll { (s1: PureStream[Int], s2: PureStream[Int]) =>
-    run { s1.get.merge(s2.get.covary[Task]) }.toSet ?=
-    (run(s1.get).toSet ++ run(s2.get).toSet)
-  }
-
-  property("merge (left/right identity)") = forAll { (s1: PureStream[Int]) =>
-    (run { s1.get.merge(Stream.empty.covary[Task]) } ?= run(s1.get)) &&
-    (run { Stream.empty.through2(s1.get.covary[Task])(pipe2.merge) } ?= run(s1.get))
-  }
-
-  property("merge (left/right failure)") = forAll { (s1: PureStream[Int], f: Failure) =>
-    try { run (s1.get merge f.get); false }
-    catch { case Err => true }
-  }
-
-  property("mergeHalt{L/R/Both}") = forAll { (s1: PureStream[Int], s2: PureStream[Int]) =>
-    (s1.tag + " " + s2.tag) |: {
-      val outBoth = run { s1.get.covary[Task].map(Left(_)) mergeHaltBoth s2.get.map(Right(_)) }
-      val outL = run { s1.get.covary[Task].map(Left(_)) mergeHaltL s2.get.map(Right(_)) }
-      val outR = run { s1.get.covary[Task].map(Left(_)) mergeHaltR s2.get.map(Right(_)) }
-      // out should contain at least all the elements from one of the input streams
-      val e1 = run(s1.get)
-      val e2 = run(s2.get)
-      val bothOk =
-        (outBoth.collect { case Left(a) => a } ?= e1) ||
-        (outBoth.collect { case Right(a) => a } ?= e2)
-      val haltLOk =
-        outL.collect { case Left(a) => a } ?= e1
-      val haltROk =
-        outR.collect { case Right(a) => a } ?= e2
-      bothOk && haltLOk && haltROk
+    "zipAllWith left/right side infinite" in {
+      val ones = Stream.constant("1")
+      val p = Stream("A","B","C")
+      runLog(ones.through2p(p)(pipe2.zipAllWith("2","Z")(_ + _)).take(5)) shouldBe
+          Vector("1A", "1B", "1C", "1Z", "1Z")
+      runLog(p.through2p(ones)(pipe2.zipAllWith("Z","2")(_ + _)).take(5)) shouldBe
+        Vector("A1", "B1", "C1", "Z1", "Z1")
     }
-  }
 
-  property("interrupt (1)") = forAll { (s1: PureStream[Int]) =>
-    val s = async.mutable.Semaphore[Task](0).unsafeRun
-    val interrupt = Stream.emit(true) ++ Stream.eval_(s.increment)
-    // tests that termination is successful even if stream being interrupted is hung
-    (run { s1.get.evalMap(_ => s.decrement).interruptWhen(interrupt) } ?= Vector()) &&
-    // tests that termination is successful even if interruption stream is infinitely false
-    (run { s1.get.covary[Task].interruptWhen(Stream.constant(false)) } ?= run(s1.get))
-  }
-
-  property("interrupt (2)") = forAll { (s1: PureStream[Int]) =>
-    val barrier = async.mutable.Semaphore[Task](0).unsafeRun
-    val enableInterrupt = async.mutable.Semaphore[Task](0).unsafeRun
-    val interruptedS1 = s1.get.evalMap { i =>
-      // enable interruption and hang when hitting a value divisible by 7
-      if (i % 7 == 0) enableInterrupt.increment.flatMap { _ => barrier.decrement.map(_ => i) }
-      else Task.now(i)
+    "zipAllWith both side infinite" in {
+      val ones = Stream.constant("1")
+      val as = Stream.constant("A")
+      runLog(ones.through2p(as)(pipe2.zipAllWith("2", "Z")(_ + _)).take(3)) shouldBe
+       Vector("1A", "1A", "1A")
+      runLog(as.through2p(ones)(pipe2.zipAllWith("Z", "2")(_ + _)).take(3)) shouldBe
+       Vector("A1", "A1", "A1")
     }
-    val interrupt = Stream.eval(enableInterrupt.decrement) flatMap { _ => Stream.emit(false) }
-    val out = run { interruptedS1.interruptWhen(interrupt) }
-    // as soon as we hit a value divisible by 7, we enable interruption then hang before emitting it,
-    // so there should be no elements in the output that are divisible by 7
-    // this also checks that interruption works fine even if one or both streams are in a hung state
-    out.forall(i => i % 7 != 0)
+
+    "zip left/right side infinite" in {
+      val ones = Stream.constant("1")
+      val p = Stream("A","B","C")
+      runLog(ones.zip(p)) shouldBe Vector("1" -> "A", "1" -> "B", "1" -> "C")
+      runLog(p.zip(ones)) shouldBe Vector("A" -> "1", "B" -> "1", "C" -> "1")
+    }
+
+    "zip both side infinite" in {
+      val ones = Stream.constant("1")
+      val as = Stream.constant("A")
+      runLog(ones.zip(as).take(3)) shouldBe Vector("1" -> "A", "1" -> "A", "1" -> "A")
+      runLog(as.zip(ones).take(3)) shouldBe Vector("A" -> "1", "A" -> "1", "A" -> "1")
+    }
+
+    "zipAll left/right side infinite" in {
+      val ones = Stream.constant("1")
+      val p = Stream("A","B","C")
+      runLog(ones.through2p(p)(pipe2.zipAll("2","Z")).take(5)) shouldBe Vector("1" -> "A", "1" -> "B", "1" -> "C", "1" -> "Z", "1" -> "Z")
+      runLog(p.through2p(ones)(pipe2.zipAll("Z","2")).take(5)) shouldBe Vector("A" -> "1", "B" -> "1", "C" -> "1", "Z" -> "1", "Z" -> "1")
+    }
+
+    "zipAll both side infinite" in {
+      val ones = Stream.constant("1")
+      val as = Stream.constant("A")
+      runLog(ones.through2p(as)(pipe2.zipAll("2", "Z")).take(3)) shouldBe Vector("1" -> "A", "1" -> "A", "1" -> "A")
+      runLog(as.through2p(ones)(pipe2.zipAll("Z", "2")).take(3)) shouldBe Vector("A" -> "1", "A" -> "1", "A" -> "1")
+    }
+
+    "interleave left/right side infinite" in {
+      val ones = Stream.constant("1")
+      val p = Stream("A","B","C")
+      runLog(ones.interleave(p)) shouldBe Vector("1", "A", "1", "B", "1", "C")
+      runLog(p.interleave(ones)) shouldBe Vector("A", "1", "B", "1", "C", "1")
+    }
+
+    "interleave both side infinite" in {
+      val ones = Stream.constant("1")
+      val as = Stream.constant("A")
+      runLog(ones.interleave(as).take(3)) shouldBe Vector("1", "A", "1")
+      runLog(as.interleave(ones).take(3)) shouldBe Vector("A", "1", "A")
+    }
+
+    "interleaveAll left/right side infinite" in {
+      val ones = Stream.constant("1")
+      val p = Stream("A","B","C")
+      runLog(ones.interleaveAll(p).take(9)) shouldBe Vector("1", "A", "1", "B", "1", "C", "1", "1", "1")
+      runLog(p.interleaveAll(ones).take(9)) shouldBe Vector("A", "1", "B", "1", "C", "1", "1", "1", "1")
+    }
+
+    "interleaveAll both side infinite" in {
+      val ones = Stream.constant("1")
+      val as = Stream.constant("A")
+      runLog(ones.interleaveAll(as).take(3)) shouldBe Vector("1", "A", "1")
+      runLog(as.interleaveAll(ones).take(3)) shouldBe Vector("A", "1", "A")
+    }
+
+    // Uses a small scope to avoid using time to generate too large streams and not finishing
+    "interleave is equal to interleaveAll on infinite streams (by step-indexing)" in {
+      forAll(Gen.choose(0,100)) { (n : Int) =>
+        val ones = Stream.constant("1")
+        val as = Stream.constant("A")
+        ones.interleaveAll(as).take(n).toVector shouldBe ones.interleave(as).take(n).toVector
+      }
+    }
+
+    "either" in forAll { (s1: PureStream[Int], s2: PureStream[Int]) =>
+      val shouldCompile = s1.get.either(s2.get.covary[Task])
+      val es = runLog { s1.get.covary[Task].through2(s2.get)(pipe2.either) }
+      es.collect { case Left(i) => i } shouldBe runLog(s1.get)
+      es.collect { case Right(i) => i } shouldBe runLog(s2.get)
+    }
+
+    "merge" in forAll { (s1: PureStream[Int], s2: PureStream[Int]) =>
+      runLog { s1.get.merge(s2.get.covary[Task]) }.toSet shouldBe
+      (runLog(s1.get).toSet ++ runLog(s2.get).toSet)
+    }
+
+    "merge (left/right identity)" in forAll { (s1: PureStream[Int]) =>
+      runLog { s1.get.merge(Stream.empty.covary[Task]) } shouldBe runLog(s1.get)
+      runLog { Stream.empty.through2(s1.get.covary[Task])(pipe2.merge) } shouldBe runLog(s1.get)
+    }
+
+    "merge (left/right failure)" in forAll { (s1: PureStream[Int], f: Failure) =>
+      an[Err.type] should be thrownBy {
+        (s1.get merge f.get).run.run.unsafeRun
+      }
+    }
+
+    "mergeHalt{L/R/Both}" in forAll { (s1: PureStream[Int], s2: PureStream[Int]) =>
+      withClue(s1.tag + " " + s2.tag) {
+        val outBoth = runLog { s1.get.covary[Task].map(Left(_)) mergeHaltBoth s2.get.map(Right(_)) }
+        val outL = runLog { s1.get.covary[Task].map(Left(_)) mergeHaltL s2.get.map(Right(_)) }
+        val outR = runLog { s1.get.covary[Task].map(Left(_)) mergeHaltR s2.get.map(Right(_)) }
+        // out should contain at least all the elements from one of the input streams
+        val e1 = runLog(s1.get)
+        val e2 = runLog(s2.get)
+        assert {
+          (outBoth.collect { case Left(a) => a } == e1) ||
+          (outBoth.collect { case Right(a) => a } == e2)
+        }
+        outL.collect { case Left(a) => a } shouldBe e1
+        outR.collect { case Right(a) => a } shouldBe e2
+      }
+    }
+
+    "interrupt (1)" in forAll { (s1: PureStream[Int]) =>
+      val s = async.mutable.Semaphore[Task](0).unsafeRun
+      val interrupt = Stream.emit(true) ++ Stream.eval_(s.increment)
+      // tests that termination is successful even if stream being interrupted is hung
+      runLog { s1.get.evalMap(_ => s.decrement).interruptWhen(interrupt) } shouldBe Vector()
+      // tests that termination is successful even if interruption stream is infinitely false
+      runLog { s1.get.covary[Task].interruptWhen(Stream.constant(false)) } shouldBe runLog(s1.get)
+    }
+
+    "interrupt (2)" in forAll { (s1: PureStream[Int]) =>
+      val barrier = async.mutable.Semaphore[Task](0).unsafeRun
+      val enableInterrupt = async.mutable.Semaphore[Task](0).unsafeRun
+      val interruptedS1 = s1.get.evalMap { i =>
+        // enable interruption and hang when hitting a value divisible by 7
+        if (i % 7 == 0) enableInterrupt.increment.flatMap { _ => barrier.decrement.map(_ => i) }
+        else Task.now(i)
+      }
+      val interrupt = Stream.eval(enableInterrupt.decrement) flatMap { _ => Stream.emit(false) }
+      val out = runLog { interruptedS1.interruptWhen(interrupt) }
+      // as soon as we hit a value divisible by 7, we enable interruption then hang before emitting it,
+      // so there should be no elements in the output that are divisible by 7
+      // this also checks that interruption works fine even if one or both streams are in a hung state
+      assert(out.forall(i => i % 7 != 0))
+    }
   }
 }

--- a/core/src/test/scala/fs2/ResourceSafetySpec.scala
+++ b/core/src/test/scala/fs2/ResourceSafetySpec.scala
@@ -1,149 +1,144 @@
 package fs2
 
-import TestUtil._
 import fs2.util.Task
 import java.util.concurrent.atomic.AtomicLong
-import org.scalacheck.Prop._
 import org.scalacheck._
 
-object ResourceSafetySpec extends Properties("ResourceSafety") {
+class ResourceSafetySpec extends Fs2Spec {
 
-  property("pure fail") = protect {
-    try { Stream.emit(0).flatMap(_ => Stream.fail(Err)) === Vector(); false }
-    catch { case Err => true } // expected
-  }
+  "Resource Safety" - {
 
-  def spuriousFail(s: Stream[Task,Int], f: Failure): Stream[Task,Int] =
-    s.flatMap { i => if (i % (math.random * 10 + 1).toInt == 0) f.get
-                     else Stream.emit(i) }
+    "pure fail" in {
+      an[Err.type] should be thrownBy {
+        Stream.emit(0).flatMap(_ => Stream.fail(Err)).toVector
+        ()
+      }
+    }
 
-  property("bracket (normal termination / failing)") = forAll {
-  (s0: List[PureStream[Int]], f: Failure, ignoreFailure: Boolean) =>
-    val c = new AtomicLong(0)
-    val s = s0.map { s => bracket(c)(if (ignoreFailure) s.get else spuriousFail(s.get,f)) }
-    val s2 = s.foldLeft(Stream.empty: Stream[Task,Int])(_ ++ _)
-    swallow { run(s2) }
-    swallow { run(s2.take(1000)) }
-    f.tag |: 0L =? c.get
-  }
+    def spuriousFail(s: Stream[Task,Int], f: Failure): Stream[Task,Int] =
+      s.flatMap { i => if (i % (math.random * 10 + 1).toInt == 0) f.get
+                       else Stream.emit(i) }
 
-  property("bracket ++ throw Err") = forAll { (s: PureStream[Int]) =>
-    val c = new AtomicLong(0)
-    val b = bracket(c)(s.get ++ ((throw Err): Stream[Pure,Int]))
-    swallow { b }
-    c.get ?= 0
-  }
+    "bracket (normal termination / failing)" in forAll { (s0: List[PureStream[Int]], f: Failure, ignoreFailure: Boolean) =>
+      val c = new AtomicLong(0)
+      val s = s0.map { s => bracket(c)(if (ignoreFailure) s.get else spuriousFail(s.get,f)) }
+      val s2 = s.foldLeft(Stream.empty: Stream[Task,Int])(_ ++ _)
+      swallow { runLog(s2) }
+      swallow { runLog(s2.take(1000)) }
+      withClue(f.tag) { 0L shouldBe c.get }
+    }
 
-  property("1 million brackets in sequence") = protect {
-    println("Starting 1 million brackets in sequence...")
-    val c = new AtomicLong(0)
-    val b = bracket(c)(Stream.emit(1))
-    val bs = Stream.range(0, 1000000).flatMap(_ => b)
-    run { bs }
-    println("Done 1 million brackets in sequence")
-    c.get ?= 0
-  }
+    "bracket ++ throw Err" in forAll { (s: PureStream[Int]) =>
+      val c = new AtomicLong(0)
+      val b = bracket(c)(s.get ++ ((throw Err): Stream[Pure,Int]))
+      swallow { b }
+      c.get shouldBe 0
+    }
 
-  property("nested bracket") = forAll { (s0: List[Int], f: Failure, finalizerFail: Boolean) =>
-    val c = new AtomicLong(0)
-    // construct a deeply nested bracket stream in which the innermost stream fails
-    // and check that as we unwind the stack, all resources get released
-    // Also test for case where finalizer itself throws an error
-    val innermost =
-      if (!finalizerFail) f.get
-      else Stream.bracket(Task.delay(c.decrementAndGet))(
-             _ => f.get,
-             _ => Task.delay { c.incrementAndGet; throw Err })
-    val nested = Chunk.seq(s0).foldRight(innermost)((i,inner) => bracket(c)(Stream.emit(i) ++ inner))
-    try { run { nested }; throw Err } // this test should always fail, so the `run` should throw
-    catch { case Err => () }
-    f.tag |: 0L =? c.get
-  }
+    "1 million brackets in sequence" in {
+      val c = new AtomicLong(0)
+      val b = bracket(c)(Stream.emit(1))
+      val bs = Stream.range(0, 1000000).flatMap(_ => b)
+      runLog { bs }
+      c.get shouldBe 0
+    }
 
-  case class Small(get: Long)
-  implicit def smallLongArb = Arbitrary(Gen.choose(0L,10L).map(Small(_)))
+    "nested bracket" in forAll { (s0: List[Int], f: Failure, finalizerFail: Boolean) =>
+      val c = new AtomicLong(0)
+      // construct a deeply nested bracket stream in which the innermost stream fails
+      // and check that as we unwind the stack, all resources get released
+      // Also test for case where finalizer itself throws an error
+      val innermost =
+        if (!finalizerFail) f.get
+        else Stream.bracket(Task.delay(c.decrementAndGet))(
+               _ => f.get,
+               _ => Task.delay { c.incrementAndGet; throw Err })
+      val nested = Chunk.seq(s0).foldRight(innermost)((i,inner) => bracket(c)(Stream.emit(i) ++ inner))
+      try { runLog { nested }; throw Err } // this test should always fail, so the `run` should throw
+      catch { case Err => () }
+      withClue(f.tag) { 0L shouldBe c.get }
+    }
 
-  property("early termination of bracket") = forAll {
-    (s: PureStream[Int], i: Small, j: Small, k: Small) =>
-    val c = new AtomicLong(0)
-    val bracketed = bracket(c)(s.get)
-    run { bracketed.take(i.get) } // early termination
-    run { bracketed.take(i.get).take(j.get) } // 2 levels termination
-    run { bracketed.take(i.get).take(i.get) } // 2 levels of early termination (2)
-    run { bracketed.take(i.get).take(j.get).take(k.get) } // 3 levels of early termination
-    // Let's just go crazy
-    run { bracketed.take(i.get).take(j.get).take(i.get).take(k.get).take(j.get).take(i.get) }
-    s.tag |: 0L =? c.get
-  }
+    case class Small(get: Long)
+    implicit def smallLongArb = Arbitrary(Gen.choose(0L,10L).map(Small(_)))
 
-  property("asynchronous resource allocation (1)") = forAll {
-    (s1: PureStream[Int], f1: Failure) =>
-    val c = new AtomicLong(0)
-    val b1 = bracket(c)(s1.get)
-    val b2 = f1.get
-    swallow { run { b1.merge(b2) }}
-    swallow { run { b2.merge(b1) }}
-    c.get ?= 0L
-  }
+    "early termination of bracket" in forAll { (s: PureStream[Int], i: Small, j: Small, k: Small) =>
+      val c = new AtomicLong(0)
+      val bracketed = bracket(c)(s.get)
+      runLog { bracketed.take(i.get) } // early termination
+      runLog { bracketed.take(i.get).take(j.get) } // 2 levels termination
+      runLog { bracketed.take(i.get).take(i.get) } // 2 levels of early termination (2)
+      runLog { bracketed.take(i.get).take(j.get).take(k.get) } // 3 levels of early termination
+      // Let's just go crazy
+      runLog { bracketed.take(i.get).take(j.get).take(i.get).take(k.get).take(j.get).take(i.get) }
+      withClue(s.tag) { 0L shouldBe c.get }
+    }
 
-  property("asynchronous resource allocation (2a)") = forAll { (u: Unit) =>
-    val s1 = Stream.fail(Err)
-    val s2 = Stream.fail(Err)
-    val c = new AtomicLong(0)
-    val b1 = bracket(c)(s1)
-    val b2 = s2: Stream[Task,Int]
-    // subtle test, get different scenarios depending on interleaving:
-    // `s2` completes with failure before the resource is acquired by `s2`.
-    // `b1` has just caught `s1` error when `s2` fails
-    // `b1` fully completes before `s2` fails
-    swallow { run { b1 merge b2 }}
-    c.get ?= 0L
-  }
+    "asynchronous resource allocation (1)" in forAll { (s1: PureStream[Int], f1: Failure) =>
+      val c = new AtomicLong(0)
+      val b1 = bracket(c)(s1.get)
+      val b2 = f1.get
+      swallow { runLog { b1.merge(b2) }}
+      swallow { runLog { b2.merge(b1) }}
+      c.get shouldBe 0L
+    }
 
-  property("asynchronous resource allocation (2b)") = forAll {
-    (s1: PureStream[Int], s2: PureStream[Int], f1: Failure, f2: Failure) =>
-    val c = new AtomicLong(0)
-    val b1 = bracket(c)(s1.get)
-    val b2 = bracket(c)(s2.get)
-    swallow { run { spuriousFail(b1,f1) merge b2 }}
-    swallow { run { b1 merge spuriousFail(b2,f2) }}
-    swallow { run { spuriousFail(b1,f1) merge spuriousFail(b2,f2) }}
-    c.get ?= 0L
-  }
+    "asynchronous resource allocation (2a)" in forAll { (u: Unit) =>
+      val s1 = Stream.fail(Err)
+      val s2 = Stream.fail(Err)
+      val c = new AtomicLong(0)
+      val b1 = bracket(c)(s1)
+      val b2 = s2: Stream[Task,Int]
+      // subtle test, get different scenarios depending on interleaving:
+      // `s2` completes with failure before the resource is acquired by `s2`.
+      // `b1` has just caught `s1` error when `s2` fails
+      // `b1` fully completes before `s2` fails
+      swallow { runLog { b1 merge b2 }}
+      c.get shouldBe 0L
+    }
 
-  property("asynchronous resource allocation (3)") = forAll {
-    (s: PureStream[(PureStream[Int], Option[Failure])]
-    , allowFailure: Boolean, f: Failure, n: SmallPositive) =>
-    val c = new AtomicLong(0)
-    val s2 = bracket(c)(s.get.map { case (s, f) =>
-      if (allowFailure) f.map(f => spuriousFail(bracket(c)(s.get), f)).getOrElse(bracket(c)(s.get))
-      else bracket(c)(s.get)
-    })
-    swallow { run { concurrent.join(n.get)(s2).take(10) }}
-    swallow { run { concurrent.join(n.get)(s2) }}
-    c.get ?= 0L
-  }
+    "asynchronous resource allocation (2b)" in forAll { (s1: PureStream[Int], s2: PureStream[Int], f1: Failure, f2: Failure) =>
+      val c = new AtomicLong(0)
+      val b1 = bracket(c)(s1.get)
+      val b2 = bracket(c)(s2.get)
+      swallow { runLog { spuriousFail(b1,f1) merge b2 }}
+      swallow { runLog { b1 merge spuriousFail(b2,f2) }}
+      swallow { runLog { spuriousFail(b1,f1) merge spuriousFail(b2,f2) }}
+      c.get shouldBe 0L
+    }
 
-  property("asynchronous resource allocation (4)") = forAll {
-    (s: PureStream[Int], f: Option[Failure]) =>
-    val c = new AtomicLong(0)
-    val s2 = bracket(c)(f match {
-      case None => s.get
-      case Some(f) => spuriousFail(s.get, f)
-    })
-    swallow { run { s2 through pipe.prefetch }}
-    swallow { run { s2 through pipe.prefetch through pipe.prefetch }}
-    swallow { run { s2 through pipe.prefetch through pipe.prefetch through pipe.prefetch }}
-    c.get ?= 0L
-  }
+    "asynchronous resource allocation (3)" in forAll {
+      (s: PureStream[(PureStream[Int], Option[Failure])], allowFailure: Boolean, f: Failure, n: SmallPositive) =>
+      val c = new AtomicLong(0)
+      val s2 = bracket(c)(s.get.map { case (s, f) =>
+        if (allowFailure) f.map(f => spuriousFail(bracket(c)(s.get), f)).getOrElse(bracket(c)(s.get))
+        else bracket(c)(s.get)
+      })
+      swallow { runLog { concurrent.join(n.get)(s2).take(10) }}
+      swallow { runLog { concurrent.join(n.get)(s2) }}
+      c.get shouldBe 0L
+    }
 
-  def swallow(a: => Any): Unit =
-    try { a; () }
-    catch { case e: Throwable => () }
+    "asynchronous resource allocation (4)" in forAll { (s: PureStream[Int], f: Option[Failure]) =>
+      val c = new AtomicLong(0)
+      val s2 = bracket(c)(f match {
+        case None => s.get
+        case Some(f) => spuriousFail(s.get, f)
+      })
+      swallow { runLog { s2 through pipe.prefetch }}
+      swallow { runLog { s2 through pipe.prefetch through pipe.prefetch }}
+      swallow { runLog { s2 through pipe.prefetch through pipe.prefetch through pipe.prefetch }}
+      c.get shouldBe 0L
+    }
 
-  def bracket[A](c: AtomicLong)(s: Stream[Task,A]): Stream[Task,A] = Stream.suspend {
-    Stream.bracket(Task.delay { c.decrementAndGet })(
-      _ => s,
-      _ => Task.delay { c.incrementAndGet; () })
+    def swallow(a: => Any): Unit =
+      try { a; () }
+      catch { case e: Throwable => () }
+
+    def bracket[A](c: AtomicLong)(s: Stream[Task,A]): Stream[Task,A] = Stream.suspend {
+      Stream.bracket(Task.delay { c.decrementAndGet })(
+        _ => s,
+        _ => Task.delay { c.incrementAndGet; () })
+    }
   }
 }

--- a/core/src/test/scala/fs2/StreamPerformanceSpec.scala
+++ b/core/src/test/scala/fs2/StreamPerformanceSpec.scala
@@ -1,108 +1,100 @@
 package fs2
 
-import org.scalacheck.Prop.{throws => _, _}
-import org.scalacheck._
-
 import java.util.concurrent.atomic.AtomicInteger
 import fs2.util._
-import fs2.TestUtil._
 
-object StreamPerformanceSpec extends Properties("StreamPerformance") {
+class StreamPerformanceSpec extends Fs2Spec {
 
-  import Stream._
+  "Stream Performance" - {
 
-  case object FailWhale extends RuntimeException("the system... is down")
+    import Stream._
 
-  val Ns = List(2,3,100,200,400,800,1600,3200,6400,12800,25600,51200,102400)
+    case object FailWhale extends RuntimeException("the system... is down")
 
-  def ranges(N: Int): List[Stream[Pure,Int]] = List(
-    // left associated ++
-    (1 until N).map(emit).foldLeft(emit(0))(_ ++ _),
-    // right associated ++
-    Chunk.seq((0 until N) map emit).foldRight(empty: Stream[Pure,Int])(_ ++ _)
-  )
+    val Ns = List(2,3,100,200,400,800,1600,3200,6400,12800,25600,51200,102400)
 
-  property("left-associated ++") = secure { Ns.forall { N =>
-   logTime("left-associated ++ ("+N.toString+")") {
-   (1 until N).map(emit).foldLeft(emit(0))(_ ++ _) ===
-   Vector.range(0,N)
-  }}}
-
-  property("right-associated ++") = secure { Ns.forall { N =>
-    logTime("right-associated ++ ("+N.toString+")") {
-    Chunk.seq((0 until N).map(emit)).foldRight(empty: Stream[Pure,Int])(_ ++ _) ===
-    Vector.range(0,N)
-  }}}
-
-  property("left-associated flatMap 1") = protect {
-    Ns.forall { N => logTime("left-associated flatMap 1 ("+N.toString+")") {
-      (1 until N).map(emit).foldLeft(emit(0))(
-        (acc,a) => acc flatMap { _ => a }) ===
-      Vector(N-1)
-    }}
-  }
-
-  property("right-associated flatMap 1") = protect {
-    Ns.forall { N => logTime("right-associated flatMap 1 ("+N.toString+")") {
-      (1 until N).map(emit).reverse.foldLeft(emit(0))(
-        (acc,a) => a flatMap { _ => acc }) ===
-      Vector(0)
-    }}
-  }
-
-  property("left-associated flatMap 2") = protect {
-    Ns.forall { N => logTime("left-associated flatMap 2 ("+N.toString+")") {
-      (1 until N).map(emit).foldLeft(emit(0) ++ emit(1) ++ emit(2))(
-        (acc,a) => acc flatMap { _ => a }) ===
-      Vector(N-1, N-1, N-1)
-    }}
-  }
-
-  property("right-associated flatMap 1") = protect {
-    Ns.forall { N => logTime("right-associated flatMap 1 ("+N.toString+")") {
-      (1 until N).map(emit).reverse.foldLeft(emit(0) ++ emit(1) ++ emit(2))(
-        (acc,a) => a flatMap { _ => acc }) === Vector(0,1,2)
-    }}
-  }
-
-  property("transduce (id)") = protect {
-    Ns.forall { N => logTime("transduce (id) " + N) {
-      (chunk(Chunk.seq(0 until N)): Stream[Task,Int]).repeatPull { (s: Handle[Task,Int]) =>
-        for {
-          s2 <- s.await1
-          _ <- Pull.output1(s2.head)
-        } yield s2.tail
-      } ==? Vector.range(0,N) }
-    }
-  }
-
-  property("bracket + onError (1)") = protect { Ns.forall { N =>
-    val open = new AtomicInteger(0)
-    val ok = new AtomicInteger(0)
-    val bracketed = bracket(Task.delay { open.incrementAndGet })(
-      _ => emit(1) ++ fail(FailWhale),
-      _ => Task.delay { ok.incrementAndGet; open.decrementAndGet; () }
+    def ranges(N: Int): List[Stream[Pure,Int]] = List(
+      // left associated ++
+      (1 until N).map(emit).foldLeft(emit(0))(_ ++ _),
+      // right associated ++
+      Chunk.seq((0 until N) map emit).foldRight(Stream.empty: Stream[Pure,Int])(_ ++ _)
     )
-    // left-associative onError chains
-    throws (FailWhale) {
-      List.fill(N)(bracketed).foldLeft(fail(FailWhale): Stream[Task,Int]) {
-        (acc,hd) => acc onError { _ => hd }
-      }
-    } &&
-    ok.get == N && open.get == 0 && { ok.set(0); true } &&
-    // right-associative onError chains
-    throws (FailWhale) {
-      List.fill(N)(bracketed).foldLeft(fail(FailWhale): Stream[Task,Int]) {
-        (tl,hd) => hd onError { _ => tl }
-      }
-    } && ok.get == N && open.get == 0
-  }}
 
-  def logTime[A](msg: String)(a: => A): A = {
-    val start = System.nanoTime
-    val result = a
-    val total = (System.nanoTime - start) / 1e6
-    println(msg + " took " + total + " milliseconds")
-    result
-  }
+    "left-associated ++" - { Ns.foreach { N =>
+      N.toString in {
+        runLog((1 until N).map(emit).foldLeft(emit(0))(_ ++ _)) shouldBe Vector.range(0,N)
+      }
+    }}
+
+    "right-associated ++" - { Ns.foreach { N =>
+      N.toString in {
+        runLog(Chunk.seq((0 until N).map(emit)).foldRight(Stream.empty: Stream[Pure,Int])(_ ++ _)) shouldBe Vector.range(0,N)
+      }
+    }}
+
+    "left-associated flatMap 1" - { Ns.foreach { N =>
+      N.toString in {
+        runLog((1 until N).map(emit).foldLeft(emit(0))((acc,a) => acc flatMap { _ => a })) shouldBe Vector(N-1)
+      }
+    }}
+
+    "right-associated flatMap 1" - { Ns.foreach { N =>
+      N.toString in {
+        runLog((1 until N).map(emit).reverse.foldLeft(emit(0))((acc,a) => a flatMap { _ => acc })) shouldBe Vector(0)
+      }
+    }}
+
+    "left-associated flatMap 2" - { Ns.foreach { N =>
+      N.toString in {
+        runLog((1 until N).map(emit).foldLeft(emit(0) ++ emit(1) ++ emit(2))(
+          (acc,a) => acc flatMap { _ => a })) shouldBe Vector(N-1, N-1, N-1)
+      }
+    }}
+
+    "right-associated flatMap 2" - { Ns.foreach { N =>
+      N.toString in {
+        runLog((1 until N).map(emit).reverse.foldLeft(emit(0) ++ emit(1) ++ emit(2))(
+          (acc,a) => a flatMap { _ => acc })) shouldBe Vector(0,1,2)
+      }
+    }}
+
+    "transduce (id)" - { Ns.foreach { N =>
+      N.toString in {
+        runLog((chunk(Chunk.seq(0 until N)): Stream[Task,Int]).repeatPull { (s: Handle[Task,Int]) =>
+          for {
+            s2 <- s.await1
+            _ <- Pull.output1(s2.head)
+          } yield s2.tail
+        }) shouldBe Vector.range(0,N)
+      }
+    }}
+
+    "bracket + onError (1)" - { Ns.foreach { N =>
+      N.toString in {
+        val open = new AtomicInteger(0)
+        val ok = new AtomicInteger(0)
+        val bracketed = bracket(Task.delay { open.incrementAndGet })(
+          _ => emit(1) ++ Stream.fail(FailWhale),
+          _ => Task.delay { ok.incrementAndGet; open.decrementAndGet; () }
+        )
+        // left-associative onError chains
+        assert(throws (FailWhale) {
+          List.fill(N)(bracketed).foldLeft(Stream.fail(FailWhale): Stream[Task,Int]) {
+            (acc,hd) => acc onError { _ => hd }
+          }
+        })
+        ok.get shouldBe N
+        open.get shouldBe 0
+        ok.set(0)
+        // right-associative onError chains
+        assert(throws (FailWhale) {
+          List.fill(N)(bracketed).foldLeft(Stream.fail(FailWhale): Stream[Task,Int]) {
+            (tl,hd) => hd onError { _ => tl }
+          }
+        })
+        ok.get shouldBe N
+        open.get shouldBe 0
+      }
+    }
+  }}
 }

--- a/core/src/test/scala/fs2/StreamSpec.scala
+++ b/core/src/test/scala/fs2/StreamSpec.scala
@@ -1,132 +1,131 @@
 package fs2
 
 import fs2.util.{Task,UF1}
-import TestUtil._
-import org.scalacheck._
-import org.scalacheck.Prop.{throws => _, _}
+import org.scalacheck.Gen
 
-object StreamSpec extends Properties("Stream") {
+class StreamSpec extends Fs2Spec {
 
-  property("chunk-formation (1)") = secure {
-    Chunk.empty.toList == List() &&
-    Chunk.singleton(23).toList == List(23)
-  }
+  "Stream" - {
 
-  property("chunk-formation (2)") = forAll { (c: Vector[Int]) =>
-    Chunk.seq(c).toVector == c &&
-    Chunk.seq(c).toList == c.toList &&
-    Chunk.indexedSeq(c).toVector == c &&
-    Chunk.indexedSeq(c).toList == c.toList &&
-    Chunk.seq(c).iterator.toList == c.iterator.toList &&
-    Chunk.indexedSeq(c).iterator.toList == c.iterator.toList
-  }
+    "chunk-formation (1)" in {
+      Chunk.empty.toList shouldBe List()
+      Chunk.singleton(23).toList shouldBe List(23)
+    }
 
-  property("chunk") = forAll { (c: Vector[Int]) =>
-    Stream.chunk(Chunk.seq(c)) ==? c
-  }
+    "chunk-formation (2)" in forAll { (c: Vector[Int]) =>
+      Chunk.seq(c).toVector shouldBe c
+      Chunk.seq(c).toList shouldBe c.toList
+      Chunk.indexedSeq(c).toVector shouldBe c
+      Chunk.indexedSeq(c).toList shouldBe c.toList
+      Chunk.seq(c).iterator.toList shouldBe c.iterator.toList
+      Chunk.indexedSeq(c).iterator.toList shouldBe c.iterator.toList
+    }
 
-  property("fail (1)") = forAll { (f: Failure) =>
-    try { run(f.get); false }
-    catch { case Err => true }
-  }
+    "chunk" in forAll { (c: Vector[Int]) =>
+      runLog(Stream.chunk(Chunk.seq(c))) shouldBe c
+    }
 
-  property("fail (2)") = secure {
-    throws (Err) { Stream.fail(Err) }
-  }
+    "fail (1)" in forAll { (f: Failure) =>
+      an[Err.type] should be thrownBy f.get.run.run.unsafeRun
+    }
 
-  property("fail (3)") = secure {
-    throws (Err) { Stream.emit(1) ++ Stream.fail(Err) }
-  }
+    "fail (2)" in {
+      assert(throws (Err) { Stream.fail(Err) })
+    }
 
-  property("eval") = secure {
-    Stream.eval(Task.delay(23)) ==? Vector(23)
-  }
+    "fail (3)" in {
+      assert(throws (Err) { Stream.emit(1) ++ Stream.fail(Err) })
+    }
 
-  property("++") = forAll { (s: PureStream[Int], s2: PureStream[Int]) =>
-    (s.get ++ s2.get) ==? { run(s.get) ++ run(s2.get) }
-  }
+    "eval" in {
+      runLog(Stream.eval(Task.delay(23))) shouldBe Vector(23)
+    }
 
-  property("flatMap") = forAll { (s: PureStream[PureStream[Int]]) =>
-    s.get.flatMap(inner => inner.get) ==? { run(s.get).flatMap(inner => run(inner.get)) }
-  }
+    "++" in forAll { (s: PureStream[Int], s2: PureStream[Int]) =>
+      runLog(s.get ++ s2.get) shouldBe { runLog(s.get) ++ runLog(s2.get) }
+    }
 
-  property("iterate") = protect {
-    Stream.iterate(0)(_ + 1).take(100).toList == List.iterate(0, 100)(_ + 1)
-  }
+    "flatMap" in forAll { (s: PureStream[PureStream[Int]]) =>
+      runLog(s.get.flatMap(inner => inner.get)) shouldBe { runLog(s.get).flatMap(inner => runLog(inner.get)) }
+    }
 
-  property("iterateEval") = protect {
-    Stream.iterateEval(0)(i => Task.delay(i + 1)).take(100).runLog.run.unsafeRun == List.iterate(0, 100)(_ + 1)
-  }
+    "iterate" in {
+      Stream.iterate(0)(_ + 1).take(100).toList shouldBe List.iterate(0, 100)(_ + 1)
+    }
 
-  property("map") = forAll { (s: PureStream[Int]) =>
-    s.get.map(identity) ==? run(s.get)
-  }
+    "iterateEval" in {
+      Stream.iterateEval(0)(i => Task.delay(i + 1)).take(100).runLog.run.unsafeRun shouldBe List.iterate(0, 100)(_ + 1)
+    }
 
-  property("onError (1)") = forAll { (s: PureStream[Int], f: Failure) =>
-    val s2 = s.get ++ f.get
-    s2.onError(_ => Stream.empty) ==? run(s.get)
-  }
+    "map" in forAll { (s: PureStream[Int]) =>
+      runLog(s.get.map(identity)) shouldBe runLog(s.get)
+    }
 
-  property("onError (2)") = protect {
-    (Stream.fail(Err) onError { _ => Stream.emit(1) }) === Vector(1)
-  }
+    "onError (1)" in forAll { (s: PureStream[Int], f: Failure) =>
+      val s2 = s.get ++ f.get
+      runLog(s2.onError(_ => Stream.empty)) shouldBe runLog(s.get)
+    }
 
-  property("onError (3)") = protect {
-    (Stream.emit(1) ++ Stream.fail(Err) onError { _ => Stream.emit(1) }) === Vector(1,1)
-  }
+    "onError (2)" in {
+      runLog(Stream.fail(Err) onError { _ => Stream.emit(1) }) shouldBe Vector(1)
+    }
 
-  property("onError (4)") = protect {
-    Stream.eval(Task.delay(throw Err)).map(Right(_)).onError(t => Stream.emit(Left(t)))
-          .take(1)
-          .runLog.run.unsafeRun ?= Vector(Left(Err))
-  }
+    "onError (3)" in {
+      runLog(Stream.emit(1) ++ Stream.fail(Err) onError { _ => Stream.emit(1) }) shouldBe Vector(1,1)
+    }
 
-  property("range") = protect {
-    Stream.range(0, 100).toList == List.range(0, 100) &&
-      Stream.range(0, 1).toList == List.range(0, 1) &&
-      Stream.range(0, 0).toList == List.range(0, 0) &&
-      Stream.range(0, 101, 2).toList == List.range(0, 101, 2) &&
-      Stream.range(5,0, -1).toList == List.range(5,0,-1) &&
-      Stream.range(5,0, 1).toList == Nil &&
-      Stream.range(10, 50, 0).toList == Nil
-  }
+    "onError (4)" in {
+      Stream.eval(Task.delay(throw Err)).map(Right(_)).onError(t => Stream.emit(Left(t)))
+            .take(1)
+            .runLog.run.unsafeRun shouldBe Vector(Left(Err))
+    }
 
-  property("ranges") = forAll(Gen.choose(1, 101)) { size =>
-    Stream.ranges[Task](0, 100, size).flatMap { case (i,j) => Stream.emits(i until j) }.runLog.run.unsafeRun ==
-      IndexedSeq.range(0, 100)
-  }
+    "range" in {
+      Stream.range(0, 100).toList shouldBe List.range(0, 100)
+      Stream.range(0, 1).toList shouldBe List.range(0, 1)
+      Stream.range(0, 0).toList shouldBe List.range(0, 0)
+      Stream.range(0, 101, 2).toList shouldBe List.range(0, 101, 2)
+      Stream.range(5,0, -1).toList shouldBe List.range(5,0,-1)
+      Stream.range(5,0, 1).toList shouldBe Nil
+      Stream.range(10, 50, 0).toList shouldBe Nil
+    }
 
-  property("translate (1)") = forAll { (s: PureStream[Int]) =>
-    s.get.flatMap(i => Stream.eval(Task.now(i))).translate(UF1.id[Task]) ==?
-    run(s.get)
-  }
+    "ranges" in forAll(Gen.choose(1, 101)) { size =>
+      Stream.ranges[Task](0, 100, size).flatMap { case (i,j) => Stream.emits(i until j) }.runLog.run.unsafeRun shouldBe
+        IndexedSeq.range(0, 100)
+    }
 
-  property("translate (2)") = forAll { (s: PureStream[Int]) =>
-    s.get.translate(UF1.id[Pure]) ==? run(s.get)
-  }
+    "translate (1)" in forAll { (s: PureStream[Int]) =>
+      runLog(s.get.flatMap(i => Stream.eval(Task.now(i))).translate(UF1.id[Task])) shouldBe
+      runLog(s.get)
+    }
 
-  property("toList") = forAll { (s: PureStream[Int]) =>
-    s.get.toList == run(s.get).toList
-  }
+    "translate (2)" in forAll { (s: PureStream[Int]) =>
+      runLog(s.get.translate(UF1.id[Pure])) shouldBe runLog(s.get)
+    }
 
-  property("toVector") = forAll { (s: PureStream[Int]) =>
-    s.get.toVector == run(s.get)
-  }
+    "toList" in forAll { (s: PureStream[Int]) =>
+      s.get.toList shouldBe runLog(s.get).toList
+    }
 
-  property("unfold") = protect {
-    Stream.unfold((0, 1)) {
-      case (f1, f2) => if (f1 <= 13) Some(((f1, f2), (f2, f1 + f2))) else None
-    }.map(_._1).toList == List(0, 1, 1, 2, 3, 5, 8, 13)
-  }
+    "toVector" in forAll { (s: PureStream[Int]) =>
+      s.get.toVector shouldBe runLog(s.get)
+    }
 
-  property("unfoldEval") = protect {
-    Stream.unfoldEval(10)(s => Task.now(if (s > 0) Some((s, s - 1)) else None))
-      .runLog.run.unsafeRun.toList == List.range(10, 0, -1)
-  }
+    "unfold" in {
+      Stream.unfold((0, 1)) {
+        case (f1, f2) => if (f1 <= 13) Some(((f1, f2), (f2, f1 + f2))) else None
+      }.map(_._1).toList shouldBe List(0, 1, 1, 2, 3, 5, 8, 13)
+    }
 
-  property("translate stack safety") = protect {
-    import fs2.util.{~>}
-    Stream.repeatEval(Task.delay(0)).translate(new (Task ~> Task) { def apply[X](x: Task[X]) = Task.suspend(x) }).take(1000000).run.run.unsafeRun
-    true
+    "unfoldEval" in {
+      Stream.unfoldEval(10)(s => Task.now(if (s > 0) Some((s, s - 1)) else None))
+        .runLog.run.unsafeRun.toList shouldBe List.range(10, 0, -1)
+    }
+
+    "translate stack safety" in {
+      import fs2.util.{~>}
+      Stream.repeatEval(Task.delay(0)).translate(new (Task ~> Task) { def apply[X](x: Task[X]) = Task.suspend(x) }).take(1000000).run.run.unsafeRun
+    }
   }
 }

--- a/core/src/test/scala/fs2/TestUtil.scala
+++ b/core/src/test/scala/fs2/TestUtil.scala
@@ -1,41 +1,22 @@
 package fs2
 
-import fs2.util.{Sub1,Task}
+import fs2.util.Task
 import org.scalacheck.{Arbitrary, Gen}
 
 import scala.concurrent.duration._
 
-object TestUtil {
+trait TestUtil {
 
   implicit val S = Strategy.fromFixedDaemonPool(8)
-  // implicit val S = Strategy.fromCachedDaemonPool("test-thread-worker")
 
-  def run[A](s: Stream[Task,A]): Vector[A] = s.runLog.run.unsafeRun
-  def runFor[A](timeout:FiniteDuration = 3.seconds)(s: Stream[Task,A]): Vector[A] = s.runLog.run.unsafeRunFor(timeout)
+  def runLog[A](s: Stream[Task,A]): Vector[A] = s.runLog.run.unsafeRun
+  def runFor[A](timeout: FiniteDuration = 3.seconds)(s: Stream[Task,A]): Vector[A] = s.runLog.run.unsafeRunFor(timeout)
 
   def throws[A](err: Throwable)(s: Stream[Task,A]): Boolean =
     s.runLog.run.unsafeAttemptRun match {
       case Left(e) if e == err => true
       case _ => false
     }
-
-  def logTiming[A](msg: String)(a: => A): A = {
-    import scala.concurrent.duration._
-    val start = System.currentTimeMillis
-    val result = a
-    val stop = System.currentTimeMillis
-    println(msg + " took " + (stop-start).milliseconds)
-    result
-  }
-
-  implicit class EqualsOp[F[_],A](s: Stream[F,A])(implicit S: Sub1[F,Task]) {
-    def ===(v: Vector[A]) = run(s.covary) == v
-    def ==?(v: Vector[A]) = {
-      val l = run(s.covary)
-      val r = v
-      l == r || { println("left: " + l); println("right: " + r); false }
-    }
-  }
 
   implicit def arbChunk[A](implicit A: Arbitrary[A]): Arbitrary[Chunk[A]] = Arbitrary(
     Gen.frequency(
@@ -126,3 +107,5 @@ object TestUtil {
 
   val nonEmptyNestedVectorGen: Gen[Vector[Vector[Int]]] = nestedVectorGen[Int](1,10)
 }
+
+object TestUtil extends TestUtil

--- a/core/src/test/scala/fs2/Utf8DecodeSpec.scala
+++ b/core/src/test/scala/fs2/Utf8DecodeSpec.scala
@@ -1,156 +1,157 @@
 package fs2
 
 import org.scalacheck._
-import Prop._
-
 import fs2.text._
 
-class Utf8DecodeSpec extends Properties("text.utf8Decode") {
+class Utf8DecodeSpec extends Fs2Spec {
+  "text" - {
+    "utf8Decoder" - {
 
-  def utf8Bytes(s: String): Chunk[Byte] = Chunk.bytes(s.getBytes("UTF-8"))
-  def utf8String(bs: Chunk[Byte]): String = new String(bs.toArray, "UTF-8")
+      def utf8Bytes(s: String): Chunk[Byte] = Chunk.bytes(s.getBytes("UTF-8"))
+      def utf8String(bs: Chunk[Byte]): String = new String(bs.toArray, "UTF-8")
 
-  def checkChar(c: Char): Boolean = (1 to 6).forall { n =>
-    Stream.chunk(utf8Bytes(c.toString)).pure.chunkLimit(n).through(utf8Decode).toList == List(c.toString)
-  }
+      def checkChar(c: Char) = (1 to 6).foreach { n =>
+        Stream.chunk(utf8Bytes(c.toString)).pure.chunkLimit(n).through(utf8Decode).toList shouldBe List(c.toString)
+      }
 
-  def checkBytes(is: Int*): Boolean = (1 to 6).forall { n =>
-    val bytes = Chunk.bytes(is.map(_.toByte).toArray)
-    Stream.chunk(bytes).pure.chunkLimit(n).through(utf8Decode).toList == List(utf8String(bytes))
-  }
+      def checkBytes(is: Int*) = (1 to 6).foreach { n =>
+        val bytes = Chunk.bytes(is.map(_.toByte).toArray)
+        Stream.chunk(bytes).pure.chunkLimit(n).through(utf8Decode).toList shouldBe List(utf8String(bytes))
+      }
 
-  def checkBytes2(is: Int*): Boolean = {
-    val bytes = Chunk.bytes(is.map(_.toByte).toArray)
-    Stream.pure(bytes).through(utf8Decode).toList.mkString == utf8String(bytes)
-  }
+      def checkBytes2(is: Int*) = {
+        val bytes = Chunk.bytes(is.map(_.toByte).toArray)
+        Stream.pure(bytes).through(utf8Decode).toList.mkString shouldBe utf8String(bytes)
+      }
 
-  property("all chars") = forAll { (c: Char) => checkChar(c) }
+      "all chars" in forAll { (c: Char) => checkChar(c) }
 
-  property("1 byte char") = checkBytes(0x24) // $
-  property("2 byte char") = checkBytes(0xC2, 0xA2) // ¢
-  property("3 byte char") = checkBytes(0xE2, 0x82, 0xAC) // €
-  property("4 byte char") = checkBytes(0xF0, 0xA4, 0xAD, 0xA2)
+      "1 byte char" in checkBytes(0x24) // $
+      "2 byte char" in checkBytes(0xC2, 0xA2) // ¢
+      "3 byte char" in checkBytes(0xE2, 0x82, 0xAC) // €
+      "4 byte char" in checkBytes(0xF0, 0xA4, 0xAD, 0xA2)
 
-  property("incomplete 2 byte char") = checkBytes(0xC2)
-  property("incomplete 3 byte char") = checkBytes(0xE2, 0x82)
-  property("incomplete 4 byte char") = checkBytes(0xF0, 0xA4, 0xAD)
+      "incomplete 2 byte char" in checkBytes(0xC2)
+      "incomplete 3 byte char" in checkBytes(0xE2, 0x82)
+      "incomplete 4 byte char" in checkBytes(0xF0, 0xA4, 0xAD)
 
-  property("preserve complete inputs") = forAll { (l: List[String]) =>
-    Stream.pure(l: _*).map(utf8Bytes).through(utf8Decode).toList == l
-  }
+      "preserve complete inputs" in forAll { (l: List[String]) =>
+        Stream.pure(l: _*).map(utf8Bytes).through(utf8Decode).toList shouldBe l
+      }
 
-  property("utf8Encode |> utf8Decode = id") = forAll { (s: String) =>
-    Stream.pure(s).through(utf8Encode).through(utf8Decode).toList == List(s)
-  }
+      "utf8Encode |> utf8Decode = id" in forAll { (s: String) =>
+        Stream.pure(s).through(utf8Encode).through(utf8Decode).toList shouldBe List(s)
+      }
 
-  property("1 byte sequences") = forAll { (s: String) =>
-    Stream.chunk(utf8Bytes(s)).pure.chunkLimit(1).through(utf8Decode).toList == s.grouped(1).toList
-  }
+      "1 byte sequences" in forAll { (s: String) =>
+        Stream.chunk(utf8Bytes(s)).pure.chunkLimit(1).through(utf8Decode).toList shouldBe s.grouped(1).toList
+      }
 
-  property("n byte sequences") = forAll { (s: String) =>
-    val n = Gen.choose(1,9).sample.getOrElse(1)
-    Stream.chunk(utf8Bytes(s)).pure.chunkLimit(1).through(utf8Decode).toList.mkString == s
-  }
+      "n byte sequences" in forAll { (s: String) =>
+        val n = Gen.choose(1,9).sample.getOrElse(1)
+        Stream.chunk(utf8Bytes(s)).pure.chunkLimit(1).through(utf8Decode).toList.mkString shouldBe s
+      }
 
-  // The next tests were taken from:
-  // https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt
+      // The next tests were taken from:
+      // https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt
 
-  // 2.1 First possible sequence of a certain length
-  property("2.1") = protect {
-    ("2.1.1" |: checkBytes(0x00)) &&
-      ("2.1.2" |: checkBytes(0xc2, 0x80)) &&
-      ("2.1.3" |: checkBytes(0xe0, 0xa0, 0x80)) &&
-      ("2.1.4" |: checkBytes(0xf0, 0x90, 0x80, 0x80)) &&
-      ("2.1.5" |: checkBytes2(0xf8, 0x88, 0x80, 0x80, 0x80)) &&
-      ("2.1.6" |: checkBytes2(0xfc, 0x84, 0x80, 0x80, 0x80, 0x80))
-  }
+      // 2.1 First possible sequence of a certain length
+      "2.1" - {
+        "2.1.1" in checkBytes(0x00)
+        "2.1.2" in checkBytes(0xc2, 0x80)
+        "2.1.3" in checkBytes(0xe0, 0xa0, 0x80)
+        "2.1.4" in checkBytes(0xf0, 0x90, 0x80, 0x80)
+        "2.1.5" in checkBytes2(0xf8, 0x88, 0x80, 0x80, 0x80)
+        "2.1.6" in checkBytes2(0xfc, 0x84, 0x80, 0x80, 0x80, 0x80)
+      }
 
-  // 2.2 Last possible sequence of a certain length
-  property("2.2") = protect {
-    ("2.2.1" |: checkBytes(0x7f)) &&
-      ("2.2.2" |: checkBytes(0xdf, 0xbf)) &&
-      ("2.2.3" |: checkBytes(0xef, 0xbf, 0xbf)) &&
-      ("2.2.4" |: checkBytes(0xf7, 0xbf, 0xbf, 0xbf)) &&
-      ("2.2.5" |: checkBytes2(0xfb, 0xbf, 0xbf, 0xbf, 0xbf)) &&
-      ("2.2.6" |: checkBytes2(0xfd, 0xbf, 0xbf, 0xbf, 0xbf, 0xbf))
-  }
+      // 2.2 Last possible sequence of a certain length
+      "2.2" - {
+        "2.2.1" in checkBytes(0x7f)
+        "2.2.2" in checkBytes(0xdf, 0xbf)
+        "2.2.3" in checkBytes(0xef, 0xbf, 0xbf)
+        "2.2.4" in checkBytes(0xf7, 0xbf, 0xbf, 0xbf)
+        "2.2.5" in checkBytes2(0xfb, 0xbf, 0xbf, 0xbf, 0xbf)
+        "2.2.6" in checkBytes2(0xfd, 0xbf, 0xbf, 0xbf, 0xbf, 0xbf)
+      }
 
-  // 2.3 Other boundary conditions
-  property("2.3") = protect {
-    ("2.3.1" |: checkBytes(0xed, 0x9f, 0xbf)) &&
-      ("2.3.2" |: checkBytes(0xee, 0x80, 0x80)) &&
-      ("2.3.3" |: checkBytes(0xef, 0xbf, 0xbd)) &&
-      ("2.3.4" |: checkBytes(0xf4, 0x8f, 0xbf, 0xbf)) &&
-      ("2.3.5" |: checkBytes(0xf4, 0x90, 0x80, 0x80))
-  }
+      // 2.3 Other boundary conditions
+      "2.3" - {
+        "2.3.1" in checkBytes(0xed, 0x9f, 0xbf)
+        "2.3.2" in checkBytes(0xee, 0x80, 0x80)
+        "2.3.3" in checkBytes(0xef, 0xbf, 0xbd)
+        "2.3.4" in checkBytes(0xf4, 0x8f, 0xbf, 0xbf)
+        "2.3.5" in checkBytes(0xf4, 0x90, 0x80, 0x80)
+      }
 
-  // 3.1 Unexpected continuation bytes
-  property("3.1") = protect {
-    ("3.1.1" |: checkBytes(0x80)) &&
-      ("3.1.2" |: checkBytes(0xbf))
-  }
+      // 3.1 Unexpected continuation bytes
+      "3.1" - {
+        "3.1.1" in checkBytes(0x80)
+        "3.1.2" in checkBytes(0xbf)
+      }
 
-  // 3.5 Impossible bytes
-  property("3.5") = protect {
-    ("3.5.1" |: checkBytes(0xfe)) &&
-      ("3.5.2" |: checkBytes(0xff)) &&
-      ("3.5.3" |: checkBytes2(0xfe, 0xfe, 0xff, 0xff))
-  }
+      // 3.5 Impossible bytes
+      "3.5" - {
+        "3.5.1" in checkBytes(0xfe)
+        "3.5.2" in checkBytes(0xff)
+        "3.5.3" in checkBytes2(0xfe, 0xfe, 0xff, 0xff)
+      }
 
-  // 4.1 Examples of an overlong ASCII character
-  property("4.1") = protect {
-    ("4.1.1" |: checkBytes(0xc0, 0xaf)) &&
-      ("4.1.2" |: checkBytes(0xe0, 0x80, 0xaf)) &&
-      ("4.1.3" |: checkBytes(0xf0, 0x80, 0x80, 0xaf)) &&
-      ("4.1.4" |: checkBytes2(0xf8, 0x80, 0x80, 0x80, 0xaf)) &&
-      ("4.1.5" |: checkBytes2(0xfc, 0x80, 0x80, 0x80, 0x80, 0xaf))
-  }
+      // 4.1 Examples of an overlong ASCII character
+      "4.1" - {
+        "4.1.1" in checkBytes(0xc0, 0xaf)
+        "4.1.2" in checkBytes(0xe0, 0x80, 0xaf)
+        "4.1.3" in checkBytes(0xf0, 0x80, 0x80, 0xaf)
+        "4.1.4" in checkBytes2(0xf8, 0x80, 0x80, 0x80, 0xaf)
+        "4.1.5" in checkBytes2(0xfc, 0x80, 0x80, 0x80, 0x80, 0xaf)
+      }
 
-  // 4.2 Maximum overlong sequences
-  property("4.2") = protect {
-    ("4.2.1" |: checkBytes(0xc1, 0xbf)) &&
-      ("4.2.2" |: checkBytes(0xe0, 0x9f, 0xbf)) &&
-      ("4.2.3" |: checkBytes(0xf0, 0x8f, 0xbf, 0xbf)) &&
-      ("4.2.4" |: checkBytes2(0xf8, 0x87, 0xbf, 0xbf, 0xbf)) &&
-      ("4.2.5" |: checkBytes2(0xfc, 0x83, 0xbf, 0xbf, 0xbf, 0xbf))
-  }
+      // 4.2 Maximum overlong sequences
+      "4.2" - {
+        "4.2.1" in checkBytes(0xc1, 0xbf)
+        "4.2.2" in checkBytes(0xe0, 0x9f, 0xbf)
+        "4.2.3" in checkBytes(0xf0, 0x8f, 0xbf, 0xbf)
+        "4.2.4" in checkBytes2(0xf8, 0x87, 0xbf, 0xbf, 0xbf)
+        "4.2.5" in checkBytes2(0xfc, 0x83, 0xbf, 0xbf, 0xbf, 0xbf)
+      }
 
-  // 4.3 Overlong representation of the NUL character
-  property("4.3") = protect {
-    ("4.3.1" |: checkBytes(0xc0, 0x80)) &&
-      ("4.3.2" |: checkBytes(0xe0, 0x80, 0x80)) &&
-      ("4.3.3" |: checkBytes(0xf0, 0x80, 0x80, 0x80)) &&
-      ("4.3.4" |: checkBytes2(0xf8, 0x80, 0x80, 0x80, 0x80)) &&
-      ("4.3.5" |: checkBytes2(0xfc, 0x80, 0x80, 0x80, 0x80, 0x80))
-  }
+      // 4.3 Overlong representation of the NUL character
+      "4.3" - {
+        "4.3.1" in checkBytes(0xc0, 0x80)
+        "4.3.2" in checkBytes(0xe0, 0x80, 0x80)
+        "4.3.3" in checkBytes(0xf0, 0x80, 0x80, 0x80)
+        "4.3.4" in checkBytes2(0xf8, 0x80, 0x80, 0x80, 0x80)
+        "4.3.5" in checkBytes2(0xfc, 0x80, 0x80, 0x80, 0x80, 0x80)
+      }
 
-  // 5.1 Single UTF-16 surrogates
-  property("5.1") = protect {
-    ("5.1.1" |: checkBytes(0xed, 0xa0, 0x80)) &&
-      ("5.1.2" |: checkBytes(0xed, 0xad, 0xbf)) &&
-      ("5.1.3" |: checkBytes(0xed, 0xae, 0x80)) &&
-      ("5.1.4" |: checkBytes(0xed, 0xaf, 0xbf)) &&
-      ("5.1.5" |: checkBytes(0xed, 0xb0, 0x80)) &&
-      ("5.1.6" |: checkBytes(0xed, 0xbe, 0x80)) &&
-      ("5.1.7" |: checkBytes(0xed, 0xbf, 0xbf))
-  }
+      // 5.1 Single UTF-16 surrogates
+      "5.1" - {
+        "5.1.1" in checkBytes(0xed, 0xa0, 0x80)
+        "5.1.2" in checkBytes(0xed, 0xad, 0xbf)
+        "5.1.3" in checkBytes(0xed, 0xae, 0x80)
+        "5.1.4" in checkBytes(0xed, 0xaf, 0xbf)
+        "5.1.5" in checkBytes(0xed, 0xb0, 0x80)
+        "5.1.6" in checkBytes(0xed, 0xbe, 0x80)
+        "5.1.7" in checkBytes(0xed, 0xbf, 0xbf)
+      }
 
-  // 5.2 Paired UTF-16 surrogates
-  property("5.2") = protect {
-    ("5.2.1" |: checkBytes2(0xed, 0xa0, 0x80, 0xed, 0xb0, 0x80)) &&
-      ("5.2.2" |: checkBytes2(0xed, 0xa0, 0x80, 0xed, 0xbf, 0xbf)) &&
-      ("5.2.3" |: checkBytes2(0xed, 0xad, 0xbf, 0xed, 0xb0, 0x80)) &&
-      ("5.2.4" |: checkBytes2(0xed, 0xad, 0xbf, 0xed, 0xbf, 0xbf)) &&
-      ("5.2.5" |: checkBytes2(0xed, 0xae, 0x80, 0xed, 0xb0, 0x80)) &&
-      ("5.2.6" |: checkBytes2(0xed, 0xae, 0x80, 0xed, 0xbf, 0xbf)) &&
-      ("5.2.7" |: checkBytes2(0xed, 0xaf, 0xbf, 0xed, 0xb0, 0x80)) &&
-      ("5.2.8" |: checkBytes2(0xed, 0xaf, 0xbf, 0xed, 0xbf, 0xbf))
-  }
+      // 5.2 Paired UTF-16 surrogates
+      "5.2" - {
+        "5.2.1" in checkBytes2(0xed, 0xa0, 0x80, 0xed, 0xb0, 0x80)
+        "5.2.2" in checkBytes2(0xed, 0xa0, 0x80, 0xed, 0xbf, 0xbf)
+        "5.2.3" in checkBytes2(0xed, 0xad, 0xbf, 0xed, 0xb0, 0x80)
+        "5.2.4" in checkBytes2(0xed, 0xad, 0xbf, 0xed, 0xbf, 0xbf)
+        "5.2.5" in checkBytes2(0xed, 0xae, 0x80, 0xed, 0xb0, 0x80)
+        "5.2.6" in checkBytes2(0xed, 0xae, 0x80, 0xed, 0xbf, 0xbf)
+        "5.2.7" in checkBytes2(0xed, 0xaf, 0xbf, 0xed, 0xb0, 0x80)
+        "5.2.8" in checkBytes2(0xed, 0xaf, 0xbf, 0xed, 0xbf, 0xbf)
+      }
 
-  // 5.3 Other illegal code positions
-  property("5.3") = protect {
-    ("5.3.1" |: checkBytes(0xef, 0xbf, 0xbe)) &&
-      ("5.3.2" |: checkBytes(0xef, 0xbf, 0xbf))
+      // 5.3 Other illegal code positions
+      "5.3" - {
+        "5.3.1" in checkBytes(0xef, 0xbf, 0xbe)
+        "5.3.2" in checkBytes(0xef, 0xbf, 0xbf)
+      }
+    }
   }
 }
-

--- a/core/src/test/scala/fs2/async/QueueSpec.scala
+++ b/core/src/test/scala/fs2/async/QueueSpec.scala
@@ -1,17 +1,19 @@
 package fs2
 package async
 
-import TestUtil._
 import fs2.util.Task
-import org.scalacheck.Prop._
-import org.scalacheck._
 
-object QueueSpec extends Properties("Queue") {
-
-  property("unbounded producer/consumer") = forAll { (s: PureStream[Int]) =>
-    s.tag |: Stream.eval(async.unboundedQueue[Task,Int]).map { q =>
-      val r = run(s.get)
-      run(q.dequeue.merge(s.get.evalMap(q.enqueue1).drain).take(r.size)) == r
-    } === Vector(true)
+class QueueSpec extends Fs2Spec {
+  "Queue" - {
+    "unbounded producer/consumer" in {
+      forAll { (s: PureStream[Int]) =>
+        withClue(s.tag) {
+          runLog(Stream.eval(async.unboundedQueue[Task,Int]).map { q =>
+            val r = s.get.toVector
+            runLog(q.dequeue.merge(s.get.evalMap(q.enqueue1).drain).take(r.size)) == r
+          }) shouldBe Vector(true)
+        }
+      }
+    }
   }
 }

--- a/core/src/test/scala/fs2/async/SemaphoreSpec.scala
+++ b/core/src/test/scala/fs2/async/SemaphoreSpec.scala
@@ -1,46 +1,49 @@
 package fs2
 package async
 
-import TestUtil.{S => _, _}
 import fs2.util.Task
-import org.scalacheck.Prop._
-import org.scalacheck._
 
-object SemaphoreSpec extends Properties("SemaphoreSpec") {
+class SemaphoreSpec extends Fs2Spec {
 
-  implicit val S: Strategy =
-    fs2.Strategy.fromCachedDaemonPool("SemaphoreSpec")
+  override implicit val S: Strategy = fs2.Strategy.fromCachedDaemonPool("SemaphoreSpec")
 
-  property("decrement n synchronously") = forAll { (s: PureStream[Int], n: Int) =>
-    val n0 = ((n.abs % 20) + 1).abs
-    Stream.eval(async.mutable.Semaphore[Task](n0)).flatMap { s =>
-      Stream.emits(0 until n0).evalMap { _ => s.decrement }.drain ++ Stream.eval(s.available)
-    } === Vector(0)
-  }
+  "Semaphore" - {
 
-  property("offsetting increment/decrements") = forAll { (ms0: Vector[Int]) =>
-    val T = implicitly[Async[Task]]
-    val s = async.mutable.Semaphore[Task](0).unsafeRun
-    val longs = ms0.map(_.toLong.abs)
-    val longsRev = longs.reverse
-    val t: Task[Unit] = for {
-      // just two parallel tasks, one incrementing, one decrementing
-      decrs <- Task.start { T.traverse(longs)(s.decrementBy) }
-      incrs <- Task.start { T.traverse(longsRev)(s.incrementBy) }
-      _ <- decrs: Task[Vector[Unit]]
-      _ <- incrs: Task[Vector[Unit]]
-    } yield ()
-    t.unsafeRun
-    val ok1 = "two threads" |: (s.count.unsafeRun == 0)
-    val t2: Task[Unit] = for {
-      // N parallel incrementing tasks and N parallel decrementing tasks
-      decrs <- Task.start { T.parallelTraverse(longs)(s.decrementBy) }
-      incrs <- Task.start { T.parallelTraverse(longsRev)(s.incrementBy) }
-      _ <- decrs: Task[Vector[Unit]]
-      _ <- incrs: Task[Vector[Unit]]
-    } yield ()
-    t2.unsafeRun
-    val ok2 = "N threads" |: (s.count.unsafeRun == 0)
-    ok1 && ok2
+    "decrement n synchronously" in {
+      forAll { (s: PureStream[Int], n: Int) =>
+        val n0 = ((n.abs % 20) + 1).abs
+        Stream.eval(async.mutable.Semaphore[Task](n0)).flatMap { s =>
+          Stream.emits(0 until n0).evalMap { _ => s.decrement }.drain ++ Stream.eval(s.available)
+        }.runLog.run.unsafeRun shouldBe Vector(0)
+      }
+    }
+
+    "offsetting increment/decrements" in {
+      forAll { (ms0: Vector[Int]) =>
+        val T = implicitly[Async[Task]]
+        val s = async.mutable.Semaphore[Task](0).unsafeRun
+        val longs = ms0.map(_.toLong.abs)
+        val longsRev = longs.reverse
+        val t: Task[Unit] = for {
+          // just two parallel tasks, one incrementing, one decrementing
+          decrs <- Task.start { T.traverse(longs)(s.decrementBy) }
+          incrs <- Task.start { T.traverse(longsRev)(s.incrementBy) }
+          _ <- decrs: Task[Vector[Unit]]
+          _ <- incrs: Task[Vector[Unit]]
+        } yield ()
+        t.unsafeRun
+        s.count.unsafeRun shouldBe 0
+
+        val t2: Task[Unit] = for {
+          // N parallel incrementing tasks and N parallel decrementing tasks
+          decrs <- Task.start { T.parallelTraverse(longs)(s.decrementBy) }
+          incrs <- Task.start { T.parallelTraverse(longsRev)(s.incrementBy) }
+          _ <- decrs: Task[Vector[Unit]]
+          _ <- incrs: Task[Vector[Unit]]
+        } yield ()
+        t2.unsafeRun
+        s.count.unsafeRun shouldBe 0
+      }
+    }
   }
 }

--- a/core/src/test/scala/fs2/async/SignalSpec.scala
+++ b/core/src/test/scala/fs2/async/SignalSpec.scala
@@ -1,27 +1,27 @@
 package fs2
 package async
 
-import TestUtil._
 import fs2.util.Task
 import java.util.concurrent.atomic.AtomicLong
-import org.scalacheck.Prop._
-import org.scalacheck._
 
-object SignalSpec extends Properties("Signal") {
-
-  property("get/set/discrete") = forAll { (vs0: List[Long]) =>
-    val vs = vs0 map { n => if (n == 0) 1 else n }
-    val s = async.signalOf[Task,Long](0L).unsafeRun
-    val r = new AtomicLong(0)
-    val u = s.discrete.map(r.set).run.run.async.unsafeRunAsyncFuture
-    vs.forall { v =>
-      s.set(v).unsafeRun
-      while (s.get.unsafeRun != v) {} // wait for set to arrive
-      // can't really be sure when the discrete subscription will be set up,
-      // but once we've gotten one update (r != 0), we know we're subscribed
-      // and should see result of all subsequent calls to set
-      if (r.get != 0) { while (r.get != v) {} }
-      true
+class SignalSpec extends Fs2Spec {
+  "Signal" - {
+    "get/set/discrete" in {
+      forAll { (vs0: List[Long]) =>
+        val vs = vs0 map { n => if (n == 0) 1 else n }
+        val s = async.signalOf[Task,Long](0L).unsafeRun
+        val r = new AtomicLong(0)
+        val u = s.discrete.map(r.set).run.run.async.unsafeRunAsyncFuture
+        assert(vs.forall { v =>
+          s.set(v).unsafeRun
+          while (s.get.unsafeRun != v) {} // wait for set to arrive
+          // can't really be sure when the discrete subscription will be set up,
+          // but once we've gotten one update (r != 0), we know we're subscribed
+          // and should see result of all subsequent calls to set
+          if (r.get != 0) { while (r.get != v) {} }
+          true
+        })
+      }
     }
   }
 }

--- a/core/src/test/scala/fs2/internal/RefSpec.scala
+++ b/core/src/test/scala/fs2/internal/RefSpec.scala
@@ -1,19 +1,21 @@
 package fs2
 package internal
 
-import TestUtil._
-import org.scalacheck.Prop._
 import org.scalacheck._
 import java.util.concurrent.CountDownLatch
 
-object RefSpec extends Properties("Ref") {
+class RefSpec extends Fs2Spec {
 
-  property("modify") = forAll(Gen.choose(1,100)) { n =>
-    val ref = Ref(0)
-    val latch = new CountDownLatch(2)
-    S { (0 until n).foreach { _ => ref.modify(_ + 1) }; latch.countDown }
-    S { (0 until n).foreach { _ => ref.modify(_ - 1) }; latch.countDown }
-    latch.await
-    ref.get ?= 0
+  "Ref" - {
+    "modify" in {
+      forAll(Gen.choose(1,100)) { n =>
+        val ref = Ref(0)
+        val latch = new CountDownLatch(2)
+        S { (0 until n).foreach { _ => ref.modify(_ + 1) }; latch.countDown }
+        S { (0 until n).foreach { _ => ref.modify(_ - 1) }; latch.countDown }
+        latch.await
+        ref.get shouldBe 0
+      }
+    }
   }
 }

--- a/core/src/test/scala/fs2/time/TimeSpec.scala
+++ b/core/src/test/scala/fs2/time/TimeSpec.scala
@@ -1,65 +1,65 @@
 package fs2
 package time
 
-import org.scalacheck.Prop._
-import org.scalacheck.{Gen, Properties}
+import org.scalacheck.Gen
 import scala.concurrent.duration._
 
 import Stream._
 
-class TimeSpec extends Properties("time") {
+class TimeSpec extends Fs2Spec {
 
   implicit val scheduler = java.util.concurrent.Executors.newScheduledThreadPool(2)
-  implicit val S = Strategy.fromExecutor(scheduler)
+  override implicit val S = Strategy.fromExecutor(scheduler)
 
-  property("awakeEvery") = protect {
-    time.awakeEvery(100.millis).map(_.toMillis/100).take(5).runLog.run.unsafeRun == Vector(1,2,3,4,5)
-  }
+  "time" - {
 
-  property("duration") = protect {
-    val firstValueDiscrepancy = time.duration.take(1).runLog.run.unsafeRun.last
-    val reasonableErrorInMillis = 200
-    val reasonableErrorInNanos = reasonableErrorInMillis * 1000000
-    def p = firstValueDiscrepancy.toNanos < reasonableErrorInNanos
-
-    val r1 = p :| "first duration is near zero on first run"
-    Thread.sleep(reasonableErrorInMillis)
-    val r2 = p :| "first duration is near zero on second run"
-
-    r1 && r2
-  }
-
-  val smallDelay = Gen.choose(10, 300) map {_.millis}
-
-  property("every") =
-    forAll(smallDelay) { delay: Duration =>
-      type BD = (Boolean, Duration)
-      val durationSinceLastTrue: Pipe[Pure,BD,BD] = {
-        def go(lastTrue: Duration): Handle[Pure,BD] => Pull[Pure,BD,Handle[Pure,BD]] = h => {
-          h.receive1 {
-            case pair #: tl =>
-              pair match {
-                case (true , d) => Pull.output1((true , d - lastTrue)) >> go(d)(tl)
-                case (false, d) => Pull.output1((false, d - lastTrue)) >> go(lastTrue)(tl)
-              }
-          }
-        }
-        _ pull go(0.seconds)
-      }
-
-      val draws = (600.millis / delay) min 10 // don't take forever
-
-      val durationsSinceSpike = time.every(delay).
-        zip(time.duration).
-        take(draws.toInt).
-        through(durationSinceLastTrue)
-
-      val result = durationsSinceSpike.runLog.run.unsafeRun.toList
-      val (head :: tail) = result
-
-      head._1 :| "every always emits true first" &&
-        tail.filter   (_._1).map(_._2).forall { _ >= delay } :| "true means the delay has passed" &&
-        tail.filterNot(_._1).map(_._2).forall { _ <= delay } :| "false means the delay has not passed"
+    "awakeEvery" in {
+      time.awakeEvery(100.millis).map(_.toMillis/100).take(5).runLog.run.unsafeRun shouldBe Vector(1,2,3,4,5)
     }
+
+    "duration" in {
+      val firstValueDiscrepancy = time.duration.take(1).runLog.run.unsafeRun.last
+      val reasonableErrorInMillis = 200
+      val reasonableErrorInNanos = reasonableErrorInMillis * 1000000
+      def p = firstValueDiscrepancy.toNanos < reasonableErrorInNanos
+
+      withClue("first duration is near zero on first run") { assert(p) }
+      Thread.sleep(reasonableErrorInMillis)
+      withClue("first duration is near zero on second run") { assert(p) }
+    }
+
+    "every" in {
+      val smallDelay = Gen.choose(10, 300) map {_.millis}
+      forAll(smallDelay) { delay: Duration =>
+        type BD = (Boolean, Duration)
+        val durationSinceLastTrue: Pipe[Pure,BD,BD] = {
+          def go(lastTrue: Duration): Handle[Pure,BD] => Pull[Pure,BD,Handle[Pure,BD]] = h => {
+            h.receive1 {
+              case pair #: tl =>
+                pair match {
+                  case (true , d) => Pull.output1((true , d - lastTrue)) >> go(d)(tl)
+                  case (false, d) => Pull.output1((false, d - lastTrue)) >> go(lastTrue)(tl)
+                }
+            }
+          }
+          _ pull go(0.seconds)
+        }
+
+        val draws = (600.millis / delay) min 10 // don't take forever
+
+        val durationsSinceSpike = time.every(delay).
+          zip(time.duration).
+          take(draws.toInt).
+          through(durationSinceLastTrue)
+
+        val result = durationsSinceSpike.runLog.run.unsafeRun.toList
+        val (head :: tail) = result
+
+        withClue("every always emits true first") { assert(head._1) }
+        withClue("true means the delay has passed") { assert(tail.filter(_._1).map(_._2).forall { _ >= delay }) }
+        withClue("false means the delay has not passed") { assert(tail.filterNot(_._1).map(_._2).forall { _ <= delay }) }
+      }
+    }
+  }
 }
 


### PR DESCRIPTION
While trying to determine why tests randomly hang on Travis, I decided to port the tests from pure ScalaCheck to ScalaTest+Scalacheck. This has a number of benefits including:
 - Better error messages
 - More predictable test ordering
 - Ability to add logging around tests

Based on this logging, I suspect the test that randomly hangs is `asynchronous resource allocation (3)` in `ResourceSafetySpec`.