### PR TITLE
Introduced `Async.Run`

### DIFF
--- a/core/src/main/scala/fs2/Async.scala
+++ b/core/src/main/scala/fs2/Async.scala
@@ -188,4 +188,35 @@ object Async {
    * is the new value computed by `f`.
    */
   case class Change[+A](previous: A, now: A)
+
+
+  /**
+    * Used to strictly evaluate `F`.
+    */
+  trait Run[F[_]]  {
+
+    /**
+      * Run this `F` and block until it completes. Performs Side effects.
+      * If the evaluation of the `F` terminates with an exception,
+      * then this will return that exception as Optional value.
+      * Otherwise this terminates with None.
+      *
+      * Note that hence this blocks, special care must be taken on thread usage.
+      * Typically, this has to be run off the thread that allows blocking and
+      * is outside the main Executor Service or Scheduler.
+      *
+      * If you run it inside the scheduler or `Strategy` that is used to run
+      * rest of your program you may encounter deadlocks due to thread resources
+      * being used.
+      *
+      * It is not recommended to use this inside user code.
+      *
+      * Purpose of this combinator is to allow libraries that perform multiple callback
+      * (like enqueueing the messages, setting signals) to be written abstract over `F`.
+      *
+      */
+    def runEffects(f:F[Unit]): Option[Throwable]
+
+  }
+
 }


### PR DESCRIPTION
@pchiusano @mpilquist. This is to allow to write libraries using fs2 that do multiple callbacks from outside the fs2 domain. For example you need to enqueue messages from the `Polling` thread to our queue, and still you don't want to specialize to `Task`. 

I didn't find any better alternative than this, not sure if Option[Throwable] is right idea, perhaps we shall just exception to be thrown. Any thoughts on that?
