### PR TITLE
Fix @implicitNotFound hint about required Strategy

### DIFF
--- a/core/src/main/scala/fs2/Async.scala
+++ b/core/src/main/scala/fs2/Async.scala
@@ -3,7 +3,7 @@ package fs2
 import Async.{Change,Future}
 import fs2.util.{Free,Functor,Effect}
 
-@annotation.implicitNotFound("No implicit `Async[${F}]` found.\nNote that the implicit `Async[fs2.util.Task]` requires an implicit `fs2.util.Strategy` in scope.")
+@annotation.implicitNotFound("No implicit `Async[${F}]` found.\nNote that the implicit `Async[fs2.util.Task]` requires an implicit `fs2.Strategy` in scope.")
 trait Async[F[_]] extends Effect[F] { self =>
   type Ref[A]
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -491,7 +491,7 @@ FS2 comes with lots of concurrent operations. The `merge` function runs two stre
 ```scala
 scala> Stream(1,2,3).merge(Stream.eval(Task.delay { Thread.sleep(200); 4 })).runLog.unsafeRun
 <console>:17: error: No implicit `Async[fs2.util.Task]` found.
-Note that the implicit `Async[fs2.util.Task]` requires an implicit `fs2.util.Strategy` in scope.
+Note that the implicit `Async[fs2.util.Task]` requires an implicit `fs2.Strategy` in scope.
        Stream(1,2,3).merge(Stream.eval(Task.delay { Thread.sleep(200); 4 })).runLog.unsafeRun
                           ^
 ```


### PR DESCRIPTION
When `Strategy` was moved from `fs2.util`, the package name in this hint wasn't changed.