### PR TITLE
Add failing test case for Task onFinish

### DIFF
--- a/core/src/test/scala/fs2/ResourceSafetySpec.scala
+++ b/core/src/test/scala/fs2/ResourceSafetySpec.scala
@@ -180,6 +180,14 @@ class ResourceSafetySpec extends Fs2Spec with org.scalatest.concurrent.Eventuall
       eventually { c.get shouldBe 0L }
     }
 
+    "preempted Task onFinish" in {
+      val c = new AtomicLong(0L)
+      val increment = Task.delay { c.incrementAndGet; () }
+      val slowStuff = Task.delay { Thread.sleep(100) } onFinish { _ => increment }
+      slowStuff.timed(20.millis).unsafeAttemptRun()
+      c.get shouldBe 1L
+    }
+
     def swallow(a: => Any): Unit =
       try { a; () }
       catch {


### PR DESCRIPTION
If a `Task` is preempted (such as with `.timed` with a shorter duration
than the `Task` takes to run), then its `onFinish` handler isn't
guaranteed to run (in fact it consistently fails this test for me).

This is an issue that @djspiewak pointed out to me as an existing issue
with scalaz's `Task`. I thought it was worth bringing to attention in
fs2, because with the more sophisticated resource/time handling in
fs2's Stream, it may be best to leave certain features (such as
`.timed`) off of fs2's `Task`, at least until they can be reliably
implemented.