### PR TITLE
Miscellaneous cleanup related to time

### DIFF
--- a/core/src/main/scala/fs2/Async.scala
+++ b/core/src/main/scala/fs2/Async.scala
@@ -188,4 +188,35 @@ object Async {
    * is the new value computed by `f`.
    */
   case class Change[+A](previous: A, now: A)
+
+
+  /**
+    * Used to strictly evaluate `F`.
+    */
+  trait Run[F[_]]  {
+
+    /**
+      * Run this `F` and block until it completes. Performs Side effects.
+      * If the evaluation of the `F` terminates with an exception,
+      * then this will return that exception as Optional value.
+      * Otherwise this terminates with None.
+      *
+      * Note that hence this blocks, special care must be taken on thread usage.
+      * Typically, this has to be run off the thread that allows blocking and
+      * is outside the main Executor Service or Scheduler.
+      *
+      * If you run it inside the scheduler or `Strategy` that is used to run
+      * rest of your program you may encounter deadlocks due to thread resources
+      * being used.
+      *
+      * It is not recommended to use this inside user code.
+      *
+      * Purpose of this combinator is to allow libraries that perform multiple callback
+      * (like enqueueing the messages, setting signals) to be written abstract over `F`.
+      *
+      */
+    def runEffects(f:F[Unit]): Option[Throwable]
+
+  }
+
 }

