### PR TITLE
fix for #597 test case, also added simplified test case which always …

### DIFF
--- a/core/src/main/scala/fs2/Async.scala
+++ b/core/src/main/scala/fs2/Async.scala
@@ -65,7 +65,7 @@ trait Async[F[_]] extends Catchable[F] { self =>
   def setFree[A](r: Ref[A])(a: Free[F,A]): F[Unit]
   def setPure[A](r: Ref[A])(a: A): F[Unit] = set(r)(pure(a))
   /** Actually run the effect of setting the ref. Has side effects. */
-  protected def runSet[A](q: Ref[A])(a: Either[Throwable,A]): Unit
+  private[fs2] def runSet[A](q: Ref[A])(a: Either[Throwable,A]): Unit
 
   /**
    * Like `get`, but returns an `F[Unit]` that can be used cancel the subscription.

--- a/core/src/main/scala/fs2/StreamCore.scala
+++ b/core/src/main/scala/fs2/StreamCore.scala
@@ -109,15 +109,23 @@ sealed trait StreamCore[F[_],O] { self =>
     val token = new Token()
     val resources = Resources.emptyNamed[Token,Free[F,Either[Throwable,Unit]]]("unconsAsync")
     val interrupt = new java.util.concurrent.atomic.AtomicBoolean(false)
-    val rootCleanup: Free[F,Either[Throwable,Unit]] = Free.suspend { resources.closeAll match {
-      case None =>
-        Free.eval(F.get(ref)) flatMap { _ =>
-          resources.closeAll match {
-            case None => Free.pure(Right(()))
-            case Some(resources) => StreamCore.runCleanup(resources.map(_._2))
+    val noopWaiters = scala.collection.immutable.Stream.continually(() => ())
+    lazy val rootCleanup: Free[F,Either[Throwable,Unit]] = Free.suspend { resources.closeAll(noopWaiters) match {
+      case Left(waiting) =>
+        Free.eval(F.traverse(Vector.fill(waiting)(F.ref[Unit]))(identity)) flatMap { gates =>
+          resources.closeAll(gates.toStream.map(gate => () => F.runSet(gate)(Right(())))) match {
+            case Left(_) => Free.eval(F.traverse(gates)(F.get)) flatMap { _ =>
+              resources.closeAll(noopWaiters) match {
+                case Left(_) => println("likely FS2 bug - resources still being acquired after Resources.closeAll call")
+                                rootCleanup
+                case Right(resources) => StreamCore.runCleanup(resources.map(_._2))
+              }
+            }
+            case Right(resources) =>
+              StreamCore.runCleanup(resources.map(_._2))
           }
         }
-        case Some(resources) =>
+        case Right(resources) =>
           StreamCore.runCleanup(resources.map(_._2))
     }}
     def tweakEnv: Scope[F,Unit] =
@@ -129,9 +137,9 @@ sealed trait StreamCore[F[_],O] { self =>
           // Important: copy any locally acquired resources to our parent and remove the placeholder
           // root token, which only needed if the parent terminated early, before the future was forced
           val removeRoot = Scope.release(List(token)) flatMap { _.fold(Scope.fail, Scope.pure) }
-          (resources.closeAll match {
-            case None => Scope.fail(new IllegalStateException("FS2 bug: resources still being acquired"))
-            case Some(rs) => removeRoot flatMap { _ => Scope.traverse(rs) {
+          (resources.closeAll(scala.collection.immutable.Stream()) match {
+            case Left(_) => Scope.fail(new IllegalStateException("FS2 bug: resources still being acquired"))
+            case Right(rs) => removeRoot flatMap { _ => Scope.traverse(rs) {
               case (token,r) => Scope.acquire(token,r)
             }}
           }) flatMap { (rs: List[Either[Throwable,Unit]]) =>
@@ -464,9 +472,9 @@ object StreamCore {
 
   private
   def runCleanup[F[_]](l: Resources[Token,Free[F,Either[Throwable,Unit]]]): Free[F,Either[Throwable,Unit]] =
-    l.closeAll match {
-      case Some(l) => runCleanup(l.map(_._2))
-      case None => sys.error("internal FS2 error: cannot run cleanup actions while resources are being acquired: "+l)
+    l.closeAll(scala.collection.immutable.Stream()) match {
+      case Right(l) => runCleanup(l.map(_._2))
+      case Left(_) => sys.error("internal FS2 error: cannot run cleanup actions while resources are being acquired: "+l)
     }
 
   private[fs2]

--- a/core/src/main/scala/fs2/internal/LinkedMap.scala
+++ b/core/src/main/scala/fs2/internal/LinkedMap.scala
@@ -60,7 +60,8 @@ private[fs2] class LinkedMap[K,+V](
 }
 
 private[fs2] object LinkedMap {
-  def empty[K,V] = new LinkedMap[K,V](Map.empty, LongMap.empty, 0)
+  def empty[K,V]: LinkedMap[K,V] = new LinkedMap[K,V](Map.empty, LongMap.empty, 0)
+  def apply[K,V](s: Iterable[(K,V)]): LinkedMap[K,V] = s.foldLeft(empty[K,V])((acc,kv) => acc.updated(kv._1, kv._2))
 }
 
 private[fs2] class LinkedSet[K](ks: LinkedMap[K,Unit]) {

--- a/core/src/main/scala/fs2/internal/Resources.scala
+++ b/core/src/main/scala/fs2/internal/Resources.scala
@@ -15,7 +15,7 @@ import Resources._
  * Once `Closed` or `Closing`, there is no way to reopen a `Resources`.
  */
 private[fs2]
-class Resources[T,R](tokens: Ref[(Status, LinkedMap[T, Option[R]])], val name: String = "Resources") {
+class Resources[T,R](tokens: Ref[(Status, LinkedMap[T, Either[List[() => Unit], R]])], val name: String = "Resources") {
 
   def isOpen: Boolean = tokens.get._1 == Open
   def isClosed: Boolean = tokens.get._1 == Closed
@@ -29,8 +29,8 @@ class Resources[T,R](tokens: Ref[(Status, LinkedMap[T, Option[R]])], val name: S
     tokens.get._2.keys.toList.filter(k => !snapshot(k))
   def release(ts: List[T]): Option[(List[R],List[T])] = tokens.access match {
     case ((open,m), update) =>
-      if (ts.forall(t => (m.get(t): Option[Option[R]]) != Some(None))) {
-        val rs = ts.flatMap(t => m.get(t).toList.flatten)
+      if (ts.forall(t => m.get(t).forall(_.fold(_ => false, _ => true)))) {
+        val rs = ts.flatMap(t => m.get(t).toList.collect { case Right(r) => r })
         val m2 = m.removeKeys(ts)
         if (!update(open -> m2)) release(ts) else Some(rs -> ts.filter(t => m.get(t).isEmpty))
       }
@@ -40,17 +40,23 @@ class Resources[T,R](tokens: Ref[(Status, LinkedMap[T, Option[R]])], val name: S
   /**
    * Close this `Resources` and return all acquired resources.
    * After finishing, no calls to `startAcquire` will succeed.
-   * Returns `None` if any resources are in process of being acquired.
+   * Returns `Left(n)` if there are n > 0 resources in the process of being
+   * acquired, and registers a thunk to be invoked when the resource
+   * is done being acquired.
    */
   @annotation.tailrec
-  final def closeAll: Option[List[(T,R)]] = tokens.access match {
+  final def closeAll(waiting: => Stream[() => Unit]): Either[Int, List[(T,R)]] = tokens.access match {
     case ((open,m),update) =>
-      val totallyDone = m.values.forall(_ != None)
-      def rs = m.orderedEntries.collect { case (t,Some(r)) => (t,r) }.toList
-      def m2 = if (!totallyDone) m else LinkedMap.empty[T,Option[R]]
-      if (!update((if (totallyDone) Closed else Closing, m2))) closeAll
-      else if (totallyDone) Some(rs)
-      else None
+      val totallyDone = m.values.forall(_.isRight)
+      def rs = m.orderedEntries.collect { case (t,Right(r)) => (t,r) }.toList
+      lazy val m2 =
+        if (!totallyDone) LinkedMap(m.orderedEntries.zip(waiting).collect { case ((t, Left(ws)), w) => (t, Left(w::ws)) })
+        else LinkedMap.empty[T,Either[List[() => Unit],R]]
+      if (update((if (totallyDone) Closed else Closing, m2))) {
+        if (totallyDone) Right(rs)
+        else Left(m2.size)
+      }
+      else closeAll(waiting)
   }
 
   /**
@@ -62,17 +68,17 @@ class Resources[T,R](tokens: Ref[(Status, LinkedMap[T, Option[R]])], val name: S
   final def startClose(t: T): Option[R] = tokens.access match {
     case ((Open,m),update) => m.get(t) match {
       case None => None // note: not flatMap so can be tailrec
-      case Some(Some(r)) => // close of an acquired resource
-        if (update((Open, m.updated(t, None)))) Some(r)
+      case Some(Right(r)) => // close of an acquired resource
+        if (update((Open, m.updated(t, Left(List()))))) Some(r)
         else startClose(t)
-      case Some(None) => None // close of any acquiring resource fails
+      case Some(Left(_)) => None // close of any acquiring resource fails
     }
     case _ => None // if already closed or closing
   }
 
   final def finishClose(t: T): Unit = tokens.modify {
     case (open,m) => m.get(t) match {
-      case Some(None) => (open, m-t)
+      case Some(Left(_)) => (open, m-t)
       case _ => sys.error("close of unknown resource: "+t)
     }
   }
@@ -86,7 +92,7 @@ class Resources[T,R](tokens: Ref[(Status, LinkedMap[T, Option[R]])], val name: S
       m.get(t) match {
         case Some(r) => sys.error("startAcquire on already used token: "+(t -> r))
         case None => open == Open && {
-          update(open -> m.edit(t, _ => Some(None))) || startAcquire(t)
+          update(open -> m.edit(t, _ => Some(Left(List())))) || startAcquire(t)
         }
       }
   }
@@ -98,13 +104,14 @@ class Resources[T,R](tokens: Ref[(Status, LinkedMap[T, Option[R]])], val name: S
   final def cancelAcquire(t: T): Unit = tokens.access match {
     case ((open,m), update) =>
       m.get(t) match {
-        case Some(Some(r)) => () // sys.error("token already acquired: "+ (t -> r))
+        case Some(Right(r)) => () // sys.error("token already acquired: "+ (t -> r))
         case None => ()
-        case Some(None) =>
+        case Some(Left(cbs)) =>
           val m2 = m - t
           val totallyDone = m2.values.forall(_ != None)
           val status = if (totallyDone && open == Closing) Closed else open
-          if (!update(status -> m2)) cancelAcquire(t)
+          if (update(status -> m2)) cbs.foreach(thunk => thunk())
+          else cancelAcquire(t)
       }
   }
 
@@ -115,9 +122,12 @@ class Resources[T,R](tokens: Ref[(Status, LinkedMap[T, Option[R]])], val name: S
   final def finishAcquire(t: T, r: R): Unit = tokens.access match {
     case ((open,m), update) =>
       m.get(t) match {
-        case Some(None) =>
-          val m2 = m.edit(t, _ => Some(Some(r)))
-          if (!update(open -> m2)) finishAcquire(t,r) // retry on contention
+        case Some(Left(waiting)) =>
+          val m2 = m.edit(t, _ => Some(Right(r)))
+          if (update(open -> m2))
+            waiting.foreach(thunk => thunk())
+          else
+            finishAcquire(t,r) // retry on contention
         case r => sys.error("expected acquiring status, got: " + r)
       }
   }


### PR DESCRIPTION
…reproduces the original bug

Bug is triggered when an async step allocates a resource, and is immediately followed by a step that never completes. If it is interrupted midway through acquiring the resource, it previously would wait until the step finished to complete finalization. If the step never completed, this would be forever, resulting in a hang. Fix is to wait only until any outstanding resource acquisitions complete. This was done by altering the Resources map slightly to allow 'callbacks' to be registered on invocation of `finishAcquire` calls.

@mpilquist you should try merging this into your join fix branch. I noticed that ResourceSafetySpec join(3) is failing