### PR TITLE
Fixed a bug where finalizers of acquired resources are skipped...

### DIFF
--- a/core/src/main/scala/fs2/StreamCore.scala
+++ b/core/src/main/scala/fs2/StreamCore.scala
@@ -108,7 +108,6 @@ sealed trait StreamCore[F[_],O] { self =>
   = Scope.eval(F.ref[(List[Token], Option[Either[Throwable, Step[Chunk[O],StreamCore[F,O]]]])]).flatMap { ref =>
     val token = new Token()
     val resources = Resources.emptyNamed[Token,Free[F,Either[Throwable,Unit]]]("unconsAsync")
-    val interrupt = new java.util.concurrent.atomic.AtomicBoolean(false)
     val noopWaiters = scala.collection.immutable.Stream.continually(() => ())
     lazy val rootCleanup: Free[F,Either[Throwable,Unit]] = Free.suspend { resources.closeAll(noopWaiters) match {
       case Left(waiting) =>


### PR DESCRIPTION
 when an unconsAsync Resources object is closed via closeAll with at least one resource with an unfinished acquisition.

This is the cause of bugfix/591 failures in resource acquisition (3).

@pchiusano 