### PR TITLE
Fixes memory leak in concurrent.join and signal.discrete

### DIFF
--- a/core/src/main/scala/fs2/PullDerived.scala
+++ b/core/src/main/scala/fs2/PullDerived.scala
@@ -6,9 +6,9 @@ trait PullDerived { self: fs2.Pull.type =>
    * Acquire a resource within a `Pull`. The cleanup action will be run at the end
    * of the `.run` scope which executes the returned `Pull`.
    */
-  def acquire[F[_],R](r: F[R])(cleanup: R => F[Unit]): Pull[F,Nothing,R] =
-    Stream.bracket(r)(Stream.emit, cleanup).open.flatMap { h => h.await1.flatMap {
-      case r #: _ => Pull.pure(r)
+  def acquire[F[_],R](r: F[R])(cleanup: R => F[Unit]): Pull[F,Nothing,(Pull[F,Nothing,Unit],R)] =
+    Stream.bracketWithToken(r)(Stream.emit, cleanup).open.flatMap { h => h.await1.flatMap {
+      case (token, r) #: _ => Pull.pure((Pull.release(List(token)), r))
     }}
 
   def map[F[_],W,R0,R](p: Pull[F,W,R0])(f: R0 => R): Pull[F,W,R] =

--- a/core/src/main/scala/fs2/concurrent.scala
+++ b/core/src/main/scala/fs2/concurrent.scala
@@ -50,7 +50,7 @@ object concurrent {
                      onFinalize {
                        F.bind(F.setPure(gate)(())) { _ =>
                          F.bind(F.get(earlyReleaseRef)) { earlyRelease =>
-                           F.map(F.start(doneQueue.enqueue1(earlyRelease)))(_ => ())
+                           F.map(doneQueue.enqueue1(earlyRelease))(_ => ())
                          }
                        }
                      }.

--- a/core/src/main/scala/fs2/concurrent.scala
+++ b/core/src/main/scala/fs2/concurrent.scala
@@ -57,7 +57,7 @@ object concurrent {
                      run
             )) { _ => gate }}
           }
-          Pull.acquire(startInnerStream) { gate => F.get(gate) }.flatMap { case (release, _) => Pull.eval(F.setPure(earlyReleaseRef)(release)) }
+          Pull.acquireCancellable(startInnerStream) { gate => F.get(gate) }.flatMap { case (release, _) => Pull.eval(F.setPure(earlyReleaseRef)(release)) }
         }
       }
 

