### PR TITLE
Changed signature of SIgnal.modify

### DIFF
--- a/core/src/main/scala/fs2/Async.scala
+++ b/core/src/main/scala/fs2/Async.scala
@@ -189,6 +189,13 @@ object Async {
    */
   case class Change[+A](previous: A, now: A)
 
+  object Change {
+    implicit class ChangeSyntax[A](val self:Change[A]) extends AnyVal {
+      def modified: Boolean = self.previous != self.now
+      def map[B](f: A => B):Change[B] = Change(f(self.previous), f(self.now))
+    }
+  }
+
   /** Used to evaluate `F`. */
   trait Run[F[_]]  {
 


### PR DESCRIPTION
@mpilquist like we have discussed earlier. This changes signature of `modify` to be almost the same like `modify` in `Async`. Furthermore this simplifies signal's state and removes the `Semaphore` from the implementation. 