### PR TITLE
Added infix syntax for fs2.util typeclasses

### DIFF
--- a/core/src/main/scala/fs2/Pulls.scala
+++ b/core/src/main/scala/fs2/Pulls.scala
@@ -36,7 +36,7 @@ trait Pulls[Pull[+_[_],+_,+_]] {
   /** If `p` terminates with `fail(e)`, invoke `handle(e)`. */
   def onError[F[_],O,R](p: Pull[F,O,R])(handle: Throwable => Pull[F,O,R]): Pull[F,O,R]
 
-  /** Monadic flatMap. */
+  /** Monadic bind. */
   def flatMap[F[_],O,R0,R](p: Pull[F,O,R0])(f: R0 => Pull[F,O,R]): Pull[F,O,R]
 
   /** Promote an effect to a `Pull`. */

--- a/core/src/main/scala/fs2/Pulls.scala
+++ b/core/src/main/scala/fs2/Pulls.scala
@@ -36,7 +36,7 @@ trait Pulls[Pull[+_[_],+_,+_]] {
   /** If `p` terminates with `fail(e)`, invoke `handle(e)`. */
   def onError[F[_],O,R](p: Pull[F,O,R])(handle: Throwable => Pull[F,O,R]): Pull[F,O,R]
 
-  /** Monadic bind. */
+  /** Monadic flatMap. */
   def flatMap[F[_],O,R0,R](p: Pull[F,O,R0])(f: R0 => Pull[F,O,R]): Pull[F,O,R]
 
   /** Promote an effect to a `Pull`. */

--- a/core/src/main/scala/fs2/Scope.scala
+++ b/core/src/main/scala/fs2/Scope.scala
@@ -17,7 +17,7 @@ case class Scope[+F[_],+O](get: Free[R[F]#f,O]) {
       def apply[A](r: RF[F,A]) = r match {
         case RF.Eval(fa) => RF.Eval(f(fa))
         case RF.FinishAcquire(token, cleanup) => RF.FinishAcquire(token, cleanup.translate(f))
-        case _ => r.asInstanceOf[RF[G,A]] // Eval and FinishAcquire are only ctors that bind `F`
+        case _ => r.asInstanceOf[RF[G,A]] // Eval and FinishAcquire are only ctors that flatMap `F`
       }
     })
   }}

