### PR TITLE
Ref usability

### DIFF
--- a/core/src/main/scala/fs2/Async.scala
+++ b/core/src/main/scala/fs2/Async.scala
@@ -1,94 +1,16 @@
 package fs2
 
-import Async.{Change,Future}
+import Async.Ref
 import fs2.util.{Free,Functor,Effect}
 
 @annotation.implicitNotFound("No implicit `Async[${F}]` found.\nNote that the implicit `Async[fs2.Task]` requires an implicit `fs2.Strategy` in scope.")
 trait Async[F[_]] extends Effect[F] { self =>
-  type Ref[A]
 
   /** Create an asynchronous, concurrent mutable reference. */
-  def ref[A]: F[Ref[A]]
+  def ref[A]: F[Ref[F,A]]
 
   /** Create an asynchronous, concurrent mutable reference, initialized to `a`. */
-  def refOf[A](a: A): F[Ref[A]] = bind(ref[A])(r => map(setPure(r)(a))(_ => r))
-
-  /** The read-only portion of a `Ref`. */
-  def read[A](r: Ref[A]): Future[F,A] = new Future[F,A] {
-    def get = self.map(self.get(r))((_,Scope.pure(())))
-    def cancellableGet = self.map(self.cancellableGet(r)) { case (f,cancel) =>
-      (self.map(f)((_,Scope.pure(()))), cancel)
-    }
-  }
-
-  /**
-   * Obtain a snapshot of the current value of the `Ref`, and a setter
-   * for updating the value. The setter may noop (in which case `false`
-   * is returned) if another concurrent call to `access` uses its
-   * setter first. Once it has noop'd or been used once, a setter
-   * never succeeds again.
-   */
-  def access[A](r: Ref[A]): F[(A, Either[Throwable,A] => F[Boolean])]
-
-  /**
-   * Try modifying the reference once, returning `None` if another
-   * concurrent `set` or `modify` completes between the time
-   * the variable is read and the time it is set.
-   */
-  def tryModify[A](r: Ref[A])(f: A => A): F[Option[Change[A]]] =
-    bind(access(r)) { case (previous,set) =>
-      val now = f(previous)
-      map(set(Right(now))) { b =>
-        if (b) Some(Change(previous, now))
-        else None
-      }
-    }
-
-  /** like `tryModify` but allows to return `B` along with change **/
-  def tryModify2[A,B](r: Ref[A])(f: A => (A,B)): F[Option[(Change[A], B)]] =
-    bind(access(r)) { case (previous,set) =>
-      val (now,b0) = f(previous)
-      map(set(Right(now))) { b =>
-        if (b) Some(Change(previous, now) -> b0)
-        else None
-      }
-  }
-
-
-  /** Repeatedly invoke `[[tryModify]](f)` until it succeeds. */
-  def modify[A](r: Ref[A])(f: A => A): F[Change[A]] =
-    bind(tryModify(r)(f)) {
-      case None => modify(r)(f)
-      case Some(change) => pure(change)
-    }
-
-  /** like modify, but allows to extra `b` in single step **/
-  def modify2[A,B](r:Ref[A])(f: A => (A,B)): F[(Change[A], B)] =
-    bind(tryModify2(r)(f)) {
-      case None => modify2(r)(f)
-      case Some(changeAndB) => pure(changeAndB)
-    }
-
-  /** Obtain the value of the `Ref`, or wait until it has been `set`. */
-  def get[A](r: Ref[A]): F[A] = map(access(r))(_._1)
-
-  /**
-   * Asynchronously set a reference. After the returned `F[Unit]` is bound,
-   * the task is running in the background. Multiple tasks may be added to a
-   * `Ref[A]`.
-   *
-   * Satisfies: `set(r)(t) flatMap { _ => get(r) } == t`.
-   */
-  def set[A](r: Ref[A])(a: F[A]): F[Unit]
-  def setFree[A](r: Ref[A])(a: Free[F,A]): F[Unit]
-  def setPure[A](r: Ref[A])(a: A): F[Unit] = set(r)(pure(a))
-  /** Actually run the effect of setting the ref. Has side effects. */
-  private[fs2] def runSet[A](q: Ref[A])(a: Either[Throwable,A]): Unit
-
-  /**
-   * Like `get`, but returns an `F[Unit]` that can be used cancel the subscription.
-   */
-  def cancellableGet[A](r: Ref[A]): F[(F[A], F[Unit])]
+  def refOf[A](a: A): F[Ref[F,A]] = bind(ref[A])(r => map(r.setPure(a))(_ => r))
 
   /**
    Create an `F[A]` from an asynchronous computation, which takes the form
@@ -98,7 +20,7 @@ trait Async[F[_]] extends Effect[F] { self =>
    */
   def async[A](register: (Either[Throwable,A] => Unit) => F[Unit]): F[A] =
     bind(ref[A]) { ref =>
-    bind(register { e => runSet(ref)(e) }) { _ => get(ref) }}
+    bind(register { e => ref.runSet(e) }) { _ => ref.get }}
 
   def parallelTraverse[A,B](s: Seq[A])(f: A => F[B]): F[Vector[B]] =
     bind(traverse(s)(f andThen start)) { tasks => traverse(tasks)(identity) }
