### PR TITLE
Ported the start here example from 0.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -105,6 +105,13 @@ lazy val publishingSettings = Seq(
   }
 )
 
+lazy val noPublish = Seq(
+  publish := (),
+  publishLocal := (),
+  publishSigned := (),
+  publishArtifact := false
+)
+
 lazy val releaseSettings = Seq(
   releaseCrossBuild := true,
   releasePublishArtifactsAction := PgpKeys.publishSigned.value
@@ -112,12 +119,7 @@ lazy val releaseSettings = Seq(
 
 lazy val root = project.in(file(".")).
   settings(commonSettings).
-  settings(
-    publish := (),
-    publishLocal := (),
-    publishSigned := (),
-    publishArtifact := false
-  ).
+  settings(noPublish).
   aggregate(core, io, benchmark)
 
 lazy val core = project.in(file("core")).
@@ -134,11 +136,9 @@ lazy val io = project.in(file("io")).
 
 lazy val benchmark = project.in(file("benchmark")).
   settings(commonSettings).
+  settings(noPublish).
   settings(
-    name := "fs2-benchmark",
-    publish := (),
-    publishLocal := (),
-    publishArtifact := false
+    name := "fs2-benchmark"
   ).dependsOn(io)
 
 lazy val docs = project.in(file("docs")).

--- a/docs/CreatingStreams.md
+++ b/docs/CreatingStreams.md
@@ -9,18 +9,18 @@ import fs2.util.Task
 // import fs2.util.Task
 
 val ones = Stream.iterate(1)(identity)
-// ones: fs2.Stream[Nothing,Int] = fs2.Stream$$anon$1@7a802fd
+// ones: fs2.Stream[Nothing,Int] = fs2.Stream$$anon$1@2c9a2dbb
 ```
 This creates a `Stream[Nothing,Int]`, which is a _pure_ stream, meaning its sole purpose is to provide an infinite stream of *1*s. However, this definition using `iterate` and `identity` obscures the intent of this code, but thankfully there's the helper function `constant` which produces the identical result.
 ```scala
 val ones = Stream.constant(1)
-// ones: fs2.Stream[Nothing,Int] = fs2.Stream$$anon$1@8f3b57e
+// ones: fs2.Stream[Nothing,Int] = fs2.Stream$$anon$1@788beb08
 ```
 
 What about producing all ints between 0 and 100? We could use the same `iterate` approach with an increment function like this:
 ```scala
 val zeroTo100 = Stream.iterate(0)(_ + 1).take(101)
-// zeroTo100: fs2.Stream[Nothing,Int] = fs2.Stream$$anon$1@4fc87c18
+// zeroTo100: fs2.Stream[Nothing,Int] = fs2.Stream$$anon$1@21417822
 ```
 That's reasonably straightforward, our Stream begins at *0* and adds one to the previous value at each step. We then take 101 elements from this stream (because we included 0), which means `zeroTo100` is no longer an infinite stream. What happens if we try to take more than 101 elements from `zeroTo100`?
 ```scala
@@ -30,17 +30,17 @@ val hmmm = zeroTo100.take(1000).toList.length
 As you'd expect, `hmm` is 101 elements long. But the initial creation of `zeroTo100` is pretty ugly and ranging over the integers is fairly common, so there is the `range` function, which allows you to generate finite ranges with an optional step-size, but only incrementing.
 ```scala
 val zeroTo100 = Stream.range(0,101)
-// zeroTo100: fs2.Stream[Nothing,Int] = fs2.Stream$$anon$1@1a146eb1
+// zeroTo100: fs2.Stream[Nothing,Int] = fs2.Stream$$anon$1@64655876
 
 val evensTo100 = Stream.range(1,101,2)
-// evensTo100: fs2.Stream[Nothing,Int] = fs2.Stream$$anon$1@14a5d5da
+// evensTo100: fs2.Stream[Nothing,Int] = fs2.Stream$$anon$1@4f65b1f6
 ```
 
 ## Evaluating Tasks
 In addition to creating pure streams using some generative function, we can also create streams by evaluating an effect, `F[A]`. The resulting stream will emit the `A` or fail attempting to do so.
 ```scala
 val greeting = Stream.eval(Task.now("Hi there!"))
-// greeting: fs2.Stream[fs2.util.Task,String] = fs2.Stream$$anon$1@7b19e2fd
+// greeting: fs2.Stream[fs2.util.Task,String] = fs2.Stream$$anon$1@c4d9329
 
 val hi = greeting.runLog.run.unsafeRun
 // hi: Vector[String] = Vector(Hi there!)
@@ -50,13 +50,13 @@ This producees a `Stream[Task, String]`, which we can then force evaluation of u
 Because `greeting` is a `Stream`, we can use all sorts of great stream operators on it
 ```scala
 greeting.repeat //analogous to constant above
-// res0: fs2.Stream[fs2.util.Task,String] = fs2.Stream$$anon$1@657df141
+// res0: fs2.Stream[fs2.util.Task,String] = fs2.Stream$$anon$1@446c20fd
 
 val goodbye = Stream.eval(Task.now("Goodbye..."))
-// goodbye: fs2.Stream[fs2.util.Task,String] = fs2.Stream$$anon$1@424b10a
+// goodbye: fs2.Stream[fs2.util.Task,String] = fs2.Stream$$anon$1@4559f615
 
 val hiBye = (greeting ++ goodbye) // concatenates the two streams
-// hiBye: fs2.Stream[fs2.util.Task,String] = fs2.Stream$$anon$1@7ee377
+// hiBye: fs2.Stream[fs2.util.Task,String] = fs2.Stream$$anon$1@32aa8559
 
 hiBye.runLog.run.unsafeRun
 // res1: Vector[String] = Vector(Hi there!, Goodbye...)
@@ -65,7 +65,7 @@ hiBye.runLog.run.unsafeRun
 The `repeat` operator repeats the current stream once the end has been reached. Repeat is effectively a no-op for infinite streams
 ```scala
 val N = Stream.iterate(0)(_ + 1)
-// N: fs2.Stream[Nothing,Int] = fs2.Stream$$anon$1@60a2848a
+// N: fs2.Stream[Nothing,Int] = fs2.Stream$$anon$1@2d8a7931
 
 N.take(10).toList
 // res2: List[Int] = List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)

--- a/docs/StartHere.md
+++ b/docs/StartHere.md
@@ -1,0 +1,106 @@
+# Start Here
+
+Let's start by looking at a reasonably complete example. This program opens a file, `fahrenheit.txt`, containing temperatures in degrees fahrenheit, one per line, and converts each temperature to celsius, incrementally writing to the file `celsius.txt`. Both files will be closed, regardless of whether any errors occur.
+
+```scala
+scala> import fs2._
+import fs2._
+
+scala> import fs2.util.Task
+import fs2.util.Task
+
+scala> import java.nio.file.Paths
+import java.nio.file.Paths
+
+scala> def fahrenheitToCelsius(f: Double): Double =
+     |   (f - 32.0) * (5.0/9.0)
+fahrenheitToCelsius: (f: Double)Double
+
+scala> val converter: Task[Unit] =
+     |   io.file.readAll[Task](Paths.get("testdata/fahrenheit.txt"), 4096).
+     |     through(text.utf8Decode).
+     |     through(text.lines).
+     |     filter(s => !s.trim.isEmpty && !s.startsWith("//")).
+     |     map(line => fahrenheitToCelsius(line.toDouble).toString).
+     |     intersperse("\n").
+     |     through(text.utf8Encode).
+     |     through(io.file.writeAll(Paths.get("testdata/celsius.txt"))).
+     |     run.run
+converter: fs2.util.Task[Unit] = fs2.util.Task@1f3ac5fe
+
+scala> converter.unsafeRun
+```
+
+Let's dissect this line by line.
+
+`Stream[Task, Byte]` is a stream of `Byte` values which may periodically evaluate an `fs2.util.Task` in order to produce additional values. `Stream` is the core data type of FS2. It is parameterized on a type constructor (here, `Task`) which defines what sort of external requests it can make, and an output type (here, `Byte`), which defines what type of values it _emits_.
+
+Operations on `Stream` are defined for any choice of type constructor, not just `Task`.
+
+`fs2.io` has a number of helper functions for constructing or working with streams that talk to the outside world. `readAll` creates a stream of bytes from a file name (specified via a `java.nio.file.Path`). It encapsulates the logic for opening and closing the file, so that users of this stream do not need to remember to close the file when they are done or in the event of exceptions during processing of the stream.
+
+```scala
+scala> val src: Stream[Task, Byte] =
+     |   io.file.readAll[Task](Paths.get("testdata/fahrenheit.txt"), 4096)
+src: fs2.Stream[fs2.util.Task,Byte] = fs2.Stream$$anon$1@1261be14
+```
+
+A stream can be attached to a pipe, allowing for stateful transformations of the input values. Here, we attach the source stream to the `text.utf8Decode` pipe, which converts the stream of bytes to a stream of strings. We then attach the result to the `text.lines` pipe, which buffers strings and emits full lines. Pipes are expressed using the type `Pipe[F,I,O]`, which describes a pipe that can accept input values of type `I` and can output values of type `O`, potentially evaluating an effect periodically.
+
+```scala
+scala> val decoded: Stream[Task, String] = src.through(text.utf8Decode)
+decoded: fs2.Stream[fs2.util.Task,String] = fs2.Stream$$anon$1@3ee9d751
+
+scala> val lines: Stream[Task, String] = decoded.through(text.lines)
+lines: fs2.Stream[fs2.util.Task,String] = fs2.Stream$$anon$1@16d10341
+```
+
+Many of the functions defined for `List` are defined for `Stream` as well, for instance `filter` and `map`. Note that no side effects occur when we call `filter` or `map`. `Stream` is a purely functional value which can _describe_ a streaming computation that interacts with the outside world. Nothing will occur until we interpret this description, and `Stream` values are thread-safe and can be shared freely.
+
+```scala
+scala> val filtered: Stream[Task, String] =
+     |   lines.filter(s => !s.trim.isEmpty && !s.startsWith("//"))
+filtered: fs2.Stream[fs2.util.Task,String] = fs2.Stream$$anon$1@241713c8
+
+scala> val mapped: Stream[Task, String] =
+     |   filtered.map(line => fahrenheitToCelsius(line.toDouble).toString)
+mapped: fs2.Stream[fs2.util.Task,String] = fs2.Stream$$anon$1@780eea47
+```
+
+Adds a newline between emitted strings of `mapped`.
+
+```scala
+scala> val withNewlines: Stream[Task, String] = mapped.intersperse("\n")
+withNewlines: fs2.Stream[fs2.util.Task,String] = fs2.Stream$$anon$1@52aca2df
+```
+
+We use another pipe, `text.utf8Encode`, to convert the stream of strings back to a stream of bytes.
+
+```scala
+scala> val encodedBytes: Stream[Task, Byte] = withNewlines.through(text.utf8Encode)
+encodedBytes: fs2.Stream[fs2.util.Task,Byte] = fs2.Stream$$anon$1@3d2deabf
+```
+
+We then write the encoded bytes to a file. Note that nothing has happened at this point -- we are just constructing a description of a computation that, when interpreted, will incrementally consume the stream, sending converted values to the specified file.
+
+```scala
+scala> val written: Stream[Task, Unit] = encodedBytes.through(io.file.writeAll(Paths.get("testdata/celsius.txt")))
+written: fs2.Stream[fs2.util.Task,Unit] = fs2.Stream$$anon$1@7563efe9
+```
+
+Interpreting the stream is done by calling `run`, which returns a description of the program in the `Free` monad. That description can then interpreted in to a value of the effect type.
+
+```scala
+scala> val freeInterpretation: fs2.util.Free[Task, Unit] = written.run
+freeInterpretation: fs2.util.Free[fs2.util.Task,Unit] = Bind(Bind(Pure(()),<function1>),<function1>)
+
+scala> val task: Task[Unit] = freeInterpretation.run
+task: fs2.util.Task[Unit] = fs2.util.Task@7c66bb9c
+```
+
+We still haven't *done* anything yet. Effects only occur when we run the resulting task. We can run a `Task` by calling `unsafeRun` -- the name is telling us that calling it performs effects and hence, it is not referentially transparent.
+
+```scala
+scala> val result: Unit = task.unsafeRun
+result: Unit = ()
+```

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -44,7 +44,7 @@ def run[A](s: Stream[Task,A]): Vector[A] =
 // run: [A](s: fs2.Stream[fs2.util.Task,A])Vector[A]
 
 val s: Stream[Nothing,Int] = Stream((0 until 100): _*)
-// s: fs2.Stream[Nothing,Int] = fs2.Stream$$anon$1@31ae9d36
+// s: fs2.Stream[Nothing,Int] = fs2.Stream$$anon$1@447a43b3
 
 run(s) == Vector.range(0, 100)
 // res0: Boolean = true
@@ -191,7 +191,7 @@ scala> import fs2.util._
 import fs2.util._
 
 scala> Stream.emit(1).++(Stream("hi"))(RealSupertype.allow[Int,Any], Sub1.sub1[Task])
-res4: fs2.Stream[fs2.util.Task,Any] = fs2.Stream$$anon$1@7ffe8ae6
+res4: fs2.Stream[fs2.util.Task,Any] = fs2.Stream$$anon$1@1f0c2b15
 ```
 
 Ugly, as it should be.


### PR DESCRIPTION
- I created a tut doc for the example, though I didn't know where to include that in the guide, so it is standalone for now.

- I changed the signature of `utf8Encode` and `utf8Decode` -- both were working with `Chunk[Byte]` instead of `Byte` which made using them with the io package annoying. The original signatures are available under a `C` suffix -- `utf8EncodeC` and `utf8DecodeC`.  The implementations did not exploit the chunky nature in any way, except for the handling of encoding/decoding empty strings -- `utf8EncodeC andThen utf8DecodeC == id` for all strings, whereas `utf8Encode andThen utf8Decode == id` for all non-empty strings. I believe this is due to the fact that we don't emit empty chunks in the interpreter.

- Added a new text.lines pipe, which buffers a stream of strings and emits individual lines.