### PR TITLE
Added test which demonstrates timing bug in interruption of stream that is evaluating a hung effect

### DIFF
--- a/core/src/test/scala/fs2/Fs2Spec.scala
+++ b/core/src/test/scala/fs2/Fs2Spec.scala
@@ -1,7 +1,7 @@
 package fs2
 
 import org.scalatest.{ Args, FreeSpec, Matchers, Status }
-import org.scalatest.concurrent.TimeLimitedTests
+import org.scalatest.concurrent.{ Eventually, TimeLimitedTests }
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.time.SpanSugar._
 
@@ -9,9 +9,12 @@ abstract class Fs2Spec extends FreeSpec
   with GeneratorDrivenPropertyChecks
   with Matchers
   with TimeLimitedTests
+  with Eventually
   with TestUtil {
 
   val timeLimit = 1.minute
+
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = 1.minute)
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     PropertyCheckConfiguration(minSuccessful = 25, workers = 1)

--- a/core/src/test/scala/fs2/ResourceSafetySpec.scala
+++ b/core/src/test/scala/fs2/ResourceSafetySpec.scala
@@ -1,11 +1,12 @@
 package fs2
 
+import scala.concurrent.duration._
 import fs2.util.Task
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicLong
 import org.scalacheck._
 
-class ResourceSafetySpec extends Fs2Spec {
+class ResourceSafetySpec extends Fs2Spec with org.scalatest.concurrent.Eventually {
 
   "Resource Safety" - {
 
@@ -130,6 +131,16 @@ class ResourceSafetySpec extends Fs2Spec {
       swallow { runLog { s2 through pipe.prefetch through pipe.prefetch }}
       swallow { runLog { s2 through pipe.prefetch through pipe.prefetch through pipe.prefetch }}
       c.get shouldBe 0L
+    }
+
+    "asynchronous resource allocation (5)" in forAll { (s: PureStream[PureStream[Int]]) =>
+      val signal = async.signalOf[Task,Boolean](false).unsafeRun
+      val c = new AtomicLong(0)
+      signal.set(true).schedule(20.millis).async.unsafeRun
+      runLog { s.get.evalMap { inner =>
+        Task.start(bracket(c)(inner.get).evalMap { _ => Task.async[Unit](_ => ()) }.interruptWhen(signal.continuous).run.run)
+      }}
+      eventually { c.get shouldBe 0L }
     }
 
     def swallow(a: => Any): Unit =

--- a/core/src/test/scala/fs2/TestUtil.scala
+++ b/core/src/test/scala/fs2/TestUtil.scala
@@ -7,11 +7,13 @@ import scala.concurrent.duration._
 
 object TestStrategy {
   implicit val S = Strategy.fromFixedDaemonPool(8)
+  implicit lazy val scheduler = java.util.concurrent.Executors.newScheduledThreadPool(2)
 }
 
 trait TestUtil {
 
   implicit val S = TestStrategy.S
+  implicit def scheduler = TestStrategy.scheduler
 
   def runLog[A](s: Stream[Task,A], timeout: FiniteDuration = 1.minute): Vector[A] = s.runLog.run.unsafeRunFor(timeout)
 

--- a/core/src/test/scala/fs2/time/TimeSpec.scala
+++ b/core/src/test/scala/fs2/time/TimeSpec.scala
@@ -8,9 +8,6 @@ import Stream._
 
 class TimeSpec extends Fs2Spec {
 
-  implicit val scheduler = java.util.concurrent.Executors.newScheduledThreadPool(2)
-  override implicit val S = Strategy.fromExecutor(scheduler)
-
   "time" - {
 
     "awakeEvery" in {


### PR DESCRIPTION
This is one of the causes of the `concurrent.join` failures.