### PR TITLE
Update scalaz-stream 0.8a to support scala 2.12.0-M5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ git.formattedShaVersion := {
 
 scalaVersion := "2.11.8"
 
-crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0-M4")
+crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0-M5")
 
 scalacOptions ++= Seq(
   "-feature",
@@ -46,10 +46,10 @@ scalacOptions in (Compile, doc) ++= Seq(
 resolvers ++= Seq(Resolver.sonatypeRepo("releases"), Resolver.sonatypeRepo("snapshots"))
 
 libraryDependencies ++= Seq(
-  "org.scalaz" %% "scalaz-core" % "7.2.2",
-  "org.scalaz" %% "scalaz-concurrent" % "7.2.2",
+  "org.scalaz" %% "scalaz-core" % "7.2.4",
+  "org.scalaz" %% "scalaz-concurrent" % "7.2.4",
   "org.scodec" %% "scodec-bits" % "1.1.0",
-  "org.scalaz" %% "scalaz-scalacheck-binding" % "7.2.2" % "test",
+  "org.scalaz" %% "scalaz-scalacheck-binding" % "7.2.4" % "test",
   "org.scalacheck" %% "scalacheck" % "1.12.5" % "test"
 )
 


### PR DESCRIPTION
 - Bump scalaz to 7.2.4 with a build for 2.12.0-M5
 - Add some `asInstanceOf` calls and type ascriptions to fix
   compilation errors.