--- a/core/src/main/scala/fs2/concurrent.scala
+++ b/core/src/main/scala/fs2/concurrent.scala
@@ -40,33 +40,38 @@ object concurrent {
 
     def throttle[A](checkIfKilled: F[Boolean]): Pipe[F,Stream[F,A],Unit] = {
 
-      def runInnerStream(inner: Stream[F,A], onInnerStreamDone: F[Unit]): Pull[F,Nothing,Unit] = {
-        Pull.eval(F.ref[Pull[F,Nothing,Unit]]).flatMap { doneRef =>
+      def runInnerStream(inner: Stream[F,A], doneQueue: async.mutable.Queue[F,Pull[F,Nothing,Unit]]): Pull[F,Nothing,Unit] = {
+        Pull.eval(F.ref[Pull[F,Nothing,Unit]]).flatMap { earlyReleaseRef =>
           val startInnerStream: F[F.Ref[Unit]] = {
             F.bind(F.ref[Unit]) { gate =>
             F.map(F.start(
               Stream.eval(checkIfKilled).
                      flatMap { killed => if (killed) Stream.empty else inner }.
-                     onFinalize { F.bind(F.setPure(gate)(())) { _ => onInnerStreamDone } }.
-                     onComplete { Stream.eval(F.get(doneRef)).flatMap { _.close } }.
+                     onFinalize {
+                       F.bind(F.setPure(gate)(())) { _ =>
+                         F.bind(F.get(earlyReleaseRef)) { earlyRelease =>
+                           F.map(F.start(doneQueue.enqueue1(earlyRelease)))(_ => ())
+                         }
+                       }
+                     }.
                      run
             )) { _ => gate }}
           }
-          Pull.acquire(startInnerStream) { gate => F.get(gate) }.flatMap { case (release, _) => Pull.eval(F.setPure(doneRef)(release)) }
+          Pull.acquire(startInnerStream) { gate => F.get(gate) }.flatMap { case (release, _) => Pull.eval(F.setPure(earlyReleaseRef)(release)) }
         }
       }
 
-      def go(doneQueue: async.mutable.Queue[F,Unit])(open: Int): (Stream.Handle[F,Stream[F,A]], Stream.Handle[F,Unit]) => Pull[F,Nothing,Unit] = (h, d) => {
+      def go(doneQueue: async.mutable.Queue[F,Pull[F,Nothing,Unit]])(open: Int): (Stream.Handle[F,Stream[F,A]], Stream.Handle[F,Pull[F,Nothing,Unit]]) => Pull[F,Nothing,Unit] = (h, d) => {
         if (open < maxOpen)
           Pull.receive1Option[F,Stream[F,A],Nothing,Unit] {
-            case Some(inner #: h) => runInnerStream(inner, F.map(F.start(doneQueue.enqueue1(())))(_ => ())).flatMap { gate => go(doneQueue)(open + 1)(h, d) }
+            case Some(inner #: h) => runInnerStream(inner, doneQueue).flatMap { gate => go(doneQueue)(open + 1)(h, d) }
             case None => Pull.done
           }(h)
         else
-          d.receive1 { case _ #: d => go(doneQueue)(open - 1)(h, d) }
+          d.receive1 { case earlyRelease #: d => earlyRelease >> go(doneQueue)(open - 1)(h, d) }
       }
 
-      in => Stream.eval(async.unboundedQueue[F,Unit]).flatMap { doneQueue => in.pull2(doneQueue.dequeue)(go(doneQueue)(0)) }
+      in => Stream.eval(async.unboundedQueue[F,Pull[F,Nothing,Unit]]).flatMap { doneQueue => in.pull2(doneQueue.dequeue)(go(doneQueue)(0)) }
     }
 
     for {

--- a/core/src/test/scala/fs2/MemorySanityChecks.scala
+++ b/core/src/test/scala/fs2/MemorySanityChecks.scala
@@ -39,3 +39,8 @@ object DrainOnCompleteSanityTest extends App {
   val s = Stream.repeatEval(Task.delay(1)).pull(Pull.echo).drain.onComplete(Stream.eval_(Task.delay(println("done"))))
   (Stream.empty[Task, Unit] merge s).run.unsafeRun()
 }
+
+object ConcurrentJoinSanityTest extends App {
+  import TestUtil.S
+  concurrent.join(5)(Stream.constant(Stream.empty).covary[Task]).run.unsafeRun
+}

--- a/core/src/test/scala/fs2/MemorySanityChecks.scala
+++ b/core/src/test/scala/fs2/MemorySanityChecks.scala
@@ -44,3 +44,10 @@ object ConcurrentJoinSanityTest extends App {
   import TestUtil.S
   concurrent.join(5)(Stream.constant(Stream.empty).covary[Task]).run.unsafeRun
 }
+
+object DanglingDequeueSanityTest extends App {
+  import TestUtil.S
+  Stream.eval(async.unboundedQueue[Task,Int]).flatMap { q =>
+    Stream.constant(1).flatMap { _ => Stream.empty mergeHaltBoth q.dequeue }
+  }.run.unsafeRun
+}

--- a/core/src/test/scala/fs2/async/TopicSpec.scala
+++ b/core/src/test/scala/fs2/async/TopicSpec.scala
@@ -51,7 +51,7 @@ class TopicSpec extends Fs2Spec {
       result.toMap.size shouldBe subs
 
       result.foreach { case (idx, subResults) =>
-        val diff:Set[Int] = subResults.map{ case (read, state) => Math.abs(state -  read) }.toSet
+        val diff:Set[Int] = subResults.map { case (read, state) => Math.abs(state - read) }.toSet
         assert( diff.min == 0 || diff.min == 1)
         assert( diff.max == 0 || diff.max == 1)
       }

--- a/io/src/main/scala/fs2/io/file/pulls.scala
+++ b/io/src/main/scala/fs2/io/file/pulls.scala
@@ -66,7 +66,7 @@ object pulls {
     * The `Pull` closes the provided `java.nio.channels.FileChannel` when it is done.
     */
   def fromFileChannel[F[_]](channel: F[FileChannel])(implicit F: Effect[F]): Pull[F, Nothing, FileHandle[F]] =
-    Pull.acquire(F.map(channel)(FileHandle.fromFileChannel[F]))(_.close()).map { case (_, ch) => ch }
+    Pull.acquire(F.map(channel)(FileHandle.fromFileChannel[F]))(_.close())
 
   /**
     * Given a `java.nio.channels.AsynchronousFileChannel`, will create a `Pull` which allows asynchronous operations against the underlying file.
@@ -74,5 +74,5 @@ object pulls {
     * The `Pull` closes the provided `java.nio.channels.AsynchronousFileChannel` when it is done.
     */
   def fromAsynchronousFileChannel[F[_]](channel: F[AsynchronousFileChannel])(implicit F: Async[F], FR: Async.Run[F]): Pull[F, Nothing, FileHandle[F]] =
-    Pull.acquire(F.map(channel)(FileHandle.fromAsynchronousFileChannel[F]))(_.close()).map { case (_, ch) => ch }
+    Pull.acquire(F.map(channel)(FileHandle.fromAsynchronousFileChannel[F]))(_.close())
 }

--- a/io/src/main/scala/fs2/io/file/pulls.scala
+++ b/io/src/main/scala/fs2/io/file/pulls.scala
@@ -66,7 +66,7 @@ object pulls {
     * The `Pull` closes the provided `java.nio.channels.FileChannel` when it is done.
     */
   def fromFileChannel[F[_]](channel: F[FileChannel])(implicit F: Effect[F]): Pull[F, Nothing, FileHandle[F]] =
-    Pull.acquire(F.map(channel)(FileHandle.fromFileChannel[F]))(_.close())
+    Pull.acquire(F.map(channel)(FileHandle.fromFileChannel[F]))(_.close()).map { case (_, ch) => ch }
 
   /**
     * Given a `java.nio.channels.AsynchronousFileChannel`, will create a `Pull` which allows asynchronous operations against the underlying file.
@@ -74,5 +74,5 @@ object pulls {
     * The `Pull` closes the provided `java.nio.channels.AsynchronousFileChannel` when it is done.
     */
   def fromAsynchronousFileChannel[F[_]](channel: F[AsynchronousFileChannel])(implicit F: Async[F], FR: Async.Run[F]): Pull[F, Nothing, FileHandle[F]] =
-    Pull.acquire(F.map(channel)(FileHandle.fromAsynchronousFileChannel[F]))(_.close())
+    Pull.acquire(F.map(channel)(FileHandle.fromAsynchronousFileChannel[F]))(_.close()).map { case (_, ch) => ch }
 }


### PR DESCRIPTION
Note that we have a similar memory leak as the one in signal in queue.dequeue

Review by @pchiusano & @pchlupacek 