### PR TITLE
Fixed deadlock in awakeEvery due to synchronous effect evaluation

### DIFF
--- a/core/src/main/scala/fs2/Async.scala
+++ b/core/src/main/scala/fs2/Async.scala
@@ -189,29 +189,17 @@ object Async {
    */
   case class Change[+A](previous: A, now: A)
 
-
-  /** Used to strictly evaluate `F`. */
+  /** Used to evaluate `F`. */
   trait Run[F[_]]  {
 
     /**
-     * Run this `F` and block until it completes. Performs side effects.
-     * If the evaluation of the `F` terminates with an exception,
-     * then this will return that exception as Optional value.
-     * Otherwise this terminates with None.
-     *
-     * Note that hence this blocks, special care must be taken on thread usage.
-     * Typically, this has to be run off the thread that allows blocking and
-     * is outside the main Executor Service or Scheduler.
-     *
-     * If you run it inside the scheduler or `Strategy` that is used to run
-     * rest of your program you may encounter deadlocks due to thread resources
-     * being used.
-     *
-     * It is not recommended to use this inside user code.
+     * Asynchronously run this `F`. Performs side effects.
+     * If the evaluation of the `F` terminates with an exception, then the `onError`
+     * callback will be called.
      *
      * Purpose of this combinator is to allow libraries that perform multiple callback
      * (like enqueueing the messages, setting signals) to be written abstract over `F`.
      */
-    def unsafeRunEffects(f: F[Unit]): Option[Throwable]
+    def unsafeRunAsyncEffects(f: F[Unit])(onError: Throwable => Unit): Unit
   }
 }

--- a/core/src/main/scala/fs2/time/time.scala
+++ b/core/src/main/scala/fs2/time/time.scala
@@ -18,6 +18,12 @@ package object time {
    * different thread pool, or with `Strategy.sequential` on the
    * same thread pool as the scheduler.
    *
+   * Note: for very small values of `d`, it is possible that multiple
+   * periods elapse and only some of those periods are visible in the
+   * stream. This occurs when the scheduler fires faster than
+   * periods are able to be published internally, possibly due to
+   * a `Strategy` that is slow to evaluate.
+   *
    * @param d           FiniteDuration between emits of the resulting stream
    * @param S           Strategy to run the stream
    * @param scheduler   Scheduler used to schedule tasks
@@ -25,12 +31,13 @@ package object time {
   def awakeEvery[F[_]](d: FiniteDuration)(implicit F: Async[F], FR: Async.Run[F], S: Strategy, scheduler: Scheduler): Stream[F,FiniteDuration] = {
     def metronomeAndSignal: F[(()=>Unit,async.mutable.Signal[F,FiniteDuration])] = {
       F.bind(async.signalOf[F, FiniteDuration](FiniteDuration(0, NANOSECONDS))) { signal =>
+        val lock = new java.util.concurrent.Semaphore(1)
         val t0 = FiniteDuration(System.nanoTime, NANOSECONDS)
         F.delay {
           val cancel = scheduler.scheduleAtFixedRate(d, d) {
             val d = FiniteDuration(System.nanoTime, NANOSECONDS) - t0
-            FR.unsafeRunEffects(signal.set(d))
-            ()
+            if (lock.tryAcquire)
+              FR.unsafeRunAsyncEffects(F.map(signal.set(d)) { _ => lock.release })(_ => ())
           }
           (cancel, signal)
         }

--- a/core/src/main/scala/fs2/util/Task.scala
+++ b/core/src/main/scala/fs2/util/Task.scala
@@ -427,9 +427,9 @@ private[fs2] trait Instances extends Instances1 {
     override def toString = "Async[Task]"
   }
 
-  implicit val runInstance: Async.Run[Task] = new Async.Run[Task] {
-    def unsafeRunEffects(f: Task[Unit]): Option[Throwable] =
-      f.unsafeAttemptRun.left.toOption
+  implicit def runInstance(implicit S:Strategy): Async.Run[Task] = new Async.Run[Task] {
+    def unsafeRunAsyncEffects(f: Task[Unit])(onError: Throwable => Unit) =
+      S(f.unsafeRunAsync(_.fold(onError, _ => ())))
     override def toString = "Run[Task]"
   }
 

--- a/core/src/test/scala/fs2/time/TimeSpec.scala
+++ b/core/src/test/scala/fs2/time/TimeSpec.scala
@@ -15,6 +15,11 @@ class TimeSpec extends Fs2Spec {
       time.awakeEvery[Task](100.millis).map(_.toMillis/100).take(5).runLog.unsafeRun shouldBe Vector(1,2,3,4,5)
     }
 
+    "awakeEvery liveness" in {
+      val s = time.awakeEvery[Task](1.milli).evalMap { i => Task.async[Unit](cb => S(cb(Right(())))) }.take(200)
+      runLog { concurrent.join(5)(Stream(s, s, s, s, s)) }
+    }
+
     "duration" in {
       val firstValueDiscrepancy = time.duration[Task].take(1).runLog.unsafeRun.last
       val reasonableErrorInMillis = 200

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -675,7 +675,7 @@ trait CSVHandle {
 def rows[F[_]](h: CSVHandle)(implicit F: Async[F], R: Run[F]): Stream[F,Row] =
   for {
     q <- Stream.eval(async.unboundedQueue[F,Either[Throwable,Row]])
-    _ <- Stream.suspend { h.withRows { e => R.unsafeRunEffects(q.enqueue1(e)); () }; Stream.emit(()) }
+    _ <- Stream.suspend { h.withRows { e => R.unsafeRunAsyncEffects(q.enqueue1(e))(_ => ()) }; Stream.emit(()) }
     row <- q.dequeue through pipe.rethrow
   } yield row
 // rows: [F[_]](h: CSVHandle)(implicit F: fs2.Async[F], implicit R: fs2.Async.Run[F])fs2.Stream[F,Row]

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -526,7 +526,7 @@ trait CSVHandle {
 def rows[F[_]](h: CSVHandle)(implicit F: Async[F], R: Run[F]): Stream[F,Row] =
   for {
     q <- Stream.eval(async.unboundedQueue[F,Either[Throwable,Row]])
-    _ <- Stream.suspend { h.withRows { e => R.unsafeRunEffects(q.enqueue1(e)); () }; Stream.emit(()) }
+    _ <- Stream.suspend { h.withRows { e => R.unsafeRunAsyncEffects(q.enqueue1(e))(_ => ()) }; Stream.emit(()) }
     row <- q.dequeue through pipe.rethrow
   } yield row
 ```


### PR DESCRIPTION
- Changed `Async.Run` to be asynchronous
- Guarded submission of work to the strategy with a semaphore to prevent unbounded growth of thread pool tasks

See [Gitter](https://gitter.im/functional-streams-for-scala/fs2?at=574301fbd3f431720bb2e335) for discussion.