### PR TITLE
Miscellaneous cleanup and consistency in IO package

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,7 @@ lazy val commonSettings = Seq(
 lazy val testSettings = Seq(
   parallelExecution in Test := false,
   testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
-  fork in Test := true,
+  // fork in Test := true, Causes issues on Travis
   publishArtifact in Test := true
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -50,6 +50,7 @@ lazy val commonSettings = Seq(
 lazy val testSettings = Seq(
   parallelExecution in Test := false,
   testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
+  fork in Test := true,
   publishArtifact in Test := true
 )
 

--- a/core/src/main/scala/fs2/Chunk.scala
+++ b/core/src/main/scala/fs2/Chunk.scala
@@ -142,7 +142,7 @@ object Chunk {
     new Booleans(values, 0, values.length)
 
   def booleans(values: Array[Boolean], offset: Int, size: Int): Chunk[Boolean] = {
-    require(offset >= 0 && offset < values.size)
+    require(offset >= 0 && offset <= values.size)
     require(offset + size <= values.size)
     new Booleans(values, offset, size)
   }
@@ -151,7 +151,7 @@ object Chunk {
     new Bytes(values, 0, values.length)
 
   def bytes(values: Array[Byte], offset: Int, size: Int): Chunk[Byte] = {
-    require(offset >= 0 && offset < values.size)
+    require(offset >= 0 && offset <= values.size)
     require(offset + size <= values.size)
     new Bytes(values, offset, size)
   }
@@ -160,7 +160,7 @@ object Chunk {
     new Longs(values, 0, values.length)
 
   def longs(values: Array[Long], offset: Int, size: Int): Chunk[Long] = {
-    require(offset >= 0 && offset < values.size)
+    require(offset >= 0 && offset <= values.size)
     require(offset + size <= values.size)
     new Longs(values, offset, size)
   }
@@ -169,7 +169,7 @@ object Chunk {
     new Doubles(values, 0, values.length)
 
   def doubles(values: Array[Double], offset: Int, size: Int): Chunk[Double] = {
-    require(offset >= 0 && offset < values.size)
+    require(offset >= 0 && offset <= values.size)
     require(offset + size <= values.size)
     new Doubles(values, offset, size)
   }

--- a/core/src/main/scala/fs2/async/mutable/Queue.scala
+++ b/core/src/main/scala/fs2/async/mutable/Queue.scala
@@ -21,6 +21,12 @@ trait Queue[F[_],A] {
   def enqueue1(a: A): F[Unit]
 
   /**
+   * Enqueues each element of the input stream to this `Queue` by
+   * calling `enqueue1` on each element.
+   */
+  def enqueue: Sink[F, A] = _.evalMap(enqueue1)
+
+  /**
    * Offers one element in this `Queue`.
    *
    * Evaluates to `false` if the queue is full, indicating the `a` was not queued up.
@@ -30,11 +36,11 @@ trait Queue[F[_],A] {
    */
   def offer1(a: A): F[Boolean]
 
-  /** Repeatedly call `dequeue1` forever. */
-  def dequeue: Stream[F, A] = Stream.repeatEval(dequeue1)
-
   /** Dequeue one `A` from this queue. Completes once one is ready. */
   def dequeue1: F[A]
+
+  /** Repeatedly call `dequeue1` forever. */
+  def dequeue: Stream[F, A] = Stream.repeatEval(dequeue1)
 
   /**
    * The time-varying size of this `Queue`. This signal refreshes

--- a/core/src/test/scala/fs2/ChunkSpec.scala
+++ b/core/src/test/scala/fs2/ChunkSpec.scala
@@ -1,6 +1,5 @@
 package fs2
 
-import fs2.Chunk.{Longs, Doubles, Bytes, Booleans}
 import org.scalacheck.{Gen, Arbitrary}
 
 import scala.reflect.ClassTag
@@ -15,7 +14,7 @@ class ChunkSpec extends Fs2Spec {
         values <- Gen.containerOfN[Array, Boolean](n, Arbitrary.arbBool.arbitrary)
         offset <- Gen.choose(0, n)
         sz <- Gen.choose(0, n - offset)
-      } yield new Booleans(values, offset, sz)
+      } yield Chunk.booleans(values, offset, sz)
     }
 
     implicit val arbByteChunk: Arbitrary[Chunk[Byte]] = Arbitrary {
@@ -24,7 +23,7 @@ class ChunkSpec extends Fs2Spec {
         values <- Gen.containerOfN[Array, Byte](n, Arbitrary.arbByte.arbitrary)
         offset <- Gen.choose(0, n)
         sz <- Gen.choose(0, n - offset)
-      } yield new Bytes(values, offset, sz)
+      } yield Chunk.bytes(values, offset, sz)
     }
 
     implicit val arbDoubleChunk: Arbitrary[Chunk[Double]] = Arbitrary {
@@ -33,7 +32,7 @@ class ChunkSpec extends Fs2Spec {
         values <- Gen.containerOfN[Array, Double](n, Arbitrary.arbDouble.arbitrary)
         offset <- Gen.choose(0, n)
         sz <- Gen.choose(0, n - offset)
-      } yield new Doubles(values, offset, sz)
+      } yield Chunk.doubles(values, offset, sz)
     }
 
     implicit val arbLongChunk: Arbitrary[Chunk[Long]] = Arbitrary {
@@ -42,7 +41,7 @@ class ChunkSpec extends Fs2Spec {
         values <- Gen.containerOfN[Array, Long](n, Arbitrary.arbLong.arbitrary)
         offset <- Gen.choose(0, n)
         sz <- Gen.choose(0, n - offset)
-      } yield new Longs(values, offset, sz)
+      } yield Chunk.longs(values, offset, sz)
     }
 
     def checkSize[A](c: Chunk[A]) = c.size shouldBe c.toVector.size

--- a/io/src/main/scala/fs2/io/tcp/tcp.scala
+++ b/io/src/main/scala/fs2/io/tcp/tcp.scala
@@ -7,7 +7,6 @@ import fs2._
 
 package object tcp {
 
-
   /**
     * Process that connects to remote server (TCP) and runs the stream `ouput`.
     *
@@ -27,8 +26,6 @@ package object tcp {
     , noDelay: Boolean = false
   )( implicit AG: AsynchronousChannelGroup, F: Async[F], FR: Async.Run[F]): Stream[F,Socket[F]] =
   Socket.client(to,reuseAddress,sendBufferSize,receiveBufferSize,keepAlive,noDelay)
-
-
 
   /**
     * Process that binds to supplied address and handles incoming TCP connections
@@ -54,5 +51,4 @@ package object tcp {
     implicit AG: AsynchronousChannelGroup, F: Async[F], FR: Async.Run[F]
   ): Stream[F, Stream[F, Socket[F]]] =
   Socket.server(bind,maxQueued,reuseAddress,receiveBufferSize)
-
 }

--- a/io/src/main/scala/fs2/io/udp/AsynchronousSocketGroup.scala
+++ b/io/src/main/scala/fs2/io/udp/AsynchronousSocketGroup.scala
@@ -125,15 +125,20 @@ object AsynchronousSocketGroup {
 
     private def read1(key: SelectionKey, channel: DatagramChannel, attachment: Attachment, reader: Either[Throwable,Packet] => Unit): Boolean = {
       readBuffer.clear
-      val src = channel.receive(readBuffer).asInstanceOf[InetSocketAddress]
-      if (src eq null) {
-        false
-      } else {
-        readBuffer.flip
-        val bytes = Array.ofDim[Byte](readBuffer.remaining)
-        readBuffer.get(bytes)
-        readBuffer.clear
-        reader(Right(new Packet(src, Chunk.bytes(bytes))))
+      try {
+        val src = channel.receive(readBuffer).asInstanceOf[InetSocketAddress]
+        if (src eq null) {
+          false
+        } else {
+          readBuffer.flip
+          val bytes = Array.ofDim[Byte](readBuffer.remaining)
+          readBuffer.get(bytes)
+          readBuffer.clear
+          reader(Right(new Packet(src, Chunk.bytes(bytes))))
+          true
+        }
+      } catch {
+        case t: IOException => reader(Left(t))
         true
       }
     }

--- a/io/src/main/scala/fs2/io/udp/udp.scala
+++ b/io/src/main/scala/fs2/io/udp/udp.scala
@@ -13,7 +13,7 @@ package object udp {
    * @param remote   remote party to send/receive packet to/from
    * @param bytes    data to send/receive
    */
-  case class Packet(remote: InetSocketAddress, bytes: Chunk.Bytes)
+  case class Packet(remote: InetSocketAddress, bytes: Chunk[Byte])
 
   /**
    * Provides a singleton stream of a UDP Socket that when run will bind to specified adress

--- a/io/src/test/scala/fs2/io/udp/UdpSpec.scala
+++ b/io/src/test/scala/fs2/io/udp/UdpSpec.scala
@@ -35,11 +35,12 @@ class UdpSpec extends Fs2Spec with BeforeAndAfterAll {
     }
 
     "echo lots" in {
-      val msgs = (1 to 100).toVector.map { n => Chunk.bytes(("Hello, world! " + n).getBytes) }
-      val numClients = 100
-      val numParallelClients = 20
+      val msgs = (1 to 20).toVector.map { n => Chunk.bytes(("Hello, world! " + n).getBytes) }
+      val numClients = 50
+      val numParallelClients = 10
       runLog {
         open[Task]().flatMap { serverSocket =>
+          var log = false
           Stream.eval(serverSocket.localAddress).map { _.getPort }.flatMap { serverPort =>
             val serverAddress = new InetSocketAddress("localhost", serverPort)
             val server = serverSocket.reads.evalMap { packet => serverSocket.write(packet) }.drain


### PR DESCRIPTION
- Optimized udp implementation
- Changed tcp to work on `Stream[F,Byte]`, and utilizing the underlying
  chunk structure
- Changed chunk constructors to return `Chunk[X]` to prevent type
  inference issues

Review by @pchlupacek 