### PR TITLE
Reimplemented join.

### DIFF
--- a/core/src/main/scala/fs2/concurrent.scala
+++ b/core/src/main/scala/fs2/concurrent.scala
@@ -27,42 +27,48 @@ object concurrent {
   // todo: document when the finalizers are calle in which situation
   def join[F[_],O](maxOpen: Int)(outer: Stream[F,Stream[F,O]])(implicit F: Async[F]): Stream[F,O] = {
     assert(maxOpen > 0,"maxOpen must be > 0, was: " + maxOpen)
+
+    def throttle[A](checkIfKilled: F[Boolean]): Pipe[F,Stream[F,A],Unit] = {
+
+      def runInnerStream(inner: Stream[F,A], onInnerStreamDone: F[Unit]): Pull[F,Nothing,Unit] = {
+        val startInnerStream: F[F.Ref[Unit]] = {
+          F.bind(F.ref[Unit]) { gate =>
+          F.map(F.start(
+            Stream.eval(checkIfKilled).
+                   flatMap { killed => if (killed) Stream.empty else inner }.
+                   onFinalize { F.bind(F.setPure(gate)(())) { _ => onInnerStreamDone } }.
+                   run.run
+          )) { _ => gate }}
+        }
+        Pull.acquire(startInnerStream) { gate => F.get(gate) }.map { _ => () }
+      }
+
+      def go(doneQueue: async.mutable.Queue[F,Unit])(open: Int): (Stream.Handle[F,Stream[F,A]], Stream.Handle[F,Unit]) => Pull[F,Nothing,Unit] = (h, d) => {
+        if (open < maxOpen)
+          Pull.receive1Option[F,Stream[F,A],Nothing,Unit] {
+            case Some(inner #: h) => runInnerStream(inner, F.map(F.start(doneQueue.enqueue1(())))(_ => ())).flatMap { gate => go(doneQueue)(open + 1)(h, d) }
+            case None => Pull.done
+          }(h)
+        else
+          d.receive1 { case _ #: d => go(doneQueue)(open - 1)(h, d) }
+      }
+
+      in => Stream.eval(async.unboundedQueue[F,Unit]).flatMap { doneQueue => in.pull2(doneQueue.dequeue)(go(doneQueue)(0)) }
+    }
+
     for {
       killSignal <- Stream.eval(async.signalOf(false))
-      openLeases <- Stream.eval(async.mutable.Semaphore(maxOpen))
-      outerDone <- Stream.eval(F.refOf[Boolean](false))
       outputQueue <- Stream.eval(async.mutable.Queue.synchronousNoneTerminated[F,Either[Throwable,Chunk[O]]])
-      o <- outer.evalMap { (inner: Stream[F,O]) =>
-        F.bind(openLeases.decrement) { _ =>
-        F.start {
-          val done =
-            F.bind(openLeases.increment) { _ =>
-            F.bind(F.get(outerDone)) { outerDone =>
-            F.bind(openLeases.count) { n =>
-              if (n == maxOpen && outerDone) {
-                outputQueue.enqueue1(None)
-              }
-              else F.pure(())
-            }}}
-          inner.chunks.attempt.evalMap { o => outputQueue.enqueue1(Some(o)) }
-          .interruptWhen(killSignal)
-          .onFinalize(done)
-          .run.run
-        }}
-      }.onFinalize(F.bind(openLeases.count) { n =>
-          F.bind(if (n == maxOpen) outputQueue.offer1(None) else F.pure(true)) { _ =>
-            F.setPure(outerDone)(true)
-          }
-      }) mergeDrainL {
+      o <- outer.map { inner =>
+        inner.chunks.attempt.evalMap { o => outputQueue.enqueue1(Some(o)) }.interruptWhen(killSignal)
+      }.through(throttle(killSignal.get)).onFinalize {
+        outputQueue.enqueue1(None)
+      }.mergeDrainL {
         outputQueue.dequeue.through(pipe.unNoneTerminate).flatMap {
           case Left(e) => Stream.eval(killSignal.set(true)).flatMap { _ => Stream.fail(e) }
           case Right(c) => Stream.chunk(c)
         }
-      } onFinalize {
-        // set kill signal, then wait for any outstanding inner streams to complete
-        F.bind(killSignal.set(true)) { _ =>
-        F.bind(openLeases.clear) { m => openLeases.decrementBy(maxOpen - m) }}
-      }
+      }.onFinalize { killSignal.set(true) }
     } yield o
   }
 }

--- a/core/src/test/scala/fs2/Fs2Spec.scala
+++ b/core/src/test/scala/fs2/Fs2Spec.scala
@@ -12,12 +12,12 @@ abstract class Fs2Spec extends FreeSpec
   with Eventually
   with TestUtil {
 
-  val timeLimit = 1.minute
+  val timeLimit = 10.minutes
 
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = 1.minute)
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
-    PropertyCheckConfiguration(minSuccessful = 25, workers = 1)
+    PropertyCheckConfiguration(minSuccessful = 1000, workers = 1)
 
   override def runTest(testName: String, args: Args): Status = {
     println("Starting " + testName)

--- a/core/src/test/scala/fs2/Fs2Spec.scala
+++ b/core/src/test/scala/fs2/Fs2Spec.scala
@@ -12,12 +12,12 @@ abstract class Fs2Spec extends FreeSpec
   with Eventually
   with TestUtil {
 
-  val timeLimit = 10.minutes
+  val timeLimit = 1.minute
 
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = 1.minute)
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
-    PropertyCheckConfiguration(minSuccessful = 1000, workers = 1)
+    PropertyCheckConfiguration(minSuccessful = 25, workers = 1)
 
   override def runTest(testName: String, args: Args): Status = {
     println("Starting " + testName)


### PR DESCRIPTION
- New join implementation is fairer than semaphore based implementation.
  This implementation ensures inner streams are started in the order
  they appear in the outer stream. The semaphore implementation raced the
  inner streams against the semaphore decrement.
- Changed the synchronous none terminated queue such that enqueuing a
  `Some` does not block after a `None` has been enqueued.
- Fixed a bug in `Task.get` and similar methods in which message ids
  were reused across multiple executions of the task. This resulted in
  hung tasks under contention. For example, calling `signal.get` and then running that task multiple times in parallel could lead to some of the tasks never completing.

Review by @pchiusano. 