### PR TITLE
Added io.tcp.serverWithLocalAddress 

### DIFF
--- a/io/src/main/scala/fs2/io/tcp/Socket.scala
+++ b/io/src/main/scala/fs2/io/tcp/Socket.scala
@@ -146,7 +146,7 @@ protected[tcp] object Socket {
     implicit AG: AsynchronousChannelGroup
     , F:Async[F]
     , FR:Async.Run[F]
-  ): Stream[F, Stream[F, Socket[F]]] = Stream.suspend {
+  ): Stream[F, Either[InetSocketAddress, Stream[F, Socket[F]]]] = Stream.suspend {
 
       def setup: F[AsynchronousServerSocketChannel] = F.delay {
         val ch = AsynchronousChannelProvider.provider().openAsynchronousServerSocketChannel(AG)
@@ -189,7 +189,7 @@ protected[tcp] object Socket {
         }
       }
 
-      Stream.bracket(setup)(sch => acceptIncoming(sch), cleanup)
+      Stream.bracket(setup)(sch => Stream.emit(Left(sch.getLocalAddress.asInstanceOf[InetSocketAddress])) ++ acceptIncoming(sch).map(Right(_)), cleanup)
   }
 
 

--- a/io/src/main/scala/fs2/io/tcp/tcp.scala
+++ b/io/src/main/scala/fs2/io/tcp/tcp.scala
@@ -50,5 +50,17 @@ package object tcp {
     , receiveBufferSize: Int = 256 * 1024)(
     implicit AG: AsynchronousChannelGroup, F: Async[F], FR: Async.Run[F]
   ): Stream[F, Stream[F, Socket[F]]] =
-  Socket.server(bind,maxQueued,reuseAddress,receiveBufferSize)
+    serverWithLocalAddress(bind, maxQueued, reuseAddress, receiveBufferSize).collect { case Right(s) => s }
+
+   /**
+    * Like [[server]] but provides the `InetSocketAddress` of the bound server socket before providing accepted sockets.
+    */
+  def serverWithLocalAddress[F[_]](
+    bind: InetSocketAddress
+    , maxQueued: Int = 0
+    , reuseAddress: Boolean = true
+    , receiveBufferSize: Int = 256 * 1024)(
+    implicit AG: AsynchronousChannelGroup, F: Async[F], FR: Async.Run[F]
+  ): Stream[F, Either[InetSocketAddress, Stream[F, Socket[F]]]] =
+    Socket.server(bind,maxQueued,reuseAddress,receiveBufferSize)
 }

--- a/io/src/test/scala/fs2/io/TestUtil.scala
+++ b/io/src/test/scala/fs2/io/TestUtil.scala
@@ -26,16 +26,10 @@ object TestUtil {
           })
           t
         }
-
       }
     )
   }
 
-
-
   def localAddress(port: Int) = new InetSocketAddress("localhost", port)
-  val localBindAddress = localAddress(9999)
-
-
-
 }
+


### PR DESCRIPTION
...which provides the address of the bound server socket, allowing use of ephemeral port numbers in servers.

This might help with Travis failures if the root cause of them is that port 9999 is in use.