### PR TITLE
Fixed deadlock in awakeEvery

### DIFF
--- a/core/src/main/scala/fs2/Async.scala
+++ b/core/src/main/scala/fs2/Async.scala
@@ -193,14 +193,13 @@ object Async {
   trait Run[F[_]]  {
 
     /**
-     * Asynchronously run this `F` and block until it completes. Performs side effects.
-     * If the evaluation of the `F` terminates with an exception, then the callback
-     * will be called with a `Left(t)`. Otherwise, the callback will be called with
-     * a `Right`.
+     * Asynchronously run this `F`. Performs side effects.
+     * If the evaluation of the `F` terminates with an exception, then the `onError`
+     * callback will be called.
      *
      * Purpose of this combinator is to allow libraries that perform multiple callback
      * (like enqueueing the messages, setting signals) to be written abstract over `F`.
      */
-    def unsafeRunAsyncEffects(f: F[Unit])(cb: Either[Throwable,Unit] => Unit): Unit
+    def unsafeRunAsyncEffects(f: F[Unit])(onError: Throwable => Unit): Unit
   }
 }

--- a/core/src/main/scala/fs2/Async.scala
+++ b/core/src/main/scala/fs2/Async.scala
@@ -189,29 +189,18 @@ object Async {
    */
   case class Change[+A](previous: A, now: A)
 
-
-  /** Used to strictly evaluate `F`. */
+  /** Used to evaluate `F`. */
   trait Run[F[_]]  {
 
     /**
-     * Run this `F` and block until it completes. Performs side effects.
-     * If the evaluation of the `F` terminates with an exception,
-     * then this will return that exception as Optional value.
-     * Otherwise this terminates with None.
-     *
-     * Note that hence this blocks, special care must be taken on thread usage.
-     * Typically, this has to be run off the thread that allows blocking and
-     * is outside the main Executor Service or Scheduler.
-     *
-     * If you run it inside the scheduler or `Strategy` that is used to run
-     * rest of your program you may encounter deadlocks due to thread resources
-     * being used.
-     *
-     * It is not recommended to use this inside user code.
+     * Asynchronously run this `F` and block until it completes. Performs side effects.
+     * If the evaluation of the `F` terminates with an exception, then the callback
+     * will be called with a `Left(t)`. Otherwise, the callback will be called with
+     * a `Right`.
      *
      * Purpose of this combinator is to allow libraries that perform multiple callback
      * (like enqueueing the messages, setting signals) to be written abstract over `F`.
      */
-    def unsafeRunEffects(f: F[Unit]): Option[Throwable]
+    def unsafeRunAsyncEffects(f: F[Unit])(cb: Either[Throwable,Unit] => Unit): Unit
   }
 }

