### PR TITLE
finishAcquire now returns a Boolean, and this is handled in various places

### DIFF
--- a/core/src/main/scala/fs2/internal/Resources.scala
+++ b/core/src/main/scala/fs2/internal/Resources.scala
@@ -112,13 +112,13 @@ class Resources[T,R](tokens: Ref[(Status, LinkedMap[T, Option[R]])], val name: S
    * Associate `r` with the given `t`.
    */
   @annotation.tailrec
-  final def finishAcquire(t: T, r: R): Unit = tokens.access match {
+  final def finishAcquire(t: T, r: R): Boolean = tokens.access match {
     case ((open,m), update) =>
       m.get(t) match {
         case Some(None) =>
           val m2 = m.edit(t, _ => Some(Some(r)))
-          if (!update(open -> m2)) finishAcquire(t,r) // retry on contention
-        case r => sys.error("expected acquiring status, got: " + r)
+          update(open -> m2) || finishAcquire(t,r) // retry on contention
+        case r => false
       }
   }
 


### PR DESCRIPTION
Previously we were getting exceptions from this.

New behavior is to run the finalizer immediately if finishAcquire fails, under the assumption (which I'm not positive is valid) that if the key has been removed from the map, it's because the stream or scope is being closed.