--- a/core/src/main/scala/fs2/StreamDerived.scala
+++ b/core/src/main/scala/fs2/StreamDerived.scala
@@ -242,7 +242,7 @@ trait StreamDerived extends PipeDerived { self: fs2.Stream.type =>
   implicit def streamCatchableInstance[F[_]]: Catchable[({ type λ[a] = Stream[F, a] })#λ] =
     new Catchable[({ type λ[a] = Stream[F, a] })#λ] {
       def pure[A](a: A): Stream[F,A] = Stream.emit(a)
-      def bind[A,B](s: Stream[F,A])(f: A => Stream[F,B]): Stream[F,B] = s.flatMap(f)
+      def flatMap[A,B](s: Stream[F,A])(f: A => Stream[F,B]): Stream[F,B] = s.flatMap(f)
       def attempt[A](s: Stream[F,A]): Stream[F,Either[Throwable,A]] = s.attempt
       def fail[A](e: Throwable): Stream[F,A] = Stream.fail(e)
     }

--- a/core/src/main/scala/fs2/StreamDerived.scala
+++ b/core/src/main/scala/fs2/StreamDerived.scala
@@ -186,8 +186,14 @@ trait StreamDerived extends PipeDerived { self: fs2.Stream.type =>
       Pull[F, Nothing, AsyncStep1[F,A2]] = self.await1Async(h)
     def invAwaitAsync[A2>:A](implicit F: Async[F], A2: RealSupertype[A,A2]):
       Pull[F, Nothing, AsyncStep[F,A2]] = self.awaitAsync(h)
-    def receive1[O,B](f: Step[A,Handle[F,A]] => Pull[F,O,B]): Pull[F,O,B] = h.await1.flatMap(f)
     def receive[O,B](f: Step[Chunk[A],Handle[F,A]] => Pull[F,O,B]): Pull[F,O,B] = h.await.flatMap(f)
+    def receive1[O,B](f: Step[A,Handle[F,A]] => Pull[F,O,B]): Pull[F,O,B] = h.await1.flatMap(f)
+    def receiveOption[O,B](f: Option[Step[Chunk[A],Handle[F,A]]] => Pull[F,O,B]): Pull[F,O,B] =
+      Pull.receiveOption(f)(h)
+    def receive1Option[O,B](f: Option[Step[A,Handle[F,A]]] => Pull[F,O,B]): Pull[F,O,B] =
+      Pull.receive1Option(f)(h)
+    def receiveNonemptyOption[O,B](f: Option[Step[Chunk[A],Handle[F,A]]] => Pull[F,O,B]): Pull[F,O,B] =
+      Pull.receiveNonemptyOption(f)(h)
   }
 
   implicit class StreamInvariantOps[F[_],A](s: Stream[F,A]) {

--- a/core/src/main/scala/fs2/async/mutable/Queue.scala
+++ b/core/src/main/scala/fs2/async/mutable/Queue.scala
@@ -1,8 +1,9 @@
-package fs2.async.mutable
+package fs2
+package async
+package mutable
 
-import fs2._
 import fs2.util.Functor
-import fs2.async.immutable
+import fs2.util.syntax._
 
 /**
  * Asynchronous queue interface. Operations are all nonblocking in their
@@ -79,9 +80,9 @@ trait Queue[F[_], A] { self =>
       def upperBound: Option[Int] = self.upperBound
       def enqueue1(a: B): F[Unit] = self.enqueue1(g(a))
       def offer1(a: B): F[Boolean] = self.offer1(g(a))
-      def dequeue1: F[B] = F.map(self.dequeue1)(f)
+      def dequeue1: F[B] = self.dequeue1.map(f)
       def cancellableDequeue1: F[(F[B],F[Unit])] =
-        F.map(self.cancellableDequeue1)(bu => F.map(bu._1)(f) -> bu._2)
+        self.cancellableDequeue1.map(bu => bu._1.map(f) -> bu._2)
     }
 }
 
@@ -95,8 +96,8 @@ object Queue {
       */
     case class State(queue: Vector[A], deq: Vector[Async.Ref[F,A]])
 
-    F.bind(Signal(0)) { szSignal =>
-    F.map(F.refOf[State](State(Vector.empty,Vector.empty))) { qref =>
+    Signal(0).flatMap { szSignal =>
+    F.refOf[State](State(Vector.empty,Vector.empty)).map { qref =>
       // Signals size change of queue, if that has changed
       def signalSize(s: State, ns: State) : F[Unit] = {
         if (s.queue.size != ns.queue.size) szSignal.set(ns.queue.size)
@@ -105,35 +106,35 @@ object Queue {
 
       new Queue[F,A] {
         def upperBound: Option[Int] = None
-        def enqueue1(a:A): F[Unit] = F.map(offer1(a))(_ => ())
+        def enqueue1(a:A): F[Unit] = offer1(a).as(())
         def offer1(a: A): F[Boolean] =
-          F.bind(qref.modify { s =>
+          qref.modify { s =>
             if (s.deq.isEmpty) s.copy(queue = s.queue :+ a)
             else s.copy(deq = s.deq.tail)
-          }) { c =>
+          }.flatMap { c =>
             if (c.previous.deq.isEmpty) // we enqueued a value to the queue
-              F.map(signalSize(c.previous, c.now)) { _ => true }
+              signalSize(c.previous, c.now).as(true)
             else // queue was empty, we had waiting dequeuers
-              F.map(c.previous.deq.head.setPure(a)) { _ => true }
+              c.previous.deq.head.setPure(a).as(true)
           }
 
-        def dequeue1: F[A] = F.bind(cancellableDequeue1) { _._1 }
+        def dequeue1: F[A] = cancellableDequeue1.flatMap { _._1 }
 
         def cancellableDequeue1: F[(F[A],F[Unit])] =
-          F.bind(F.ref[A]) { r =>
-          F.map(qref.modify { s =>
+          F.ref[A].flatMap { r =>
+          qref.modify { s =>
             if (s.queue.isEmpty) s.copy(deq = s.deq :+ r)
             else s.copy(queue = s.queue.tail)
-          }) { c =>
-            val deq = F.bind(signalSize(c.previous, c.now)) { _ =>
+          }.map { c =>
+            val deq = signalSize(c.previous, c.now).flatMap { _ =>
               if (c.previous.queue.nonEmpty) F.pure(c.previous.queue.head)
               else r.get
             }
             val cleanup =
               if (c.previous.queue.nonEmpty) F.pure(())
-              else F.map(qref.modify { s =>
+              else qref.modify { s =>
                 s.copy(deq = s.deq.filterNot(_ == r))
-              })(_ => ())
+              }.as(())
             (deq,cleanup)
           }}
 
@@ -144,17 +145,17 @@ object Queue {
     }}}
 
   def bounded[F[_],A](maxSize: Int)(implicit F: Async[F]): F[Queue[F,A]] =
-    F.bind(Semaphore(maxSize.toLong)) { permits =>
-    F.map(unbounded[F,A]) { q =>
+    Semaphore(maxSize.toLong).flatMap { permits =>
+    unbounded[F,A].map { q =>
       new Queue[F,A] {
         def upperBound: Option[Int] = Some(maxSize)
         def enqueue1(a:A): F[Unit] =
-          F.bind(permits.decrement) { _ => q.enqueue1(a) }
+          permits.decrement >> q.enqueue1(a)
         def offer1(a: A): F[Boolean] =
-          F.bind(permits.tryDecrement) { b => if (b) q.offer1(a) else F.pure(false) }
-        def dequeue1: F[A] = F.bind(cancellableDequeue1) { _._1 }
+          permits.tryDecrement.flatMap { b => if (b) q.offer1(a) else F.pure(false) }
+        def dequeue1: F[A] = cancellableDequeue1.flatMap { _._1 }
         def cancellableDequeue1: F[(F[A],F[Unit])] =
-          F.map(q.cancellableDequeue1) { case (deq,cancel) => (F.bind(deq)(a => F.map(permits.increment)(_ => a)), cancel) }
+          q.cancellableDequeue1.map { case (deq,cancel) => (deq.flatMap(a => permits.increment.as(a)), cancel) }
         def size = q.size
         def full: immutable.Signal[F, Boolean] = q.size.map(_ >= maxSize)
         def available: immutable.Signal[F, Int] = q.size.map(maxSize - _)
@@ -162,17 +163,17 @@ object Queue {
     }}
 
   def synchronous[F[_],A](implicit F: Async[F]): F[Queue[F,A]] =
-    F.bind(Semaphore(0)) { permits =>
-    F.map(unbounded[F,A]) { q =>
+    Semaphore(0).flatMap { permits =>
+    unbounded[F,A].map { q =>
       new Queue[F,A] {
         def upperBound: Option[Int] = Some(0)
         def enqueue1(a: A): F[Unit] =
-          F.bind(permits.decrement) { _ => q.enqueue1(a) }
+          permits.decrement >> q.enqueue1(a)
         def offer1(a: A): F[Boolean] =
-          F.bind(permits.tryDecrement) { b => if (b) q.offer1(a) else F.pure(false) }
-        def dequeue1: F[A] = F.bind(cancellableDequeue1) { _._1 }
+          permits.tryDecrement.flatMap { b => if (b) q.offer1(a) else F.pure(false) }
+        def dequeue1: F[A] = cancellableDequeue1.flatMap { _._1 }
         def cancellableDequeue1: F[(F[A],F[Unit])] =
-          F.bind(permits.increment) { _ => q.cancellableDequeue1 }
+          permits.increment >> q.cancellableDequeue1
         def size = q.size
         def full: immutable.Signal[F, Boolean] = Signal.constant(true)
         def available: immutable.Signal[F, Int] = Signal.constant(0)
@@ -181,28 +182,28 @@ object Queue {
 
   /** Like `Queue.synchronous`, except that an enqueue or offer of `None` will never block. */
   def synchronousNoneTerminated[F[_],A](implicit F: Async[F]): F[Queue[F,Option[A]]] =
-    F.bind(Semaphore(0)) { permits =>
-    F.bind(F.refOf(false)) { doneRef =>
-    F.map(unbounded[F,Option[A]]) { q =>
+    Semaphore(0).flatMap { permits =>
+    F.refOf(false).flatMap { doneRef =>
+    unbounded[F,Option[A]].map { q =>
       new Queue[F,Option[A]] {
         def upperBound: Option[Int] = Some(0)
-        def enqueue1(a: Option[A]): F[Unit] = F.bind(doneRef.access) { case (done, update) =>
+        def enqueue1(a: Option[A]): F[Unit] = doneRef.access.flatMap { case (done, update) =>
           if (done) F.pure(())
           else a match {
-            case None => F.bind(update(Right(true))) { successful => if (successful) q.enqueue1(None) else enqueue1(None) }
-            case _ => F.bind(permits.decrement) { _ => q.enqueue1(a) }
+            case None => update(Right(true)).flatMap { successful => if (successful) q.enqueue1(None) else enqueue1(None) }
+            case _ => permits.decrement >> q.enqueue1(a)
           }
         }
-        def offer1(a: Option[A]): F[Boolean] = F.bind(doneRef.access) { case (done, update) =>
+        def offer1(a: Option[A]): F[Boolean] = doneRef.access.flatMap { case (done, update) =>
           if (done) F.pure(true)
           else a match {
-            case None => F.bind(update(Right(true))) { successful => if (successful) q.offer1(None) else offer1(None) }
-            case _ => F.bind(permits.decrement) { _ => q.offer1(a) }
+            case None => update(Right(true)).flatMap { successful => if (successful) q.offer1(None) else offer1(None) }
+            case _ => permits.decrement >> q.offer1(a)
           }
         }
-        def dequeue1: F[Option[A]] = F.bind(cancellableDequeue1) { _._1 }
+        def dequeue1: F[Option[A]] = cancellableDequeue1.flatMap { _._1 }
         def cancellableDequeue1: F[(F[Option[A]],F[Unit])] =
-          F.bind(permits.increment) { _ => q.cancellableDequeue1 }
+          permits.increment >> q.cancellableDequeue1
         def size = q.size
         def full: immutable.Signal[F, Boolean] = Signal.constant(true)
         def available: immutable.Signal[F, Int] = Signal.constant(0)

--- a/core/src/main/scala/fs2/async/mutable/Semaphore.scala
+++ b/core/src/main/scala/fs2/async/mutable/Semaphore.scala
@@ -1,6 +1,8 @@
-package fs2.async.mutable
+package fs2
+package async
+package mutable
 
-import fs2.Async
+import fs2.util.syntax._
 
 /**
  * An asynchronous semaphore, useful as a concurrency primitive.
@@ -62,19 +64,19 @@ object Semaphore {
     // semaphore is either empty, and there are number of outstanding acquires (Left)
     // or it is nonempty, and there are n permits available (Right)
     type S = Either[Vector[(Long,Async.Ref[F,Unit])], Long]
-    F.map(F.refOf[S](Right(n))) { ref => new Semaphore[F] {
+    F.refOf[S](Right(n)).map { ref => new Semaphore[F] {
       private def open(gate: Async.Ref[F,Unit]): F[Unit] =
         gate.setPure(())
 
-      def count = F.map(ref.get)(count_)
+      def count = ref.get.map(count_)
       def decrementBy(n: Long) = { ensureNonneg(n)
         if (n == 0) F.pure(())
-        else F.bind(F.ref[Unit]) { gate => F.bind(ref.modify {
+        else F.ref[Unit].flatMap { gate => ref.modify {
           case Left(waiting) => Left(waiting :+ (n -> gate))
           case Right(m) =>
             if (n <= m) Right(m-n)
             else Left(Vector((n-m) -> gate))
-        }) { c => c.now match {
+        }.flatMap { c => c.now match {
           case Left(waiting) =>
             def err = sys.error("FS2 bug: Semaphore has empty waiting queue rather than 0 count")
             waiting.lastOption.getOrElse(err)._2.get
@@ -83,10 +85,10 @@ object Semaphore {
       }
 
       def clear: F[Long] =
-        F.bind(ref.modify {
-        case Left(e) => throw new IllegalStateException("cannot clear a semaphore with negative count")
-        case Right(n) => Right(0)
-        }) { c => c.previous match {
+        ref.modify {
+          case Left(e) => throw new IllegalStateException("cannot clear a semaphore with negative count")
+          case Right(n) => Right(0)
+        }.flatMap { c => c.previous match {
           case Right(n) => F.pure(n)
           case Left(_) => sys.error("impossible, exception thrown above")
         }}
@@ -96,7 +98,7 @@ object Semaphore {
 
       def incrementBy(n: Long) = { ensureNonneg(n)
         if (n == 0) F.pure(())
-        else F.bind(ref.modify {
+        else ref.modify {
           case Left(waiting) =>
             // just figure out how many to strip from waiting queue,
             // but don't run anything here inside the modify
@@ -110,7 +112,7 @@ object Semaphore {
             if (waiting2.nonEmpty) Left(waiting2)
             else Right(m)
           case Right(m) => Right(m+n)
-        }) { change =>
+        }.flatMap { change =>
           // invariant: count_(change.now) == count_(change.previous) + n
           change.previous match {
           case Left(waiting) =>
@@ -119,20 +121,20 @@ object Semaphore {
             val released = waiting.size - newSize
             // just using Chunk for its stack-safe foldRight
             fs2.Chunk.indexedSeq(waiting.take(released))
-                     .foldRight(F.pure(())) { (hd,tl) => F.bind(open(hd._2)){ _ => tl }}
+                     .foldRight(F.pure(())) { (hd,tl) => open(hd._2) >> tl }
           case Right(_) => F.pure(())
         }}
       }
 
       def tryDecrementBy(n: Long) = { ensureNonneg(n)
         if (n == 0) F.pure(true)
-        else F.map(ref.modify {
+        else ref.modify {
           case Right(m) if m >= n => Right(m-n)
           case w => w
-        }) { c => c.now.fold(_ => false, n => c.previous.fold(_ => false, m => n != m)) }
+        }.map { c => c.now.fold(_ => false, n => c.previous.fold(_ => false, m => n != m)) }
       }
 
-      def available = F.map(ref.get) {
+      def available = ref.get.map {
         case Left(_) => 0
         case Right(n) => n
       }

--- a/core/src/main/scala/fs2/concurrent.scala
+++ b/core/src/main/scala/fs2/concurrent.scala
@@ -63,10 +63,10 @@ object concurrent {
 
       def go(doneQueue: async.mutable.Queue[F,Pull[F,Nothing,Unit]])(open: Int): (Stream.Handle[F,Stream[F,A]], Stream.Handle[F,Pull[F,Nothing,Unit]]) => Pull[F,Nothing,Unit] = (h, d) => {
         if (open < maxOpen)
-          Pull.receive1Option[F,Stream[F,A],Nothing,Unit] {
+          h.receive1Option {
             case Some(inner #: h) => runInnerStream(inner, doneQueue).flatMap { gate => go(doneQueue)(open + 1)(h, d) }
             case None => Pull.done
-          }(h)
+          }
         else
           d.receive1 { case earlyRelease #: d => earlyRelease >> go(doneQueue)(open - 1)(h, d) }
       }

--- a/core/src/main/scala/fs2/task.scala
+++ b/core/src/main/scala/fs2/task.scala
@@ -405,7 +405,7 @@ object Task extends Instances {
 private[fs2] trait Instances1 {
   implicit def effect: Effect[Task] = new Effect[Task] {
     def pure[A](a: A) = Task.now(a)
-    def bind[A,B](a: Task[A])(f: A => Task[B]): Task[B] = a flatMap f
+    def flatMap[A,B](a: Task[A])(f: A => Task[B]): Task[B] = a flatMap f
     override def delay[A](a: => A) = Task.delay(a)
     def suspend[A](fa: => Task[A]) = Task.suspend(fa)
     def fail[A](err: Throwable) = Task.fail(err)
@@ -419,7 +419,7 @@ private[fs2] trait Instances extends Instances1 {
   implicit def asyncInstance(implicit S:Strategy): Async[Task] = new Async[Task] {
     def ref[A]: Task[Async.Ref[Task,A]] = Task.ref[A](S, this)
     def pure[A](a: A): Task[A] = Task.now(a)
-    def bind[A, B](a: Task[A])(f: (A) => Task[B]): Task[B] = a flatMap f
+    def flatMap[A, B](a: Task[A])(f: (A) => Task[B]): Task[B] = a flatMap f
     override def delay[A](a: => A) = Task.delay(a)
     def suspend[A](fa: => Task[A]) = Task.suspend(fa)
     def fail[A](err: Throwable): Task[A] = Task.fail(err)

--- a/core/src/main/scala/fs2/text.scala
+++ b/core/src/main/scala/fs2/text.scala
@@ -129,13 +129,13 @@ object text {
     }
 
     def go(buffer: Vector[String], pendingLineFeed: Boolean): Handle[F, String] => Pull[F, String, Unit] = {
-      Pull.receiveOption[F,String,String,Unit] {
+      _.receiveOption {
         case Some(chunk #: h) =>
           val (toOutput, newBuffer, newPendingLineFeed) = extractLines(buffer, chunk, pendingLineFeed)
           Pull.output(toOutput) >> go(newBuffer, newPendingLineFeed)(h)
         case None if buffer.nonEmpty => Pull.output1(buffer.mkString)
         case None => Pull.done
-      }(_)
+      }
     }
     _.pull(go(Vector.empty, false))
   }

--- a/core/src/main/scala/fs2/util/Eq.scala
+++ b/core/src/main/scala/fs2/util/Eq.scala
@@ -1,24 +1,16 @@
 package fs2
 package util
 
+/** Evidence that `A` is the same type as `B` (a better version of `=:=`). */
 private[fs2] sealed trait Eq[A,B] {
-  def flip: Eq[B,A] = this.asInstanceOf[Eq[B,A]]
   def apply(a: A): B = Eq.subst[({type f[x] = x})#f, A, B](a)(this)
+  def flip: Eq[B,A] = this.asInstanceOf[Eq[B,A]]
 }
 
-object Eq {
+private[fs2] object Eq {
   private val _instance = new Eq[Unit,Unit] {}
   implicit def refl[A]: Eq[A,A] = _instance.asInstanceOf[Eq[A,A]]
 
   def subst[F[_],A,B](f: F[A])(implicit Eq: Eq[A,B]): F[B] =
     f.asInstanceOf[F[B]]
-
-  def substStream[F[_],A,B](s: Stream[F,A])(implicit Eq: Eq[A,B]): Stream[F,B] =
-    subst[({ type f[x] = Stream[F,x] })#f, A, B](s)
-
-  def substPull[F[_],W,A,B](p: Pull[F,W,A])(implicit Eq: Eq[A,B]): Pull[F,W,B] =
-    subst[({ type f[x] = Pull[F,W,x] })#f, A, B](p)
-
-  def substHandler[F[_],A,B](h: Throwable => Stream[F,A])(implicit Eq: Eq[A,B]): Throwable => Stream[F,B] =
-    subst[({ type f[x] = Throwable => Stream[F,x] })#f, A, B](h)
 }

--- a/core/src/main/scala/fs2/util/Functor.scala
+++ b/core/src/main/scala/fs2/util/Functor.scala
@@ -3,4 +3,3 @@ package fs2.util
 trait Functor[F[_]] {
   def map[A,B](a: F[A])(f: A => B): F[B]
 }
-

--- a/core/src/main/scala/fs2/util/Monad.scala
+++ b/core/src/main/scala/fs2/util/Monad.scala
@@ -1,12 +1,16 @@
 package fs2.util
 
 trait Monad[F[_]] extends Functor[F] {
-  def map[A,B](a: F[A])(f: A => B): F[B] = bind(a)(f andThen (pure))
-  def bind[A,B](a: F[A])(f: A => F[B]): F[B]
   def pure[A](a: A): F[A]
+  def flatMap[A,B](a: F[A])(f: A => F[B]): F[B]
+
+  def map[A,B](a: F[A])(f: A => B): F[B] = flatMap(a)(f andThen (pure))
 
   def traverse[A,B](v: Seq[A])(f: A => F[B]): F[Vector[B]] =
     v.reverse.foldLeft(pure(Vector.empty[B])) {
-      (tl,hd) => bind(f(hd)) { b => map(tl)(b +: _) }
+      (tl,hd) => flatMap(f(hd)) { b => map(tl)(b +: _) }
     }
+
+  def sequence[A](v: Seq[F[A]]): F[Vector[A]] =
+    traverse(v)(identity)
 }

--- a/core/src/main/scala/fs2/util/syntax.scala
+++ b/core/src/main/scala/fs2/util/syntax.scala
@@ -1,0 +1,26 @@
+package fs2.util
+
+/** Provides infix syntax for the typeclasses in the util package. */
+object syntax {
+
+  implicit class FunctorOps[F[_],A](val self: F[A]) extends AnyVal {
+    def map[B](f: A => B)(implicit F: Functor[F]): F[B] = F.map(self)(f)
+    def as[B](b: B)(implicit F: Functor[F]): F[B] = F.map(self)(_ => b)
+  }
+
+  implicit class MonadOps[F[_],A](val self: F[A]) extends AnyVal {
+    def flatMap[B](f: A => F[B])(implicit F: Monad[F]): F[B] = F.flatMap(self)(f)
+    def flatten[B](implicit F: Monad[F], ev: A <:< F[B]): F[B] = F.flatMap(self)(a => ev(a))
+    def andThen[A, B](b: F[B])(implicit F: Monad[F]): F[B] = F.flatMap(self)(_ => b)
+    def >>[A, B](b: F[B])(implicit F: Monad[F]): F[B] = andThen(b)
+  }
+
+  implicit class TraverseOps[F[_],A](val self: Seq[A]) extends AnyVal {
+    def traverse[B](f: A => F[B])(implicit F: Monad[F]): F[Vector[B]] = F.traverse(self)(f)
+    def sequence[B](implicit F: Monad[F], ev: A =:= F[B]): F[Vector[B]] = F.sequence(self.asInstanceOf[Seq[F[B]]])
+  }
+
+  implicit class CatchableOps[F[_],A](val self: F[A]) extends AnyVal {
+    def attempt(implicit F: Catchable[F]): F[Either[Throwable,A]] = F.attempt(self)
+  }
+}

--- a/io/src/main/scala/fs2/io/file/FileHandle.scala
+++ b/io/src/main/scala/fs2/io/file/FileHandle.scala
@@ -1,10 +1,12 @@
-package fs2.io.file
+package fs2
+package io
+package file
 
 import java.nio.ByteBuffer
 import java.nio.channels.{AsynchronousFileChannel, FileChannel, FileLock}
 
-import fs2._
 import fs2.util.Effect
+import fs2.util.syntax._
 
 trait FileHandle[F[_]] {
   type Lock
@@ -109,12 +111,9 @@ object FileHandle {
 
       override def read(numBytes: Int, offset: Long): F[Option[Chunk[Byte]]] = {
         val buf = ByteBuffer.allocate(numBytes)
-        F.bind(
-          asyncCompletionHandler[F, Integer](f => F.pure(chan.read(buf, offset, null, f))))(
-          len => F.pure {
-            if (len < 0) None else if (len == 0) Some(Chunk.empty) else Some(Chunk.bytes(buf.array.take(len)))
-          }
-        )
+        asyncCompletionHandler[F, Integer](f => F.pure(chan.read(buf, offset, null, f))).map { len =>
+          if (len < 0) None else if (len == 0) Some(Chunk.empty) else Some(Chunk.bytes(buf.array.take(len)))
+        }
       }
 
       override def size: F[Long] =
@@ -161,11 +160,9 @@ object FileHandle {
 
       override def read(numBytes: Int, offset: Long): F[Option[Chunk[Byte]]] = {
         val buf = ByteBuffer.allocate(numBytes)
-        F.bind(
-          F.delay(chan.read(buf, offset)))(len => F.pure {
+        F.delay(chan.read(buf, offset)).map { len => 
           if (len < 0) None else if (len == 0) Some(Chunk.empty) else Some(Chunk.bytes(buf.array.take(len)))
         }
-        )
       }
 
       override def size: F[Long] =

--- a/io/src/main/scala/fs2/io/file/pulls.scala
+++ b/io/src/main/scala/fs2/io/file/pulls.scala
@@ -1,11 +1,13 @@
-package fs2.io.file
+package fs2
+package io
+package file
 
 import java.nio.channels._
 import java.nio.file._
 
-import fs2._
 import fs2.Stream.Handle
 import fs2.util.Effect
+import fs2.util.syntax._
 
 object pulls {
   //
@@ -66,7 +68,7 @@ object pulls {
     * The `Pull` closes the provided `java.nio.channels.FileChannel` when it is done.
     */
   def fromFileChannel[F[_]](channel: F[FileChannel])(implicit F: Effect[F]): Pull[F, Nothing, FileHandle[F]] =
-    Pull.acquire(F.map(channel)(FileHandle.fromFileChannel[F]))(_.close())
+    Pull.acquire(channel.map(FileHandle.fromFileChannel[F]))(_.close())
 
   /**
     * Given a `java.nio.channels.AsynchronousFileChannel`, will create a `Pull` which allows asynchronous operations against the underlying file.
@@ -74,5 +76,5 @@ object pulls {
     * The `Pull` closes the provided `java.nio.channels.AsynchronousFileChannel` when it is done.
     */
   def fromAsynchronousFileChannel[F[_]](channel: F[AsynchronousFileChannel])(implicit F: Async[F], FR: Async.Run[F]): Pull[F, Nothing, FileHandle[F]] =
-    Pull.acquire(F.map(channel)(FileHandle.fromAsynchronousFileChannel[F]))(_.close())
+    Pull.acquire(channel.map(FileHandle.fromAsynchronousFileChannel[F]))(_.close())
 }

--- a/io/src/main/scala/fs2/io/tcp/Socket.scala
+++ b/io/src/main/scala/fs2/io/tcp/Socket.scala
@@ -141,7 +141,7 @@ protected[tcp] object Socket {
 
 
   def server[F[_]](
-    flatMap: InetSocketAddress
+    bind: InetSocketAddress
     , maxQueued: Int
     , reuseAddress: Boolean
     , receiveBufferSize: Int )(
@@ -154,7 +154,7 @@ protected[tcp] object Socket {
         val ch = AsynchronousChannelProvider.provider().openAsynchronousServerSocketChannel(AG)
         ch.setOption[java.lang.Boolean](StandardSocketOptions.SO_REUSEADDR, reuseAddress)
         ch.setOption[Integer](StandardSocketOptions.SO_RCVBUF, receiveBufferSize)
-        ch.bind(flatMap)
+        ch.bind(bind)
         ch
       }
 

--- a/io/src/main/scala/fs2/io/tcp/Socket.scala
+++ b/io/src/main/scala/fs2/io/tcp/Socket.scala
@@ -141,7 +141,7 @@ protected[tcp] object Socket {
 
 
   def server[F[_]](
-    bind: InetSocketAddress
+    address: InetSocketAddress
     , maxQueued: Int
     , reuseAddress: Boolean
     , receiveBufferSize: Int )(
@@ -154,7 +154,7 @@ protected[tcp] object Socket {
         val ch = AsynchronousChannelProvider.provider().openAsynchronousServerSocketChannel(AG)
         ch.setOption[java.lang.Boolean](StandardSocketOptions.SO_REUSEADDR, reuseAddress)
         ch.setOption[Integer](StandardSocketOptions.SO_RCVBUF, receiveBufferSize)
-        ch.bind(bind)
+        ch.bind(address)
         ch
       }
 

--- a/io/src/main/scala/fs2/io/tcp/tcp.scala
+++ b/io/src/main/scala/fs2/io/tcp/tcp.scala
@@ -28,7 +28,7 @@ package object tcp {
   Socket.client(to,reuseAddress,sendBufferSize,receiveBufferSize,keepAlive,noDelay)
 
   /**
-    * Process that binds to supplied address and handles incoming TCP connections
+    * Process that flatMaps to supplied address and handles incoming TCP connections
     * using the specified handler.
     *
     * The outer stream returned scopes the lifetime of the server socket.
@@ -37,30 +37,30 @@ package object tcp {
     * The inner streams represents individual connections, handled by `handler`. If
     * any inner stream fails, this will _NOT_ cause the server connection to fail/close/terminate.
     *
-    * @param bind               address to which this process has to be bound
+    * @param flatMap               address to which this process has to be bound
     * @param maxQueued          Number of queued requests before they will become rejected by server
     *                           Supply <= 0 if unbounded
     * @param reuseAddress       whether address has to be reused (@see [[java.net.StandardSocketOptions.SO_REUSEADDR]])
     * @param receiveBufferSize  size of receive buffer (@see [[java.net.StandardSocketOptions.SO_RCVBUF]])
     */
   def server[F[_]](
-    bind: InetSocketAddress
+    flatMap: InetSocketAddress
     , maxQueued: Int = 0
     , reuseAddress: Boolean = true
     , receiveBufferSize: Int = 256 * 1024)(
     implicit AG: AsynchronousChannelGroup, F: Async[F], FR: Async.Run[F]
   ): Stream[F, Stream[F, Socket[F]]] =
-    serverWithLocalAddress(bind, maxQueued, reuseAddress, receiveBufferSize).collect { case Right(s) => s }
+    serverWithLocalAddress(flatMap, maxQueued, reuseAddress, receiveBufferSize).collect { case Right(s) => s }
 
    /**
     * Like [[server]] but provides the `InetSocketAddress` of the bound server socket before providing accepted sockets.
     */
   def serverWithLocalAddress[F[_]](
-    bind: InetSocketAddress
+    flatMap: InetSocketAddress
     , maxQueued: Int = 0
     , reuseAddress: Boolean = true
     , receiveBufferSize: Int = 256 * 1024)(
     implicit AG: AsynchronousChannelGroup, F: Async[F], FR: Async.Run[F]
   ): Stream[F, Either[InetSocketAddress, Stream[F, Socket[F]]]] =
-    Socket.server(bind,maxQueued,reuseAddress,receiveBufferSize)
+    Socket.server(flatMap,maxQueued,reuseAddress,receiveBufferSize)
 }

--- a/io/src/main/scala/fs2/io/udp/udp.scala
+++ b/io/src/main/scala/fs2/io/udp/udp.scala
@@ -20,7 +20,7 @@ package object udp {
    * Provides a singleton stream of a UDP Socket that when run will flatMap to specified adress
    * by `flatMap`.
    *
-   * @param flatMap                 address to flatMap to; defaults to an ephemeral port on all interfaces
+   * @param address              address to bind to; defaults to an ephemeral port on all interfaces
    * @param reuseAddress         whether address has to be reused (@see [[java.net.StandardSocketOptions.SO_REUSEADDR]])
    * @param sendBufferSize       size of send buffer  (@see [[java.net.StandardSocketOptions.SO_SNDBUF]])
    * @param receiveBufferSize    size of receive buffer (@see [[java.net.StandardSocketOptions.SO_RCVBUF]])
@@ -31,7 +31,7 @@ package object udp {
    * @param multicastLoopback    whether sent multicast packets should be looped back to this host
    */
   def open[F[_]](
-    flatMap: InetSocketAddress = new InetSocketAddress(0)
+    addresss: InetSocketAddress = new InetSocketAddress(0)
     , reuseAddress: Boolean = false
     , sendBufferSize: Option[Int] = None
     , receiveBufferSize: Option[Int] = None
@@ -50,7 +50,7 @@ package object udp {
       multicastInterface.foreach { iface => channel.setOption[NetworkInterface](StandardSocketOptions.IP_MULTICAST_IF, iface) }
       multicastTTL.foreach { ttl => channel.setOption[Integer](StandardSocketOptions.IP_MULTICAST_TTL, ttl) }
       channel.setOption[java.lang.Boolean](StandardSocketOptions.IP_MULTICAST_LOOP, multicastLoopback)
-      channel.bind(flatMap)
+      channel.bind(addresss)
       channel
     }
     Stream.bracket(mkChannel.flatMap(ch => Socket.mkSocket(ch)))(s => Stream.emit(s), _.close)

--- a/io/src/main/scala/fs2/io/udp/udp.scala
+++ b/io/src/main/scala/fs2/io/udp/udp.scala
@@ -1,9 +1,10 @@
-package fs2.io
+package fs2
+package io
 
 import java.net.{InetSocketAddress,NetworkInterface,ProtocolFamily,StandardSocketOptions}
 import java.nio.channels.DatagramChannel
 
-import fs2._
+import fs2.util.syntax._
 
 package object udp {
 
@@ -16,10 +17,10 @@ package object udp {
   case class Packet(remote: InetSocketAddress, bytes: Chunk[Byte])
 
   /**
-   * Provides a singleton stream of a UDP Socket that when run will bind to specified adress
-   * by `bind`.
+   * Provides a singleton stream of a UDP Socket that when run will flatMap to specified adress
+   * by `flatMap`.
    *
-   * @param bind                 address to bind to; defaults to an ephemeral port on all interfaces
+   * @param flatMap                 address to flatMap to; defaults to an ephemeral port on all interfaces
    * @param reuseAddress         whether address has to be reused (@see [[java.net.StandardSocketOptions.SO_REUSEADDR]])
    * @param sendBufferSize       size of send buffer  (@see [[java.net.StandardSocketOptions.SO_SNDBUF]])
    * @param receiveBufferSize    size of receive buffer (@see [[java.net.StandardSocketOptions.SO_RCVBUF]])
@@ -30,7 +31,7 @@ package object udp {
    * @param multicastLoopback    whether sent multicast packets should be looped back to this host
    */
   def open[F[_]](
-    bind: InetSocketAddress = new InetSocketAddress(0)
+    flatMap: InetSocketAddress = new InetSocketAddress(0)
     , reuseAddress: Boolean = false
     , sendBufferSize: Option[Int] = None
     , receiveBufferSize: Option[Int] = None
@@ -49,9 +50,9 @@ package object udp {
       multicastInterface.foreach { iface => channel.setOption[NetworkInterface](StandardSocketOptions.IP_MULTICAST_IF, iface) }
       multicastTTL.foreach { ttl => channel.setOption[Integer](StandardSocketOptions.IP_MULTICAST_TTL, ttl) }
       channel.setOption[java.lang.Boolean](StandardSocketOptions.IP_MULTICAST_LOOP, multicastLoopback)
-      channel.bind(bind)
+      channel.bind(flatMap)
       channel
     }
-    Stream.bracket(F.bind(mkChannel)(ch => Socket.mkSocket(ch)))(s => Stream.emit(s), _.close)
+    Stream.bracket(mkChannel.flatMap(ch => Socket.mkSocket(ch)))(s => Stream.emit(s), _.close)
   }
 }

--- a/io/src/main/scala/fs2/io/udp/udp.scala
+++ b/io/src/main/scala/fs2/io/udp/udp.scala
@@ -17,7 +17,7 @@ package object udp {
   case class Packet(remote: InetSocketAddress, bytes: Chunk[Byte])
 
   /**
-   * Provides a singleton stream of a UDP Socket that when run will flatMap to specified adress
+   * Provides a singleton stream of a UDP Socket that when run will bind to specified adress
    * by `flatMap`.
    *
    * @param address              address to bind to; defaults to an ephemeral port on all interfaces


### PR DESCRIPTION
I renamed `bind` to `flatMap` in order to pick up for-comp syntax. We could have `flatMap` as an alias for `bind` like scalaz does, but I think a single way to do things is better than having folks pick the name they prefer in each case.

Goal of this PR is not to compete with scalaz/cats but rather to cleanup the fs2 internals, where the use of prefix syntax gets pretty complex.

When I started this PR, I used simulacrum. I ended up removing the simulacrum dependency in order to define the syntax in AnyVal classes so that there's no runtime overhead.

Merge after #673