### PR TITLE
Fixed bug in channel.observe where observing with a finite sink caused hangs

### DIFF
--- a/core/src/test/scala/fs2/async/ChannelSpec.scala
+++ b/core/src/test/scala/fs2/async/ChannelSpec.scala
@@ -37,6 +37,19 @@ class ChannelSpec extends Fs2Spec {
           } should contain theSameElementsAs Left(Err) +: s.get.toVector.map(Right(_))
         }
       }
+      "handle finite observing sink" in {
+        forAll { (s: PureStream[Int]) =>
+          runLog {
+            channel.observe(s.get.covary[Task]) { _ => Stream.empty }
+          } should contain theSameElementsAs s.get.toVector
+          runLog {
+            channel.observe(s.get.covary[Task]) { _.take(2).drain }
+          } should contain theSameElementsAs s.get.toVector
+          runLog {
+            channel.observeAsync(s.get.covary[Task], 2) { _ => Stream.empty }
+          } should contain theSameElementsAs s.get.toVector
+        }
+      }
     }
 
     "sanity-test" in {


### PR DESCRIPTION
I don't love this implementation but it works... Review by @pchiusano.