--- a/core/src/main/scala/fs2/Scheduler.scala
+++ b/core/src/main/scala/fs2/Scheduler.scala
@@ -7,21 +7,21 @@ import java.util.concurrent.{ Executors, ScheduledExecutorService, TimeUnit }
 trait Scheduler {
 
   /**
-   * Evaluates the specified thunk after the specified delay.
+   * Evaluates the thunk using the strategy after the delay.
    * Returns a thunk that when evaluated, cancels the execution.
    */
-  def scheduleOnce(delay: FiniteDuration)(thunk: => Unit): () => Unit
+  def scheduleOnce(delay: FiniteDuration)(thunk: => Unit)(implicit S: Strategy): () => Unit
 
   /**
-   * Evaluates the specified thunk after the specified initial delay and then every specified period.
-   * Returns a thunk that cwen evaluated, cancels the execution.
+   * Evaluates the thunk after the initial delay and then every period, using the strategy.
+   * Returns a thunk that when evaluated, cancels the execution.
    */
-  def scheduleAtFixedRate(initialDelay: FiniteDuration, period: FiniteDuration)(thunk: => Unit): () => Unit
+  def scheduleAtFixedRate(initialDelay: FiniteDuration, period: FiniteDuration)(thunk: => Unit)(implicit S: Strategy): () => Unit
 
   /**
    * Returns a strategy that executes all tasks after a specified delay.
    */
-  def delayedStrategy(delay: FiniteDuration): Strategy = new Strategy {
+  def delayedStrategy(delay: FiniteDuration)(implicit S: Strategy): Strategy = new Strategy {
     def apply(thunk: => Unit) = { scheduleOnce(delay)(thunk); () }
     override def toString = s"DelayedStrategy($delay)"
   }
@@ -33,12 +33,12 @@ object Scheduler {
     fromScheduledExecutorService(Executors.newScheduledThreadPool(corePoolSize, Strategy.daemonThreadFactory(threadName)))
 
   def fromScheduledExecutorService(service: ScheduledExecutorService): Scheduler = new Scheduler {
-    override def scheduleOnce(delay: FiniteDuration)(thunk: => Unit): () => Unit = {
-      val f = service.schedule(new Runnable { def run = thunk }, delay.toNanos, TimeUnit.NANOSECONDS)
+    override def scheduleOnce(delay: FiniteDuration)(thunk: => Unit)(implicit S: Strategy): () => Unit = {
+      val f = service.schedule(new Runnable { def run = S(thunk) }, delay.toNanos, TimeUnit.NANOSECONDS)
       () => { f.cancel(false); () }
     }
-    override def scheduleAtFixedRate(initialDelay: FiniteDuration, period: FiniteDuration)(thunk: => Unit): () => Unit = {
-      val f = service.scheduleAtFixedRate(new Runnable { def run = thunk }, initialDelay.toNanos, period.toNanos, TimeUnit.NANOSECONDS)
+    override def scheduleAtFixedRate(initialDelay: FiniteDuration, period: FiniteDuration)(thunk: => Unit)(implicit S: Strategy): () => Unit = {
+      val f = service.scheduleAtFixedRate(new Runnable { def run = S(thunk) }, initialDelay.toNanos, period.toNanos, TimeUnit.NANOSECONDS)
       () => { f.cancel(false); () }
     }
     override def toString = s"Scheduler($service)"

--- a/core/src/main/scala/fs2/Scheduler.scala
+++ b/core/src/main/scala/fs2/Scheduler.scala
@@ -1,0 +1,47 @@
+package fs2
+
+import scala.concurrent.duration.FiniteDuration
+import java.util.concurrent.{ Executors, ScheduledExecutorService, TimeUnit }
+
+/** Provides the ability to schedule evaluation of thunks in the future. */
+trait Scheduler {
+
+  /**
+   * Evaluates the specified thunk after the specified delay.
+   * Returns a thunk that when evaluated, cancels the execution.
+   */
+  def scheduleOnce(delay: FiniteDuration)(thunk: => Unit): () => Unit
+
+  /**
+   * Evaluates the specified thunk after the specified initial delay and then every specified period.
+   * Returns a thunk that cwen evaluated, cancels the execution.
+   */
+  def scheduleAtFixedRate(initialDelay: FiniteDuration, period: FiniteDuration)(thunk: => Unit): () => Unit
+
+  /**
+   * Returns a strategy that executes all tasks after a specified delay.
+   */
+  def delayedStrategy(delay: FiniteDuration): Strategy = new Strategy {
+    def apply(thunk: => Unit) = { scheduleOnce(delay)(thunk); () }
+    override def toString = s"DelayedStrategy($delay)"
+  }
+}
+
+object Scheduler {
+
+  def fromFixedDaemonPool(corePoolSize: Int, threadName: String = "Scheduler.fromFixedDaemonPool"): Scheduler =
+    fromScheduledExecutorService(Executors.newScheduledThreadPool(corePoolSize, Strategy.daemonThreadFactory(threadName)))
+
+  def fromScheduledExecutorService(service: ScheduledExecutorService): Scheduler = new Scheduler {
+    override def scheduleOnce(delay: FiniteDuration)(thunk: => Unit): () => Unit = {
+      val f = service.schedule(new Runnable { def run = thunk }, delay.toNanos, TimeUnit.NANOSECONDS)
+      () => { f.cancel(false); () }
+    }
+    override def scheduleAtFixedRate(initialDelay: FiniteDuration, period: FiniteDuration)(thunk: => Unit): () => Unit = {
+      val f = service.scheduleAtFixedRate(new Runnable { def run = thunk }, initialDelay.toNanos, period.toNanos, TimeUnit.NANOSECONDS)
+      () => { f.cancel(false); () }
+    }
+    override def toString = s"Scheduler($service)"
+  }
+
+}

--- a/core/src/test/scala/fs2/TestUtil.scala
+++ b/core/src/test/scala/fs2/TestUtil.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration._
 
 object TestStrategy {
   implicit val S = Strategy.fromFixedDaemonPool(8)
-  implicit lazy val scheduler = java.util.concurrent.Executors.newScheduledThreadPool(2)
+  implicit lazy val scheduler = Scheduler.fromFixedDaemonPool(2)
 }
 
 trait TestUtil {

--- a/core/src/test/scala/fs2/time/TimeSpec.scala
+++ b/core/src/test/scala/fs2/time/TimeSpec.scala
@@ -5,17 +5,18 @@ import org.scalacheck.Gen
 import scala.concurrent.duration._
 
 import Stream._
+import fs2.util.Task
 
 class TimeSpec extends Fs2Spec {
 
   "time" - {
 
     "awakeEvery" in {
-      time.awakeEvery(100.millis).map(_.toMillis/100).take(5).runLog.run.unsafeRun shouldBe Vector(1,2,3,4,5)
+      time.awakeEvery[Task](100.millis).map(_.toMillis/100).take(5).runLog.run.unsafeRun shouldBe Vector(1,2,3,4,5)
     }
 
     "duration" in {
-      val firstValueDiscrepancy = time.duration.take(1).runLog.run.unsafeRun.last
+      val firstValueDiscrepancy = time.duration[Task].take(1).runLog.run.unsafeRun.last
       val reasonableErrorInMillis = 200
       val reasonableErrorInNanos = reasonableErrorInMillis * 1000000
       def p = firstValueDiscrepancy.toNanos < reasonableErrorInNanos
@@ -44,8 +45,8 @@ class TimeSpec extends Fs2Spec {
 
         val draws = (600.millis / delay) min 10 // don't take forever
 
-        val durationsSinceSpike = time.every(delay).
-          zip(time.duration).
+        val durationsSinceSpike = time.every[Task](delay).
+          zip(time.duration[Task]).
           take(draws.toInt).
           through(durationSinceLastTrue)
 

--- a/core/src/test/scala/fs2/time/TimeSpec.scala
+++ b/core/src/test/scala/fs2/time/TimeSpec.scala
@@ -28,10 +28,10 @@ class TimeSpec extends Fs2Spec {
 
     "every" in {
       val smallDelay = Gen.choose(10, 300) map {_.millis}
-      forAll(smallDelay) { delay: Duration =>
-        type BD = (Boolean, Duration)
+      forAll(smallDelay) { delay: FiniteDuration =>
+        type BD = (Boolean, FiniteDuration)
         val durationSinceLastTrue: Pipe[Pure,BD,BD] = {
-          def go(lastTrue: Duration): Handle[Pure,BD] => Pull[Pure,BD,Handle[Pure,BD]] = h => {
+          def go(lastTrue: FiniteDuration): Handle[Pure,BD] => Pull[Pure,BD,Handle[Pure,BD]] = h => {
             h.receive1 {
               case pair #: tl =>
                 pair match {


### PR DESCRIPTION
 - Introduced `Scheduler` trait as wrapper for `ScheduledExecutorService`
 - Replaced usage of `Duration` with `FiniteDuration`
 - Removed old methods implemented in terms of millisecond timeouts

I based this off of #611 but if we decide not to merge that, I can fix this PR.