### PR TITLE
Update scalaz-stream 0.8 to support scala 2.12.0-M5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ git.formattedShaVersion := {
 
 scalaVersion := "2.11.8"
 
-crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0-M4")
+crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0-M5")
 
 scalacOptions ++= Seq(
   "-feature",
@@ -46,10 +46,10 @@ scalacOptions in (Compile, doc) ++= Seq(
 resolvers ++= Seq(Resolver.sonatypeRepo("releases"), Resolver.sonatypeRepo("snapshots"))
 
 libraryDependencies ++= Seq(
-  "org.scalaz" %% "scalaz-core" % "7.1.7",
-  "org.scalaz" %% "scalaz-concurrent" % "7.1.7",
+  "org.scalaz" %% "scalaz-core" % "7.1.8",
+  "org.scalaz" %% "scalaz-concurrent" % "7.1.8",
   "org.scodec" %% "scodec-bits" % "1.1.0",
-  "org.scalaz" %% "scalaz-scalacheck-binding" % "7.1.7" % "test",
+  "org.scalaz" %% "scalaz-scalacheck-binding" % "7.1.8" % "test",
   "org.scalacheck" %% "scalacheck" % "1.12.5" % "test"
 )
 


### PR DESCRIPTION
 - Bump scalaz to 7.1.8 with a build for 2.12.0-M5
 - Add some `asInstanceOf` calls and type ascriptions to fix
   compilation errors.