### PR TITLE
Parametric time

### DIFF
--- a/core/src/main/scala/fs2/Async.scala
+++ b/core/src/main/scala/fs2/Async.scala
@@ -188,4 +188,35 @@ object Async {
    * is the new value computed by `f`.
    */
   case class Change[+A](previous: A, now: A)
+
+
+  /**
+    * Used to strictly evaluate `F`.
+    */
+  trait Run[F[_]]  {
+
+    /**
+      * Run this `F` and block until it completes. Performs Side effects.
+      * If the evaluation of the `F` terminates with an exception,
+      * then this will return that exception as Optional value.
+      * Otherwise this terminates with None.
+      *
+      * Note that hence this blocks, special care must be taken on thread usage.
+      * Typically, this has to be run off the thread that allows blocking and
+      * is outside the main Executor Service or Scheduler.
+      *
+      * If you run it inside the scheduler or `Strategy` that is used to run
+      * rest of your program you may encounter deadlocks due to thread resources
+      * being used.
+      *
+      * It is not recommended to use this inside user code.
+      *
+      * Purpose of this combinator is to allow libraries that perform multiple callback
+      * (like enqueueing the messages, setting signals) to be written abstract over `F`.
+      *
+      */
+    def runEffects(f:F[Unit]): Option[Throwable]
+
+  }
+
 }

--- a/core/src/test/scala/fs2/time/TimeSpec.scala
+++ b/core/src/test/scala/fs2/time/TimeSpec.scala
@@ -5,17 +5,18 @@ import org.scalacheck.Gen
 import scala.concurrent.duration._
 
 import Stream._
+import fs2.util.Task
 
 class TimeSpec extends Fs2Spec {
 
   "time" - {
 
     "awakeEvery" in {
-      time.awakeEvery(100.millis).map(_.toMillis/100).take(5).runLog.run.unsafeRun shouldBe Vector(1,2,3,4,5)
+      time.awakeEvery[Task](100.millis).map(_.toMillis/100).take(5).runLog.run.unsafeRun shouldBe Vector(1,2,3,4,5)
     }
 
     "duration" in {
-      val firstValueDiscrepancy = time.duration.take(1).runLog.run.unsafeRun.last
+      val firstValueDiscrepancy = time.duration[Task].take(1).runLog.run.unsafeRun.last
       val reasonableErrorInMillis = 200
       val reasonableErrorInNanos = reasonableErrorInMillis * 1000000
       def p = firstValueDiscrepancy.toNanos < reasonableErrorInNanos
@@ -44,8 +45,8 @@ class TimeSpec extends Fs2Spec {
 
         val draws = (600.millis / delay) min 10 // don't take forever
 
-        val durationsSinceSpike = time.every(delay).
-          zip(time.duration).
+        val durationsSinceSpike = time.every[Task](delay).
+          zip(time.duration[Task]).
           take(draws.toInt).
           through(durationSinceLastTrue)
 


### PR DESCRIPTION
If we merge #610, then we can use the new `Async.Run` type class to implement the `time` package for arbitrary effect types.