@@ -109,10 +31,98 @@ trait Async[F[_]] extends Effect[F] { self =>
    */
   def start[A](f: F[A]): F[F[A]] =
     bind(ref[A]) { ref =>
-    bind(set(ref)(f)) { _ => pure(get(ref)) }}
+    bind(ref.set(f)) { _ => pure(ref.get) }}
 }
 
 object Async {
+
+  /** Create an asynchronous, concurrent mutable reference. */
+  def ref[F[_],A](implicit F:Async[F]): F[Async.Ref[F,A]] = F.ref
+
+  /** Create an asynchronous, concurrent mutable reference, initialized to `a`. */
+  def refOf[F[_],A](a: A)(implicit F:Async[F]): F[Async.Ref[F,A]] = F.refOf(a)
+
+  /** An asynchronous, concurrent mutable reference. */
+  trait Ref[F[_],A] { self =>
+    protected val F: Async[F]
+
+    /**
+     * Obtain a snapshot of the current value of the `Ref`, and a setter
+     * for updating the value. The setter may noop (in which case `false`
+     * is returned) if another concurrent call to `access` uses its
+     * setter first. Once it has noop'd or been used once, a setter
+     * never succeeds again.
+     */
+    def access: F[(A, Either[Throwable,A] => F[Boolean])]
+
+
+    /** Obtain the value of the `Ref`, or wait until it has been `set`. */
+    def get: F[A] = F.map(access)(_._1)
+
+    /** Like `get`, but returns an `F[Unit]` that can be used cancel the subscription. */
+    def cancellableGet: F[(F[A], F[Unit])]
+
+    /** The read-only portion of a `Ref`. */
+    def read: Future[F,A] = new Future[F,A] {
+      def get = F.map(self.get)((_,Scope.pure(())))
+      def cancellableGet = F.map(self.cancellableGet) { case (f,cancel) =>
+        (F.map(f)((_,Scope.pure(()))), cancel)
+      }
+    }
+
+    /**
+     * Try modifying the reference once, returning `None` if another
+     * concurrent `set` or `modify` completes between the time
+     * the variable is read and the time it is set.
+     */
+    def tryModify(f: A => A): F[Option[Change[A]]] =
+      F.bind(access) { case (previous,set) =>
+        val now = f(previous)
+        F.map(set(Right(now))) { b =>
+          if (b) Some(Change(previous, now))
+          else None
+        }
+      }
+
+    /** Like `tryModify` but allows to return `B` along with change. **/
+    def tryModify2[B](f: A => (A,B)): F[Option[(Change[A], B)]] =
+      F.bind(access) { case (previous,set) =>
+        val (now,b0) = f(previous)
+        F.map(set(Right(now))) { b =>
+          if (b) Some(Change(previous, now) -> b0)
+          else None
+        }
+    }
+
+    /** Repeatedly invoke `[[tryModify]](f)` until it succeeds. */
+    def modify(f: A => A): F[Change[A]] =
+      F.bind(tryModify(f)) {
+        case None => modify(f)
+        case Some(change) => F.pure(change)
+      }
+
+    /** Like modify, but allows to extra `b` in single step. **/
+    def modify2[B](f: A => (A,B)): F[(Change[A], B)] =
+      F.bind(tryModify2(f)) {
+        case None => modify2(f)
+        case Some(changeAndB) => F.pure(changeAndB)
+      }
+
+    /**
+     * Asynchronously set a reference. After the returned `F[Unit]` is bound,
+     * the task is running in the background. Multiple tasks may be added to a
+     * `Ref[A]`.
+     *
+     * Satisfies: `set(r)(t) flatMap { _ => get(r) } == t`.
+     */
+    def set(a: F[A]): F[Unit]
+    def setFree(a: Free[F,A]): F[Unit]
+    def setPure(a: A): F[Unit] = set(F.pure(a))
+
+    /** Actually run the effect of setting the ref. Has side effects. */
+    private[fs2] def runSet(a: Either[Throwable,A]): Unit
+
+  }
 
   trait Future[F[_],A] { self =>
     private[fs2] def get: F[(A, Scope[F,Unit])]
@@ -138,10 +148,10 @@ object Async {
         F.bind(F.ref[Either[(A,Scope[F,Unit]),(B,Scope[F,Unit])]]) { ref =>
         F.bind(self.cancellableGet) { case (a, cancelA) =>
         F.bind(b.cancellableGet) { case (b, cancelB) =>
-        F.bind(F.set(ref)(F.map(a)(Left(_)))) { _ =>
-        F.bind(F.set(ref)(F.map(b)(Right(_)))) { _ =>
+        F.bind(ref.set(F.map(a)(Left(_)))) { _ =>
+        F.bind(ref.set(F.map(b)(Right(_)))) { _ =>
         F.pure {
-         (F.bind(F.get(ref)) {
+         (F.bind(ref.get) {
            case Left((a,onForce)) => F.map(cancelB)(_ => (Left(a),onForce))
            case Right((b,onForce)) => F.map(cancelA)(_ => (Right(b),onForce)) },
           F.bind(cancelA)(_ => cancelB))
@@ -184,12 +194,12 @@ object Async {
           F.bind(F.ref[((A,Scope[F,Unit]),Int)]) { ref =>
             val cancels: F[Vector[(F[Unit],Int)]] = F.traverse(es zip (0 until es.size)) { case (a,i) =>
               F.bind(a.cancellableGet) { case (a, cancelA) =>
-                F.map(F.set(ref)(F.map(a)((_,i))))(_ => (cancelA,i))
+                F.map(ref.set(F.map(a)((_,i))))(_ => (cancelA,i))
               }
             }
             F.bind(cancels) { cancels =>
               F.pure {
-                val get = F.bind(F.get(ref)) { case (a,i) =>
+                val get = F.bind(ref.get) { case (a,i) =>
                   F.map(F.traverse(cancels.collect { case (a,j) if j != i => a })(identity))(_ => (a,i))
                 }
                 val cancel = F.map(F.traverse(cancels)(_._1))(_ => ())


### PR DESCRIPTION
Sometimes client code needs to use refs (e.g., when the data types in the async package don't fit a given problem). This can be annoying to work with though, because `Ref[A]` is defined as a type member on the `Async` instance. This requires that folks summon the `Async[F]` instance and then thread it through all usages, or else be at the mercy of scalac's path equality, which often fails.

This PR moves `Ref[A]` to the `Async` companion, and adds the effect type as a parameter, making usage much simpler.

Merge after #670.