--- a/core/src/main/scala/fs2/time/time.scala
+++ b/core/src/main/scala/fs2/time/time.scala
@@ -29,8 +29,7 @@ package object time {
         F.delay {
           val cancel = scheduler.scheduleAtFixedRate(d, d) {
             val d = FiniteDuration(System.nanoTime, NANOSECONDS) - t0
-            FR.unsafeRunEffects(signal.set(d))
-            ()
+            FR.unsafeRunAsyncEffects(signal.set(d))(_ => ())
           }
           (cancel, signal)
         }

--- a/core/src/main/scala/fs2/util/Task.scala
+++ b/core/src/main/scala/fs2/util/Task.scala
@@ -428,8 +428,8 @@ private[fs2] trait Instances extends Instances1 {
   }
 
   implicit val runInstance: Async.Run[Task] = new Async.Run[Task] {
-    def unsafeRunEffects(f: Task[Unit]): Option[Throwable] =
-      f.unsafeAttemptRun.left.toOption
+    def unsafeRunAsyncEffects(f: Task[Unit])(cb: Either[Throwable,Unit] => Unit) =
+      f.unsafeRunAsync(cb)
     override def toString = "Run[Task]"
   }
 

--- a/core/src/main/scala/fs2/util/Task.scala
+++ b/core/src/main/scala/fs2/util/Task.scala
@@ -427,9 +427,9 @@ private[fs2] trait Instances extends Instances1 {
     override def toString = "Async[Task]"
   }
 
-  implicit val runInstance: Async.Run[Task] = new Async.Run[Task] {
+  implicit def runInstance(implicit S:Strategy): Async.Run[Task] = new Async.Run[Task] {
     def unsafeRunAsyncEffects(f: Task[Unit])(cb: Either[Throwable,Unit] => Unit) =
-      f.unsafeRunAsync(cb)
+      S(f.unsafeRunAsync(cb))
     override def toString = "Run[Task]"
   }
 

--- a/core/src/main/scala/fs2/util/Task.scala
+++ b/core/src/main/scala/fs2/util/Task.scala
@@ -428,8 +428,8 @@ private[fs2] trait Instances extends Instances1 {
   }
 
   implicit def runInstance(implicit S:Strategy): Async.Run[Task] = new Async.Run[Task] {
-    def unsafeRunAsyncEffects(f: Task[Unit])(cb: Either[Throwable,Unit] => Unit) =
-      S(f.unsafeRunAsync(cb))
+    def unsafeRunAsyncEffects(f: Task[Unit])(onError: Throwable => Unit) =
+      S(f.unsafeRunAsync(_.fold(onError, _ => ())))
     override def toString = "Run[Task]"
   }
 

--- a/core/src/test/scala/fs2/time/TimeSpec.scala
+++ b/core/src/test/scala/fs2/time/TimeSpec.scala
@@ -15,6 +15,11 @@ class TimeSpec extends Fs2Spec {
       time.awakeEvery[Task](100.millis).map(_.toMillis/100).take(5).runLog.unsafeRun shouldBe Vector(1,2,3,4,5)
     }
 
+    "awakeEvery liveness" in {
+      val s = time.awakeEvery[Task](1.milli).evalMap { i => Task.async[Unit](cb => S(cb(Right(())))) }.take(200)
+      runLog { concurrent.join(5)(Stream(s, s, s, s, s)) }
+    }
+
     "duration" in {
       val firstValueDiscrepancy = time.duration[Task].take(1).runLog.unsafeRun.last
       val reasonableErrorInMillis = 200

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -675,7 +675,7 @@ trait CSVHandle {
 def rows[F[_]](h: CSVHandle)(implicit F: Async[F], R: Run[F]): Stream[F,Row] =
   for {
     q <- Stream.eval(async.unboundedQueue[F,Either[Throwable,Row]])
-    _ <- Stream.suspend { h.withRows { e => R.unsafeRunEffects(q.enqueue1(e)); () }; Stream.emit(()) }
+    _ <- Stream.suspend { h.withRows { e => R.unsafeRunAsyncEffects(q.enqueue1(e))(_ => ()) }; Stream.emit(()) }
     row <- q.dequeue through pipe.rethrow
   } yield row
 // rows: [F[_]](h: CSVHandle)(implicit F: fs2.Async[F], implicit R: fs2.Async.Run[F])fs2.Stream[F,Row]

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -526,7 +526,7 @@ trait CSVHandle {
 def rows[F[_]](h: CSVHandle)(implicit F: Async[F], R: Run[F]): Stream[F,Row] =
   for {
     q <- Stream.eval(async.unboundedQueue[F,Either[Throwable,Row]])
-    _ <- Stream.suspend { h.withRows { e => R.unsafeRunEffects(q.enqueue1(e)); () }; Stream.emit(()) }
+    _ <- Stream.suspend { h.withRows { e => R.unsafeRunAsyncEffects(q.enqueue1(e))(_ => ()) }; Stream.emit(()) }
     row <- q.dequeue through pipe.rethrow
   } yield row
 ```


### PR DESCRIPTION
Use of `awakeEvery` may deadlock if the `Strategy` is used for things other than `awakeEvery`. See [Gitter](https://gitter.im/functional-streams-for-scala/fs2?at=574301fbd3f431720bb2e335) for discussion.