### PR TITLE
Remove unused suspend method in Free monad instance

### DIFF
--- a/core/src/main/scala/fs2/util/Free.scala
+++ b/core/src/main/scala/fs2/util/Free.scala
@@ -171,6 +171,5 @@ object Free {
   new Monad[({ type f[x] = Free[F,x]})#f] {
     def pure[A](a: A) = Pure(a)
     def bind[A,B](a: Free[F,A])(f: A => Free[F,B]) = a flatMap f
-    def suspend[A](a: => A): Free[F, A] = Free.suspend(Free.pure(a))
   }
 }


### PR DESCRIPTION
Remove unused `suspend` method left over from moving delay/suspend to `Effect`.