### PR TITLE
Changes stream.runXyz methods so that they return effectful values instead of free interpretations

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ val converter: Task[Unit] =
     .intersperse("\n")
     .through(text.utf8Encode)
     .through(io.file.writeAll(Paths.get("testdata/celsius.txt")))
-    .run.run
+    .run
 
 // at the end of the universe...
 val u: Unit = converter.unsafeRun

--- a/core/src/main/scala/fs2/Stream.scala
+++ b/core/src/main/scala/fs2/Stream.scala
@@ -20,10 +20,10 @@ abstract class Stream[+F[_],+O] extends StreamOps[F,O] { self =>
 
   override final def map[O2](f: O => O2): Stream[F,O2] = mapChunks(_ map f)
 
-  override final def runFold[O2](z: O2)(f: (O2,O) => O2): Free[F,O2] =
+  override final def runFoldFree[O2](z: O2)(f: (O2,O) => O2): Free[F,O2] =
     get.runFold(z)(f)
 
-  override final def runFoldTrace[O2](t: Trace)(z: O2)(f: (O2,O) => O2): Free[F,O2] =
+  override final def runFoldTraceFree[O2](t: Trace)(z: O2)(f: (O2,O) => O2): Free[F,O2] =
     get.runFoldTrace(t)(z)(f)
 
   final def step: Pull[F,Nothing,Step[Chunk[O],Handle[F,O]]] =
@@ -131,11 +131,11 @@ object Stream extends Streams[Stream] with StreamDerived {
     if (c.isEmpty) h
     else new Handle(c :: h.buffer, h.underlying)
 
-  def runFold[F[_], A, B](p: Stream[F,A], z: B)(f: (B, A) => B): Free[F,B] =
-    p.runFold(z)(f)
+  def runFoldFree[F[_], A, B](p: Stream[F,A], z: B)(f: (B, A) => B): Free[F,B] =
+    p.runFoldFree(z)(f)
 
-  def runFoldTrace[F[_], A, B](t: Trace)(p: Stream[F,A], z: B)(f: (B, A) => B): Free[F,B] =
-    p.runFoldTrace(t)(z)(f)
+  def runFoldTraceFree[F[_], A, B](t: Trace)(p: Stream[F,A], z: B)(f: (B, A) => B): Free[F,B] =
+    p.runFoldTraceFree(t)(z)(f)
 
   def scope[F[_],O](s: Stream[F,O]): Stream[F,O] =
     Stream.mk { StreamCore.scope { s.get } }

--- a/core/src/main/scala/fs2/StreamDerived.scala
+++ b/core/src/main/scala/fs2/StreamDerived.scala
@@ -1,6 +1,6 @@
 package fs2
 
-import fs2.util.{RealSupertype,Sub1,Task}
+import fs2.util.{Catchable,RealSupertype,Sub1,Task}
 
 /** Various derived operations that are mixed into the `Stream` companion object. */
 private[fs2]
@@ -95,9 +95,9 @@ trait StreamDerived extends PipeDerived { self: fs2.Stream.type =>
    * `emits(start until stopExclusive)`.
    */
   def range[F[_]](start: Int, stopExclusive: Int, by: Int = 1): Stream[F,Int] =
-    unfold(start){i => 
-      if ((by > 0 && i < stopExclusive && start < stopExclusive) || 
-          (by < 0 && i > stopExclusive && start > stopExclusive)) 
+    unfold(start){i =>
+      if ((by > 0 && i < stopExclusive && start < stopExclusive) ||
+          (by < 0 && i > stopExclusive && start > stopExclusive))
         Some((i, i + by))
       else None
     }
@@ -199,6 +199,16 @@ trait StreamDerived extends PipeDerived { self: fs2.Stream.type =>
       Stream.repeatPull(s)(using)
     def repeatPull2[B,C](s2: Stream[F,B])(using: (Handle[F,A],Handle[F,B]) => Pull[F,C,(Handle[F,A],Handle[F,B])]): Stream[F,C] =
       Stream.repeatPull2(s,s2)(using)
+    def run(implicit F: Catchable[F]):F[Unit] =
+      s.runFree.run
+    def runTrace(t: Trace)(implicit F: Catchable[F]):F[Unit] =
+      s.runTraceFree(t).run
+    def runFold[B](z: B)(f: (B,A) => B)(implicit F: Catchable[F]): F[B] =
+      s.runFoldFree(z)(f).run
+    def runFoldTrace[B](t: Trace)(z: B)(f: (B,A) => B)(implicit F: Catchable[F]): F[B] =
+      s.runFoldTraceFree(t)(z)(f).run
+    def runLog(implicit F: Catchable[F]): F[Vector[A]] =
+      s.runLogFree.run
     /** Transform this stream using the given `Pipe`. */
     def through[B](f: Pipe[F,A,B]): Stream[F,B] = f(s)
     /** Transform this stream using the given pure `Pipe`. */
@@ -215,8 +225,8 @@ trait StreamDerived extends PipeDerived { self: fs2.Stream.type =>
 
   implicit class StreamPureOps[+A](s: Stream[Pure,A]) {
     def toList: List[A] =
-      s.covary[Task].runFold(List.empty[A])((b, a) => a :: b).run.unsafeRun.reverse
-    def toVector: Vector[A] = s.covary[Task].runLog.run.unsafeRun
+      s.covary[Task].runFold(List.empty[A])((b, a) => a :: b).unsafeRun.reverse
+    def toVector: Vector[A] = s.covary[Task].runLog.unsafeRun
   }
 
   implicit def covaryPure[F[_],A](s: Stream[Pure,A]): Stream[F,A] = s.covary[F]

--- a/core/src/main/scala/fs2/StreamOps.scala
+++ b/core/src/main/scala/fs2/StreamOps.scala
@@ -70,20 +70,20 @@ private[fs2] trait StreamOps[+F[_],+A] extends StreamPipeOps[F,A] with StreamPip
     self ++ repeat
   }
 
-  def run:Free[F,Unit] =
-    Stream.runFold(self,())((_,_) => ())
+  def runFree:Free[F,Unit] =
+    Stream.runFoldFree(self,())((_,_) => ())
 
-  def runTrace(t: Trace):Free[F,Unit] =
-    Stream.runFoldTrace(t)(self,())((_,_) => ())
+  def runTraceFree(t: Trace):Free[F,Unit] =
+    Stream.runFoldTraceFree(t)(self,())((_,_) => ())
 
-  def runFold[B](z: B)(f: (B,A) => B): Free[F,B] =
-    Stream.runFold(self, z)(f)
+  def runFoldFree[B](z: B)(f: (B,A) => B): Free[F,B] =
+    Stream.runFoldFree(self, z)(f)
 
-  def runFoldTrace[B](t: Trace)(z: B)(f: (B,A) => B): Free[F,B] =
-    Stream.runFoldTrace(t)(self, z)(f)
+  def runFoldTraceFree[B](t: Trace)(z: B)(f: (B,A) => B): Free[F,B] =
+    Stream.runFoldTraceFree(t)(self, z)(f)
 
-  def runLog: Free[F,Vector[A]] =
-    Stream.runFold(self, Vector.empty[A])(_ :+ _)
+  def runLogFree: Free[F,Vector[A]] =
+    Stream.runFoldFree(self, Vector.empty[A])(_ :+ _)
 
   /** Like `through`, but the specified `Pipe`'s effect may be a supertype of `F`. */
   def throughv[F2[_],B](f: Pipe[F2,A,B])(implicit S: Sub1[F,F2]): Stream[F2,B] =

--- a/core/src/main/scala/fs2/Streams.scala
+++ b/core/src/main/scala/fs2/Streams.scala
@@ -86,7 +86,7 @@ trait Streams[Stream[+_[_],+_]] { self =>
 
   // evaluation
 
-  def runFold[F[_],A,B](p: Stream[F,A], z: B)(f: (B,A) => B): Free[F,B]
-  def runFoldTrace[F[_],A,B](t: Trace)(p: Stream[F,A], z: B)(f: (B,A) => B): Free[F,B]
+  def runFoldFree[F[_],A,B](p: Stream[F,A], z: B)(f: (B,A) => B): Free[F,B]
+  def runFoldTraceFree[F[_],A,B](t: Trace)(p: Stream[F,A], z: B)(f: (B,A) => B): Free[F,B]
 }
 

--- a/core/src/main/scala/fs2/concurrent.scala
+++ b/core/src/main/scala/fs2/concurrent.scala
@@ -47,7 +47,7 @@ object concurrent {
             Stream.eval(checkIfKilled).
                    flatMap { killed => if (killed) Stream.empty else inner }.
                    onFinalize { F.bind(F.setPure(gate)(())) { _ => onInnerStreamDone } }.
-                   run.run
+                   run
           )) { _ => gate }}
         }
         Pull.acquire(startInnerStream) { gate => F.get(gate) }.map { _ => () }

--- a/core/src/main/scala/fs2/pipe.scala
+++ b/core/src/main/scala/fs2/pipe.scala
@@ -482,7 +482,7 @@ object pipe {
     = s.buffer match {
         case hd :: tl => Free.pure(Some(Step(hd, new Handle[Read,O](tl, s.stream))))
         case List() => s.stream.step.flatMap { s => Pull.output1(s) }
-         .run.runFold(None: Option[Step[Chunk[O],Handle[Read, O]]])(
+         .run.runFoldFree(None: Option[Step[Chunk[O],Handle[Read, O]]])(
           (_,s) => Some(s))
       }
     def go(s: Free[Read, Option[Step[Chunk[O],Handle[Read, O]]]]): Stepper[I,O] =

--- a/core/src/main/scala/fs2/pipe2.scala
+++ b/core/src/main/scala/fs2/pipe2.scala
@@ -139,7 +139,7 @@ object pipe2 {
     = s.buffer match {
         case hd :: tl => Free.pure(Some(Step(hd, new Handle[Read,O](tl, s.stream))))
         case List() => s.stream.step.flatMap { s => Pull.output1(s) }
-         .run.runFold(None: Option[Step[Chunk[O],Handle[Read, O]]])(
+         .run.runFoldFree(None: Option[Step[Chunk[O],Handle[Read, O]]])(
           (_,s) => Some(s))
       }
     def go(s: Free[Read, Option[Step[Chunk[O],Handle[Read, O]]]]): Stepper[I,I2,O] =

--- a/core/src/main/scala/fs2/util/Task.scala
+++ b/core/src/main/scala/fs2/util/Task.scala
@@ -218,7 +218,7 @@ object Task extends Instances {
 
   /** Create a `Future` that will evaluate `a` using the given `Strategy`. */
   def apply[A](a: => A)(implicit S: Strategy): Task[A] =
-    async(_(Try(a)))
+    async { cb => S(cb(Try(a))) }
 
   /**
    * Don't use this. It doesn't do what you think. If you have a `t: Task[A]` you'd

--- a/core/src/test/scala/fs2/BracketBug.scala
+++ b/core/src/test/scala/fs2/BracketBug.scala
@@ -13,6 +13,6 @@ object BracketBug extends App {
   println{
     Stream(3).flatMap(logBracket).map {
       n => if (n > 2) sys.error("bad") else n
-    }.run.run.unsafeAttemptRun
+    }.run.unsafeAttemptRun
   }
 }

--- a/core/src/test/scala/fs2/ConcurrentSpec.scala
+++ b/core/src/test/scala/fs2/ConcurrentSpec.scala
@@ -44,7 +44,7 @@ class ConcurrentSpec extends Fs2Spec {
 
     "merge (left/right failure)" in forAll { (s1: PureStream[Int], f: Failure) =>
       an[Err.type] should be thrownBy {
-        s1.get.merge(f.get).run.run.unsafeRun
+        s1.get.merge(f.get).run.unsafeRun
       }
     }
 

--- a/core/src/test/scala/fs2/MemorySanityChecks.scala
+++ b/core/src/test/scala/fs2/MemorySanityChecks.scala
@@ -9,12 +9,12 @@ object ResourceTrackerSanityTest extends App {
   val big = Stream.constant(1).flatMap { n =>
     Stream.bracket(Task.delay(()))(_ => Stream.emits(List(1, 2, 3)), _ => Task.delay(()))
   }
-  big.run.run.unsafeRun
+  big.run.unsafeRun
 }
 
 object RepeatPullSanityTest extends App {
   def id[A]: Pipe[Pure, A, A] = _ repeatPull Pull.receive1 { case h #: t => Pull.output1(h) as t }
-  Stream.constant(1).covary[Task].throughp(id).run.run.unsafeRun
+  Stream.constant(1).covary[Task].throughp(id).run.unsafeRun
 }
 
 object RepeatEvalSanityTest extends App {
@@ -23,19 +23,19 @@ object RepeatEvalSanityTest extends App {
       _.receive1 { case h #: t => Pull.output1(h) >> go(t) }
     _ pull go
   }
-  Stream.repeatEval(Task.delay(1)).throughp(id).run.run.unsafeRun
+  Stream.repeatEval(Task.delay(1)).throughp(id).run.unsafeRun
 }
 
 object AppendSanityTest extends App {
-  (Stream.constant(1).covary[Task] ++ Stream.empty).pull(Pull.echo).run.run.unsafeRun
+  (Stream.constant(1).covary[Task] ++ Stream.empty).pull(Pull.echo).run.unsafeRun
 }
 
 object OnCompleteSanityTest extends App {
-  Stream.constant(1).covary[Task].onComplete(Stream.empty).pull(Pull.echo).run.run.unsafeRun
+  Stream.constant(1).covary[Task].onComplete(Stream.empty).pull(Pull.echo).run.unsafeRun
 }
 
 object DrainOnCompleteSanityTest extends App {
   import TestUtil.S
   val s = Stream.repeatEval(Task.delay(1)).pull(Pull.echo).drain.onComplete(Stream.eval_(Task.delay(println("done"))))
-  (Stream.empty[Task, Unit] merge s).run.run.unsafeRun
+  (Stream.empty[Task, Unit] merge s).run.unsafeRun
 }

--- a/core/src/test/scala/fs2/Pipe2Spec.scala
+++ b/core/src/test/scala/fs2/Pipe2Spec.scala
@@ -123,7 +123,7 @@ class Pipe2Spec extends Fs2Spec {
 
     "merge (left/right failure)" in forAll { (s1: PureStream[Int], f: Failure) =>
       an[Err.type] should be thrownBy {
-        (s1.get merge f.get).run.run.unsafeRun
+        (s1.get merge f.get).run.unsafeRun
       }
     }
 

--- a/core/src/test/scala/fs2/ResourceSafetySpec.scala
+++ b/core/src/test/scala/fs2/ResourceSafetySpec.scala
@@ -142,7 +142,7 @@ class ResourceSafetySpec extends Fs2Spec with org.scalatest.concurrent.Eventuall
       val c = new AtomicLong(0)
       signal.set(true).schedule(20.millis).async.unsafeRun
       runLog { s.get.evalMap { inner =>
-        Task.start(bracket(c)(inner.get).evalMap { _ => Task.async[Unit](_ => ()) }.interruptWhen(signal.continuous).run.run)
+        Task.start(bracket(c)(inner.get).evalMap { _ => Task.async[Unit](_ => ()) }.interruptWhen(signal.continuous).run)
       }}
       eventually { c.get shouldBe 0L }
     }
@@ -159,7 +159,7 @@ class ResourceSafetySpec extends Fs2Spec with org.scalatest.concurrent.Eventuall
         Stream.bracket(Task.delay { Thread.sleep(2000) })( // which will be in the middle of acquiring the resource
           _ => inner,
           _ => Task.delay { c.decrementAndGet; () }
-        ).evalMap { _ => Task.async[Unit](_ => ()) }.interruptWhen(signal.discrete).run.run
+        ).evalMap { _ => Task.async[Unit](_ => ()) }.interruptWhen(signal.discrete).run
       }}}
       eventually { c.get shouldBe 0L }
     }

--- a/core/src/test/scala/fs2/StreamSpec.scala
+++ b/core/src/test/scala/fs2/StreamSpec.scala
@@ -26,7 +26,7 @@ class StreamSpec extends Fs2Spec {
     }
 
     "fail (1)" in forAll { (f: Failure) =>
-      an[Err.type] should be thrownBy f.get.run.run.unsafeRun
+      an[Err.type] should be thrownBy f.get.run.unsafeRun
     }
 
     "fail (2)" in {
@@ -54,7 +54,7 @@ class StreamSpec extends Fs2Spec {
     }
 
     "iterateEval" in {
-      Stream.iterateEval(0)(i => Task.delay(i + 1)).take(100).runLog.run.unsafeRun shouldBe List.iterate(0, 100)(_ + 1)
+      Stream.iterateEval(0)(i => Task.delay(i + 1)).take(100).runLog.unsafeRun shouldBe List.iterate(0, 100)(_ + 1)
     }
 
     "map" in forAll { (s: PureStream[Int]) =>
@@ -77,7 +77,7 @@ class StreamSpec extends Fs2Spec {
     "onError (4)" in {
       Stream.eval(Task.delay(throw Err)).map(Right(_)).onError(t => Stream.emit(Left(t)))
             .take(1)
-            .runLog.run.unsafeRun shouldBe Vector(Left(Err))
+            .runLog.unsafeRun shouldBe Vector(Left(Err))
     }
 
     "range" in {
@@ -91,7 +91,7 @@ class StreamSpec extends Fs2Spec {
     }
 
     "ranges" in forAll(Gen.choose(1, 101)) { size =>
-      Stream.ranges[Task](0, 100, size).flatMap { case (i,j) => Stream.emits(i until j) }.runLog.run.unsafeRun shouldBe
+      Stream.ranges[Task](0, 100, size).flatMap { case (i,j) => Stream.emits(i until j) }.runLog.unsafeRun shouldBe
         IndexedSeq.range(0, 100)
     }
 
@@ -120,12 +120,12 @@ class StreamSpec extends Fs2Spec {
 
     "unfoldEval" in {
       Stream.unfoldEval(10)(s => Task.now(if (s > 0) Some((s, s - 1)) else None))
-        .runLog.run.unsafeRun.toList shouldBe List.range(10, 0, -1)
+        .runLog.unsafeRun.toList shouldBe List.range(10, 0, -1)
     }
 
     "translate stack safety" in {
       import fs2.util.{~>}
-      Stream.repeatEval(Task.delay(0)).translate(new (Task ~> Task) { def apply[X](x: Task[X]) = Task.suspend(x) }).take(1000000).run.run.unsafeRun
+      Stream.repeatEval(Task.delay(0)).translate(new (Task ~> Task) { def apply[X](x: Task[X]) = Task.suspend(x) }).take(1000000).run.unsafeRun
     }
   }
 }

--- a/core/src/test/scala/fs2/TestUtil.scala
+++ b/core/src/test/scala/fs2/TestUtil.scala
@@ -16,10 +16,10 @@ trait TestUtil {
  implicit val S = TestStrategy.S
  implicit val scheduler = TestStrategy.scheduler
 
-  def runLog[A](s: Stream[Task,A], timeout: FiniteDuration = 1.minute): Vector[A] = s.runLog.run.unsafeRunFor(timeout)
+  def runLog[A](s: Stream[Task,A], timeout: FiniteDuration = 1.minute): Vector[A] = s.runLog.unsafeRunFor(timeout)
 
   def throws[A](err: Throwable)(s: Stream[Task,A]): Boolean =
-    s.runLog.run.unsafeAttemptRun match {
+    s.runLog.unsafeAttemptRun match {
       case Left(e) if e == err => true
       case _ => false
     }

--- a/core/src/test/scala/fs2/async/SemaphoreSpec.scala
+++ b/core/src/test/scala/fs2/async/SemaphoreSpec.scala
@@ -14,7 +14,7 @@ class SemaphoreSpec extends Fs2Spec {
         val n0 = ((n.abs % 20) + 1).abs
         Stream.eval(async.mutable.Semaphore[Task](n0)).flatMap { s =>
           Stream.emits(0 until n0).evalMap { _ => s.decrement }.drain ++ Stream.eval(s.available)
-        }.runLog.run.unsafeRun shouldBe Vector(0)
+        }.runLog.unsafeRun shouldBe Vector(0)
       }
     }
 

--- a/core/src/test/scala/fs2/async/SignalSpec.scala
+++ b/core/src/test/scala/fs2/async/SignalSpec.scala
@@ -11,7 +11,7 @@ class SignalSpec extends Fs2Spec {
         val vs = vs0 map { n => if (n == 0) 1 else n }
         val s = async.signalOf[Task,Long](0L).unsafeRun
         val r = new AtomicLong(0)
-        val u = s.discrete.map(r.set).run.run.async.unsafeRunAsyncFuture
+        val u = s.discrete.map(r.set).run.async.unsafeRunAsyncFuture
         assert(vs.forall { v =>
           s.set(v).unsafeRun
           while (s.get.unsafeRun != v) {} // wait for set to arrive
@@ -29,7 +29,7 @@ class SignalSpec extends Fs2Spec {
         val vs = v0 :: vsTl
         val s = async.signalOf[Task,Long](0L).unsafeRun
         val r = new AtomicLong(0)
-        val u = s.discrete.map { i => Thread.sleep(10); r.set(i) }.run.run.async.unsafeRunAsyncFuture
+        val u = s.discrete.map { i => Thread.sleep(10); r.set(i) }.run.async.unsafeRunAsyncFuture
         vs.foreach { v => s.set(v).unsafeRun }
         val last = vs.last
         while (r.get != last) {}

--- a/core/src/test/scala/fs2/time/TimeSpec.scala
+++ b/core/src/test/scala/fs2/time/TimeSpec.scala
@@ -12,11 +12,11 @@ class TimeSpec extends Fs2Spec {
   "time" - {
 
     "awakeEvery" in {
-      time.awakeEvery[Task](100.millis).map(_.toMillis/100).take(5).runLog.run.unsafeRun shouldBe Vector(1,2,3,4,5)
+      time.awakeEvery[Task](100.millis).map(_.toMillis/100).take(5).runLog.unsafeRun shouldBe Vector(1,2,3,4,5)
     }
 
     "duration" in {
-      val firstValueDiscrepancy = time.duration[Task].take(1).runLog.run.unsafeRun.last
+      val firstValueDiscrepancy = time.duration[Task].take(1).runLog.unsafeRun.last
       val reasonableErrorInMillis = 200
       val reasonableErrorInNanos = reasonableErrorInMillis * 1000000
       def p = firstValueDiscrepancy.toNanos < reasonableErrorInNanos
@@ -50,7 +50,7 @@ class TimeSpec extends Fs2Spec {
           take(draws.toInt).
           through(durationSinceLastTrue)
 
-        val result = durationsSinceSpike.runLog.run.unsafeRun.toList
+        val result = durationsSinceSpike.runLog.unsafeRun.toList
         val (head :: tail) = result
 
         withClue("every always emits true first") { assert(head._1) }

--- a/docs/ReadmeExample.md
+++ b/docs/ReadmeExample.md
@@ -20,7 +20,7 @@ scala> object Converter {
      |       .intersperse("\n")
      |       .through(text.utf8Encode)
      |       .through(io.file.writeAll(Paths.get("testdata/celsius.txt")))
-     |       .run.run
+     |       .run
      | }
 defined object Converter
 
@@ -94,13 +94,10 @@ scala> val written: Stream[Task, Unit] = encodedBytes.through(io.file.writeAll(P
 written: fs2.Stream[fs2.util.Task,Unit] = evalScope(Scope(Bind(Eval(Snapshot),<function1>))).flatMap(<function1>)
 ```
 
-There are a number of ways of interpreting the stream. In this case, we call `run`, which returns a description of the program in the `Free` monad, where the output of the stream is ignored - we run it solely for its effect. That description can then interpreted in to a value of the effect type.
+There are a number of ways of interpreting the stream. In this case, we call `run`, which returns a val value of the effect type, `Task`. The output of the stream is ignored - we run it solely for its effect.
 
 ```scala
-scala> val freeInterpretation: fs2.util.Free[Task, Unit] = written.run
-freeInterpretation: fs2.util.Free[fs2.util.Task,Unit] = Bind(Bind(Pure(()),<function1>),<function1>)
-
-scala> val task: Task[Unit] = freeInterpretation.run
+scala> val task: Task[Unit] = written.run
 task: fs2.util.Task[Unit] = Task
 ```
 

--- a/docs/src/ReadmeExample.md
+++ b/docs/src/ReadmeExample.md
@@ -20,7 +20,7 @@ object Converter {
       .intersperse("\n")
       .through(text.utf8Encode)
       .through(io.file.writeAll(Paths.get("testdata/celsius.txt")))
-      .run.run
+      .run
 }
 
 Converter.converter.unsafeRun
@@ -83,11 +83,10 @@ We then write the encoded bytes to a file. Note that nothing has happened at thi
 val written: Stream[Task, Unit] = encodedBytes.through(io.file.writeAll(Paths.get("testdata/celsius.txt")))
 ```
 
-There are a number of ways of interpreting the stream. In this case, we call `run`, which returns a description of the program in the `Free` monad, where the output of the stream is ignored - we run it solely for its effect. That description can then interpreted in to a value of the effect type.
+There are a number of ways of interpreting the stream. In this case, we call `run`, which returns a val value of the effect type, `Task`. The output of the stream is ignored - we run it solely for its effect.
 
 ```tut
-val freeInterpretation: fs2.util.Free[Task, Unit] = written.run
-val task: Task[Unit] = freeInterpretation.run
+val task: Task[Unit] = written.run
 ```
 
 We still haven't *done* anything yet. Effects only occur when we run the resulting task. We can run a `Task` by calling `unsafeRun` -- the name is telling us that calling it performs effects and hence, it is not referentially transparent.

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -121,27 +121,17 @@ val rb = eff.run // purely for effects
 val rc = eff.runFold(0)(_ + _) // run and accumulate some result
 ```
 
-Notice these all return an `fs2.util.Free[Task,_]`. `Free` has various useful functions on it (for instance, we can translate to a different effect type), but most of the time we'll just want to run it using the `run` method:
-
-```tut
-ra.run
-rb.run
-rc.run
-```
-
-This requires an implicit `Catchable[Task]` in scope (or a `Catchable[F]` for whatever your effect type, `F`).
-
 Notice nothing has actually happened yet (our `println` hasn't been executed), we just have a `Task`. If we want to run this for its effects 'at the end of the universe', we can use one of the `unsafe*` methods on `Task`:
 
 ```tut
-ra.run.unsafeRun
-ra.run.unsafeRun
+ra.unsafeRun
+ra.unsafeRun
 ```
 
 Here we finally see the task is executed. Rerunning the task executes the entire computation again; nothing is cached for you automatically. Here's a complete example:
 
 ```tut
-Stream.eval(Task.now(23)).runLog.run.unsafeRun
+Stream.eval(Task.now(23)).runLog.unsafeRun
 ```
 
 ### Basic stream operations
@@ -153,7 +143,7 @@ val appendEx1 = Stream(1,2,3) ++ Stream.emit(42)
 val appendEx2 = Stream(1,2,3) ++ Stream.eval(Task.now(4))
 
 appendEx1.toVector
-appendEx2.runLog.run.unsafeRun
+appendEx2.runLog.unsafeRun
 
 appendEx1.map(_ + 1).toList
 ```
@@ -187,7 +177,7 @@ try err2.toList catch { case e: Exception => println(e) }
 ```
 
 ```tut
-try err3.run.run.unsafeRun catch { case e: Exception => println(e) }
+try err3.run.unsafeRun catch { case e: Exception => println(e) }
 ```
 
 The `onError` method lets us catch any of these errors:
@@ -207,7 +197,7 @@ val release = Task.delay { println("decremented: " + count.decrementAndGet); () 
 ```
 
 ```tut:fail
-Stream.bracket(acquire)(_ => Stream(1,2,3) ++ err, _ => release).run.run.unsafeRun
+Stream.bracket(acquire)(_ => Stream(1,2,3) ++ err, _ => release).run.unsafeRun
 ```
 
 The inner stream fails, but notice the `release` action is still run:
@@ -233,7 +223,7 @@ Implement `repeat`, which repeats a stream indefinitely, `drain`, which strips a
 ```tut
 Stream(1,0).repeat.take(6).toList
 Stream(1,2,3).drain.toList
-Stream.eval_(Task.delay(println("!!"))).runLog.run.unsafeRun
+Stream.eval_(Task.delay(println("!!"))).runLog.unsafeRun
 (Stream(1,2) ++ (throw new Exception("nooo!!!"))).attempt.toList
 ```
 
@@ -354,7 +344,7 @@ Stream.range(1,10).scan(0)(_ + _).toList // running sum
 FS2 comes with lots of concurrent operations. The `merge` function runs two streams concurrently, combining their outputs. It halts when both inputs have halted:
 
 ```tut:fail
-Stream(1,2,3).merge(Stream.eval(Task.delay { Thread.sleep(200); 4 })).runLog.run.unsafeRun
+Stream(1,2,3).merge(Stream.eval(Task.delay { Thread.sleep(200); 4 })).runLog.unsafeRun
 ```
 
 Oop, we need an `fs2.Strategy` in implicit scope in order to get an `Async[Task]`. Let's add that:
@@ -362,7 +352,7 @@ Oop, we need an `fs2.Strategy` in implicit scope in order to get an `Async[Task]
 ```tut
 implicit val S = fs2.Strategy.fromFixedDaemonPool(8, threadName = "worker")
 
-Stream(1,2,3).merge(Stream.eval(Task.delay { Thread.sleep(200); 4 })).runLog.run.unsafeRun
+Stream(1,2,3).merge(Stream.eval(Task.delay { Thread.sleep(200); 4 })).runLog.unsafeRun
 ```
 
 The `merge` function is defined in [`pipe2`](../core/src/main/scala/fs2/pipe2), along with other useful concurrency functions, like `interrupt` (halts if the left branch produces `false`), `either` (like `merge` but returns an `Either`), `mergeHaltBoth` (halts if either branch halts), and others.
@@ -430,7 +420,7 @@ These are easy to deal with. Just wrap these effects in a `Stream.eval`:
 def destroyUniverse(): Unit = { println("BOOOOM!!!"); } // stub implementation
 
 val s = Stream.eval_(Task.delay { destroyUniverse() }) ++ Stream("...moving on")
-s.runLog.run.unsafeRun
+s.runLog.unsafeRun
 ```
 
 _Note:_ `Stream.eval_(f)` is just `Stream.eval(f).flatMap(_ => Stream.empty)`.
@@ -442,7 +432,7 @@ import fs2.Async
 
 val T = implicitly[Async[Task]]
 val s = Stream.eval_(T.delay { destroyUniverse() }) ++ Stream("...moving on")
-s.runLog.run.unsafeRun
+s.runLog.unsafeRun
 ```
 
 When using this approach, be sure that the expression you pass to delay doesn't throw exceptions.
@@ -493,7 +483,7 @@ val bytes = T.async[Array[Byte]] { (cb: Either[Throwable,Array[Byte]] => Unit) =
   T.delay { c.readBytesE(cb) }
 }
 
-Stream.eval(bytes).map(_.toList).runLog.run.unsafeRun
+Stream.eval(bytes).map(_.toList).runLog.unsafeRun
 ```
 
 Be sure to check out the [`fs2.io`](../io) package which has nice FS2 bindings to these libraries, using exactly these approaches.

--- a/io/src/test/scala/fs2/io/tcp/SocketSpec.scala
+++ b/io/src/test/scala/fs2/io/tcp/SocketSpec.scala
@@ -64,7 +64,7 @@ class SocketSpec extends Fs2Spec {
             echoServer.drain
             , clients
           ))
-          .take(clientCount).runLog.run.unsafeRun
+          .take(clientCount).runLog.unsafeRun
 
 
         (result.size shouldBe clientCount)


### PR DESCRIPTION
- Renamed the existing methods to `runXyzFree`
- Created new methods of the form `runXyz` which alias `runXyzFree andThen run`
- Fixed an unrelated bug in `Task.apply`, where the value was being evaluated on the calling thread instead of via the strategy