### PR TITLE
Renamed pull.run to pull.close

### DIFF
--- a/core/src/main/scala/fs2/Pull.scala
+++ b/core/src/main/scala/fs2/Pull.scala
@@ -7,7 +7,7 @@ import fs2.util.{Free,RealSupertype,Sub1}
 class Pull[+F[_],+O,+R](private[fs2] val get: Free[P[F,O]#f,Option[Either[Throwable,R]]]) extends PullOps[F,O,R] {
 
   private
-  def run_(asStep: Boolean): Stream[F,O] = Stream.mk { val s = {
+  def close_(asStep: Boolean): Stream[F,O] = Stream.mk { val s = {
     type G[x] = StreamCore[F,O]; type Out = Option[Either[Throwable,R]]
     get.fold[P[F,O]#f,G,Out](
       StreamCore.suspend,
@@ -25,11 +25,11 @@ class Pull[+F[_],+O,+R](private[fs2] val get: Free[P[F,O]#f,Option[Either[Throwa
   }; if (asStep) s else StreamCore.scope(s) }
 
 
-  def run: Stream[F,O] = run_(false)
+  def close: Stream[F,O] = close_(false)
 
-  /** Run this `Pull`, but don't cleanup any resources acquired. */
+  /** Close this `Pull`, but don't cleanup any resources acquired. */
   private[fs2]
-  def runAsStep: Stream[F,O] = run_(true)
+  def closeAsStep: Stream[F,O] = close_(true)
 }
 
 object Pull extends Pulls[Pull] with PullDerived with pull1 {
@@ -93,7 +93,7 @@ object Pull extends Pulls[Pull] with PullDerived with pull1 {
   def pure[R](r: R): Pull[Nothing,Nothing,R] =
     new Pull(Free.pure(Some(Right(r))))
 
-  def run[F[_], O, R](p: Pull[F,O,R]): Stream[F,O] = p.run
+  def close[F[_], O, R](p: Pull[F,O,R]): Stream[F,O] = p.close
 
   private
   def Try[F[_],O,R](p: => Pull[F,O,R]): Pull[F,O,R] =

--- a/core/src/main/scala/fs2/Pulls.scala
+++ b/core/src/main/scala/fs2/Pulls.scala
@@ -52,5 +52,5 @@ trait Pulls[Pull[+_[_],+_,+_]] {
   def or[F[_],O,R](p1: Pull[F,O,R], p2: => Pull[F,O,R]): Pull[F,O,R]
 
   /** Interpret this `Pull` to produce a `Stream`. The result type `R` is discarded. */
-  def run[F[_],O,R](p: Pull[F,O,R]): Stream[F,O]
+  def close[F[_],O,R](p: Pull[F,O,R]): Stream[F,O]
 }

--- a/core/src/main/scala/fs2/pipe.scala
+++ b/core/src/main/scala/fs2/pipe.scala
@@ -482,7 +482,7 @@ object pipe {
     = s.buffer match {
         case hd :: tl => Free.pure(Some(Step(hd, new Handle[Read,O](tl, s.stream))))
         case List() => s.stream.step.flatMap { s => Pull.output1(s) }
-         .run.runFoldFree(None: Option[Step[Chunk[O],Handle[Read, O]]])(
+         .close.runFoldFree(None: Option[Step[Chunk[O],Handle[Read, O]]])(
           (_,s) => Some(s))
       }
     def go(s: Free[Read, Option[Step[Chunk[O],Handle[Read, O]]]]): Stepper[I,O] =

--- a/core/src/main/scala/fs2/pipe2.scala
+++ b/core/src/main/scala/fs2/pipe2.scala
@@ -139,7 +139,7 @@ object pipe2 {
     = s.buffer match {
         case hd :: tl => Free.pure(Some(Step(hd, new Handle[Read,O](tl, s.stream))))
         case List() => s.stream.step.flatMap { s => Pull.output1(s) }
-         .run.runFoldFree(None: Option[Step[Chunk[O],Handle[Read, O]]])(
+         .close.runFoldFree(None: Option[Step[Chunk[O],Handle[Read, O]]])(
           (_,s) => Some(s))
       }
     def go(s: Free[Read, Option[Step[Chunk[O],Handle[Read, O]]]]): Stepper[I,I2,O] =

--- a/core/src/main/scala/fs2/text.scala
+++ b/core/src/main/scala/fs2/text.scala
@@ -64,7 +64,7 @@ object text {
       }
     }
 
-    pipe.covary[F, Chunk[Byte], String](_.open.flatMap(doPull(Chunk.empty) _).run)
+    pipe.covary[F, Chunk[Byte], String](_.open.flatMap(doPull(Chunk.empty) _).close)
   }
 
   /** Encodes a stream of `String` in to a stream of bytes using the UTF-8 charset. */

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -409,7 +409,7 @@ So this line is writing the chunk we read, ignoring the `Unit` result, then recu
 
 For the recursive call, we update the state, subtracting the `chunk.size` elements we've seen. Easy!
 
-To actually use a `Pull` to transform a `Stream`, we have to `run` it:
+To actually use a `Pull` to transform a `Stream`, we have to `close` it:
 
 ```scala
 scala> val s2 = Stream(1,2,3,4).pure.pull(Pull_.take(2))
@@ -427,14 +427,14 @@ res36: List[Int] = List(1, 2)
 
 _Note:_ The `.pure` converts a `Stream[Nothing,A]` to a `Stream[Pure,A]`. Scala will not infer `Nothing` for a type parameter, so using `Pure` as the effect provides better type inference in some cases.
 
-The `pull` method on `Stream` just calls `open` then `run`. We could express the above as:
+The `pull` method on `Stream` just calls `open` then `close`. We could express the above as:
 
 ```scala
-scala> Stream(1,2,3,4).pure.open.flatMap { Pull_.take(2) }.run
+scala> Stream(1,2,3,4).pure.open.flatMap { Pull_.take(2) }.close
 res37: fs2.Stream[[x]fs2.Pure[x],Int] = evalScope(Scope(Bind(Eval(Snapshot),<function1>))).flatMap(<function1>)
 ```
 
-FS2 takes care to guarantee that any resources allocated by the `Pull` are released when the `run` completes. Note again that _nothing happens_ when we call `.run` on a `Pull`, it is merely establishing a scope in which all resource allocations are tracked so that they may be appropriately freed.
+FS2 takes care to guarantee that any resources allocated by the `Pull` are released when the `close` completes. Note again that _nothing happens_ when we call `.close` on a `Pull`, it is merely establishing a scope in which all resource allocations are tracked so that they may be appropriately freed.
 
 There are lots of useful transformation functions in [`pipe`](../core/src/scala/main/fs2/pipe) and [`pipe2`](../core/src/main/fs2/pipe2) built using the `Pull` type, for example:
 

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -313,7 +313,7 @@ So this line is writing the chunk we read, ignoring the `Unit` result, then recu
 
 For the recursive call, we update the state, subtracting the `chunk.size` elements we've seen. Easy!
 
-To actually use a `Pull` to transform a `Stream`, we have to `run` it:
+To actually use a `Pull` to transform a `Stream`, we have to `close` it:
 
 ```tut
 val s2 = Stream(1,2,3,4).pure.pull(Pull_.take(2))
@@ -324,13 +324,13 @@ s3.toList
 
 _Note:_ The `.pure` converts a `Stream[Nothing,A]` to a `Stream[Pure,A]`. Scala will not infer `Nothing` for a type parameter, so using `Pure` as the effect provides better type inference in some cases.
 
-The `pull` method on `Stream` just calls `open` then `run`. We could express the above as:
+The `pull` method on `Stream` just calls `open` then `close`. We could express the above as:
 
 ```tut
-Stream(1,2,3,4).pure.open.flatMap { Pull_.take(2) }.run
+Stream(1,2,3,4).pure.open.flatMap { Pull_.take(2) }.close
 ```
 
-FS2 takes care to guarantee that any resources allocated by the `Pull` are released when the `run` completes. Note again that _nothing happens_ when we call `.run` on a `Pull`, it is merely establishing a scope in which all resource allocations are tracked so that they may be appropriately freed.
+FS2 takes care to guarantee that any resources allocated by the `Pull` are released when the `close` completes. Note again that _nothing happens_ when we call `.close` on a `Pull`, it is merely establishing a scope in which all resource allocations are tracked so that they may be appropriately freed.
 
 There are lots of useful transformation functions in [`pipe`](../core/src/scala/main/fs2/pipe) and [`pipe2`](../core/src/main/fs2/pipe2) built using the `Pull` type, for example:
 

--- a/io/src/main/scala/fs2/io/file/package.scala
+++ b/io/src/main/scala/fs2/io/file/package.scala
@@ -29,13 +29,13 @@ package object file {
     * Reads all data synchronously from the file at the specified `java.nio.file.Path`.
     */
   def readAll[F[_]](path: Path, chunkSize: Int)(implicit F: Effect[F]): Stream[F, Byte] =
-    pulls.fromPath(path, List(StandardOpenOption.READ)).flatMap(pulls.readAllFromFileHandle(chunkSize)).run
+    pulls.fromPath(path, List(StandardOpenOption.READ)).flatMap(pulls.readAllFromFileHandle(chunkSize)).close
 
   /**
     * Reads all data asynchronously from the file at the specified `java.nio.file.Path`.
     */
   def readAllAsync[F[_]](path: Path, chunkSize: Int)(implicit F: Async[F], S: Strategy): Stream[F, Byte] =
-    pulls.fromPathAsync(path, List(StandardOpenOption.READ)).flatMap(pulls.readAllFromFileHandle(chunkSize)).run
+    pulls.fromPathAsync(path, List(StandardOpenOption.READ)).flatMap(pulls.readAllFromFileHandle(chunkSize)).close
 
   //
   // Stream transducers
@@ -51,7 +51,7 @@ package object file {
       in <- s.open
       out <- pulls.fromPath(path, StandardOpenOption.WRITE :: flags.toList)
       _ <- pulls.writeAllToFileHandle(in, out)
-    } yield ()).run
+    } yield ()).close
 
   /**
     * Writes all data asynchronously to the file at the specified `java.nio.file.Path`.
@@ -63,7 +63,7 @@ package object file {
       in <- s.open
       out <- pulls.fromPathAsync(path, StandardOpenOption.WRITE :: flags.toList)
       _ <- _writeAll0(in, out, 0)
-    } yield ()).run
+    } yield ()).close
 
   private def _writeAll0[F[_]](in: Handle[F, Byte], out: FileHandle[F], offset: Long): Pull[F, Nothing, Unit] = for {
     hd #: tail <- in.await


### PR DESCRIPTION
I think `close` is clearer for folks learning the library:
 - `close` helps separate the act of closing a pull from the act of running a stream
 - symmetrical with `open` on `Stream`