### PR TITLE
Initial implementation of Topic

### DIFF
--- a/core/src/main/scala/fs2/async/async.scala
+++ b/core/src/main/scala/fs2/async/async.scala
@@ -1,5 +1,7 @@
 package fs2
 
+import fs2.async.mutable.Topic
+
 package object async {
 
   /**
@@ -47,4 +49,11 @@ package object async {
    */
   def hold[F[_]:Async,A](initial: A, source: Stream[F, A]): Stream[F, immutable.Signal[F,A]] =
      immutable.Signal.hold(initial, source)
+
+  /**
+    * Creates asynchronous topic, that allows distribute published `A` to arbitrary number of subscribers.
+    * Each subscriber is guaranteed to received at least initial `A` passed, or last value published by any publisher.
+    */
+  def topic[F[_]:Async, A](initial: A):F[Topic[F,A]] =
+    Topic(initial)
 }

--- a/core/src/main/scala/fs2/async/mutable/Topic.scala
+++ b/core/src/main/scala/fs2/async/mutable/Topic.scala
@@ -57,7 +57,7 @@ trait Topic[F[_],A] {
     * Additionally this emits current size of the queue of `A` for this subscriber allowing
     * you to terminate (or adjust) the subscription if subscriber is way behind the elements available.
     *
-    * Note that queue size is approximate and may not be exactly the size when `a` was take.
+    * Note that queue size is approximate and may not be exactly the size when `A` was taken.
     *
     * If the subscriber is over `maxQueued` bound of messages awaiting to be processed,
     * then publishers will hold into publishing to the queue.

--- a/core/src/main/scala/fs2/async/mutable/Topic.scala
+++ b/core/src/main/scala/fs2/async/mutable/Topic.scala
@@ -1,0 +1,250 @@
+package fs2.async.mutable
+
+import fs2.Async.Change
+import fs2._
+import fs2.Stream._
+
+/**
+  * Asynchronous Topic.
+  *
+  * Topic allows you to distribute `A` published by arbitrary number of publishers to arbitrary number of subscribers.
+  *
+  * Topic has built-in back-pressure support implemented as maximum bound (`maxQueued`) that subscriber is allowed to enqueue.
+  * Once that bound is hit, the publish may hold on until subscriber consumes some of its published elements .
+  *
+  * Additionally the subscriber has possibility to terminate whenever size of enqueued elements is over certain size
+  * by using `subscribeSize`.
+  *
+  *
+  */
+trait Topic[F[_],A] {
+
+  /**
+    * Published any elements from source of `A` to this topic. This will stop publishing if the source has no elements
+    * or, any subscriber is far behind the `maxQueued` limit.
+    */
+  def publish:Sink[F,A]
+
+
+  /**
+    * Publish one `A` to topic.
+    *
+    * This will wait until `A` is published to all subscribers.
+    * If one of the subscribers is over the `maxQueued` limit, this will wait to complete until that subscriber processes
+    * some of its elements to get room for this new. published `A`
+    *
+    * @param a
+    * @return
+    */
+  def publish1(a:A):F[Unit]
+
+  /**
+    * Offers one `A` to topic.
+    *
+    * This will either publishes `A` to all its subscribers and return true, or this will return false publishing to None of them.
+    * In case publish failed, this indicates that some of the subscribers was over `maxQueued` parameter.
+    *
+    * @param a
+    * @return
+    */
+  def offer1(a:A):F[Boolean]
+
+
+  /**
+    * Subscribes to receive any published `A` to this topic.
+    *
+    * Always returns last `A` published first, and then any next `A` published.
+    *
+    * If the subscriber is over `maxQueued` bound of messages awaiting to be processed,
+    * then publishers will hold into publishing to the queue.
+    *
+    */
+  def subscribe(maxQueued:Int):Stream[F,A]
+
+  /**
+    * Subscribes to receive published `A` to this topic.
+    *
+    * Always returns last `A` published first, and then any next `A` available
+    *
+    * Additionally this emits current size of the queue of `A` for this subscriber allowing
+    * you to terminate (or adjust) the subscription if subscriber is way behind the elements available.
+    *
+    * Note that queue size is approximate and may not be exactly the size when `a` was take.
+    *
+    * If the subscriber is over `maxQueued` bound of messages awaiting to be processed,
+    * then publishers will hold into publishing to the queue.
+    *
+    */
+  def subscribeSize(maxQueued:Int):Stream[F,(Int,A)]
+
+
+  /**
+    * Discrete stream of current active subscribers
+    */
+  def subscribers:Stream[F,Int]
+
+}
+
+
+
+object Topic {
+
+
+  def apply[F[_], A](initial:A)(implicit F: Async[F]):F[Topic[F,A]] = {
+    // Id identifying each subscriber uniquely
+    class ID
+
+
+    // State of each subscriber.
+    sealed trait Subscriber
+
+    // Subscriber awaits nest `A`
+    case class Await(maxQueued:Int, ref:F.Ref[Chunk[A]]) extends Subscriber
+
+    //Subscriber is running, next elements has to be enqueued in `q`
+    case class Running(maxQueued:Int, q:Vector[A]) extends Subscriber
+
+    // internal state of the topic
+    // `last` is last value published to topic, or if nothing was published then this eq to initial
+    // `ready` all subscribers that are ready to accept any published value
+    // `full` subscribers that are full and will block any publishers to enqueue `a`
+    //  `publishers` any publishers awaiting to be consumed
+    case class State(
+      last:A
+      , ready:Map[ID, Subscriber]
+      , full:Map[ID, Running]
+      , publishers:Vector[(Chunk[A], F.Ref[Unit])]
+    )
+
+
+
+
+    F.map(F.refOf(State(initial,Map.empty, Map.empty, Vector.empty))) { (stateRef:F.Ref[State]) =>
+
+      def publish0(chunk:Chunk[A]):F[Unit] = {
+
+        ???
+      }
+
+
+      def appendChunk(s:State, chunk:Chunk[A]):(State, F[Unit]) = {
+        val (ready, f) =
+          s.ready.foldLeft((Map[ID, Subscriber](),F.pure(()))) {
+            case ((m,f0), (id,Await(max,ref))) => (m + (id -> Running(max,Vector.empty))) -> F.bind(f0)(_ => F.setPure(ref)(chunk))
+            case ((m,f0), (id,Running(max,q))) => (m + (id -> Running(max,q ++ chunk.toVector)) -> f0)
+          }
+
+        s.copy(ready = ready) -> f
+      }
+
+
+      def offer0(a:A):F[Boolean] = {
+        F.bind(F.modify2(stateRef){ s =>
+          if (s.full.nonEmpty) s -> F.pure(false)
+          else {
+            val (ns,f) = appendChunk(s, Chunk.singleton(a))
+            ns -> F.map(f){_ => true}
+          }
+        }) { _._2 }
+      }
+
+
+      def subscribe0(maxQueued: Int, id:ID): Stream[F, A] = {
+        def register:F[A] =
+          F.bind(F.modify(stateRef){s => s.copy(ready =  s.ready + (id -> Running(maxQueued,Vector.empty)))}) { c =>
+            F.pure(c.previous.last)
+          }
+
+        def empty(s: State,r:Running) = s.copy(ready = s.ready + (id -> r.copy(q = Vector.empty))) -> Some(Chunk.seq(r.q))
+
+        def tryAwaits0(s:State):(State, Option[F[Chunk[A]]]) = ???
+
+        def tryAwaits(c:Change[State]):F[Unit] = {
+          if (c.previous.full.nonEmpty && c.now.full.isEmpty && c.now.publishers.nonEmpty) {
+            F.bind(F.modify2(stateRef)(tryAwaits0)) {
+              case (c0,Some(fa)) => ???
+              case (c0, None) => F.pure(())
+            }
+          } else F.pure(())
+        }
+
+        def registerRef0(ref:F.Ref[Chunk[A]])(s: State):(State,Option[Chunk[A]]) = {
+          def register :(State,Option[Chunk[A]]) = s.copy(ready = s.ready + (id -> Await(maxQueued, ref)), full = s.full - id) -> None
+
+          s.ready.get(id) match {
+            case Some(r:Running) =>
+              if (r.q.nonEmpty) empty(s,r) else register
+            case _ => register //impossible
+          }
+        }
+
+        def registerRef:F[Chunk[A]] = {
+          F.bind(F.ref[Chunk[A]]) { ref =>
+            F.bind(F.modify2(stateRef)(registerRef0(ref))) {
+              case (_, None) => F.get(ref)
+              case (c, Some(chunk)) => F.map(tryAwaits(c))(_ => chunk)
+            }
+          }
+        }
+
+
+        def getNext0(s: State):(State,Option[Chunk[A]]) = {
+
+          s.ready.get(id) match {
+            case Some(r@Running(_,q)) => if (q.nonEmpty) empty(s,r) else s -> None
+            case Some(Await(max,ref)) => s -> None // impossible
+            case None =>
+              s.full.get(id) match {
+                case Some(r@Running(_,q)) => if (q.nonEmpty) empty(s,r) else s -> None
+                case None => s -> None
+              }
+          }
+        }
+
+        def getNext:F[Chunk[A]] = {
+          F.bind(F.modify2(stateRef)(getNext0)){
+            case (_,None) => registerRef
+            case (c,Some(chunk)) => F.map(tryAwaits(c))(_ => chunk)
+          }
+
+        }
+
+        def unRegister:F[Unit] = {
+          F.map(F.modify(stateRef) { s => s.copy(ready = s.ready - id, full = s.full - id) }){_ => () }
+        }
+
+        (eval(register) ++ repeatEval(getNext).flatMap(Stream.chunk)).onFinalize(unRegister)
+      }
+
+
+
+
+      new Topic[F,A] {
+        def publish:Sink[F,A] = {
+          pipe.chunks andThen { _.evalMap(publish0) }
+        }
+        def subscribers: Stream[F, Int] = {
+          repeatEval(F.map(F.get(stateRef)){ s => s.ready.size + s.full.size })
+        }
+        def offer1(a: A): F[Boolean] = offer0(a)
+        def publish1(a: A): F[Unit] = publish0(Chunk.singleton(a))
+        def subscribe(maxQueued: Int): Stream[F, A] = subscribe0(maxQueued, new ID)
+        def subscribeSize(maxQueued: Int): Stream[F, (Int, A)] = {
+          val id = new ID
+          def getSize:F[Int] =
+            F.map(F.get(stateRef)){ s =>
+              (s.ready.get(id).collect {
+                case Running(_,q) => q.size
+              } orElse s.full.get(id).map(_.q.size)).getOrElse(0)
+            }
+          subscribe0(maxQueued,id) flatMap { a =>
+            eval(getSize) map { _ -> a }
+          }
+        }
+      }
+    }
+
+  }
+
+
+}

--- a/core/src/test/scala/fs2/async/TopicSpec.scala
+++ b/core/src/test/scala/fs2/async/TopicSpec.scala
@@ -1,0 +1,62 @@
+package fs2.async
+
+import fs2._
+import fs2.Stream._
+import fs2.util.Task
+
+import scala.concurrent.duration._
+
+
+class TopicSpec extends Fs2Spec {
+
+  "Topic" - {
+
+    "subscribers see all elements published" in {
+
+      val topic = async.topic[Task,Int](-1).unsafeRun
+      val count = 100
+      val subs = 10
+      val publisher = time.sleep[Task](1.second) ++ Stream.range[Task](0,count).through(topic.publish)
+      val subscriber = topic.subscribe(Int.MaxValue).take(count+1).fold(Vector.empty[Int]){ _ :+ _ }
+
+      val result =
+      concurrent.join(subs + 1)(
+        Stream.range(0,subs).map(idx => subscriber.map(idx -> _)) ++ publisher.drain
+      ).runLog.unsafeRun
+
+      val expected = (for { i <- 0 until subs } yield i).map { idx =>
+        idx -> (for { i <- -1 until count } yield i).toVector
+      }.toMap
+
+      result.toMap.size shouldBe subs
+      result.toMap shouldBe expected
+    }
+
+
+    "synchronous publish" in {
+
+      val topic = async.topic[Task,Int](-1).unsafeRun
+      val signal = async.signalOf[Task,Int](0).unsafeRun
+      val count = 100
+      val subs = 10
+
+      val publisher = time.sleep[Task](1.second) ++ Stream.range[Task](0,count).flatMap(i => eval(signal.set(i)).map(_ => i)).through(topic.publish)
+      val subscriber = topic.subscribe(1).take(count+1).flatMap { is => eval(signal.get).map(is -> _) }.fold(Vector.empty[(Int,Int)]){ _ :+ _ }
+
+      val result =
+        concurrent.join(subs + 1)(
+          Stream.range(0,subs).map(idx => subscriber.map(idx -> _)) ++ publisher.drain
+        ).runLog.unsafeRun
+
+      result.toMap.size shouldBe subs
+
+      result.foreach { case (idx, subResults) =>
+        val diff:Set[Int] = subResults.map{ case (read, state) => Math.abs(state -  read) }.toSet
+        assert( diff.min == 0 || diff.min == 1)
+        assert( diff.max == 0 || diff.max == 1)
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
@mpilquist @pchiusano This is a very rough idea on the topic. Can you please comment on Api? In contrast of 0.8 this:

 - Allows to set limit per subscriber to stop (block) any publish if that subscriber is behind that amount of messages
 - Honors chunking of input stream
 - Subscriber always receive single value, even when there was no value yet published. 
 - There is a variant of `subscribe` with approximate value of queue size, that eventually may be used to fine-tune dequeue operations based on size of the queue of that subscriber. 
 
I don't think so there will be need for WriterTopic as in 0.8. I think we should be able to get Writer topic behaviour with this defined as Topic[F,(W,O)]

I am also thinking on ways how to simplify implementation, which is now WIP. I am thinking on implementing some sort of buffer with low/high watermarks instead keeping buffer per subscriber. But if you have any other idea, please share :-)

