### PR TITLE
Fix for #589 finalization order bug

### DIFF
--- a/core/src/main/scala/fs2/StreamCore.scala
+++ b/core/src/main/scala/fs2/StreamCore.scala
@@ -471,9 +471,9 @@ object StreamCore {
 
   private[fs2]
   def runCleanup[F[_]](cleanups: Iterable[Free[F,Either[Throwable,Unit]]]): Free[F,Either[Throwable,Unit]] = {
-    // note - run cleanup actions in LIFO order, later actions run first
+    // note - run cleanup actions in FIFO order, but avoid left-nesting binds
     // all actions are run but only first error is reported
-    cleanups.foldLeft[Free[F,Either[Throwable,Unit]]](Free.pure(Right(())))(
+    cleanups.toList.reverse.foldLeft[Free[F,Either[Throwable,Unit]]](Free.pure(Right(())))(
       (tl,hd) => hd flatMap { _.fold(e => tl flatMap { _ => Free.pure(Left(e)) }, _ => tl) }
     )
   }


### PR DESCRIPTION
Previously, when reaching the end of a stream, any remaining uncalled finalizers were run in LIFO order. Now they are run in FIFO order. I believe this is more correct, especially since when nesting calls to `bracket`, it's actually the innermost finalizer that will be added to the resources map first and we generally want to call finalizers 'innermost first'. This has the effect that `a.onFinalize(f1).onFinalize(f2)` will run `f1` then `f2`.

Review by @pchlupacek 