### PR TITLE
Expose runSet so that  typeclass instances that build on top of other…

### DIFF
--- a/core/src/main/scala/fs2/Async.scala
+++ b/core/src/main/scala/fs2/Async.scala
@@ -21,7 +21,7 @@ trait Async[F[_]] extends Effect[F] { self =>
    */
   def async[A](register: (Either[Throwable,A] => Unit) => F[Unit]): F[A] =
     flatMap(ref[A]) { ref =>
-    flatMap(register { e => ref.runSet(e) }) { _ => ref.get }}
+    flatMap(register { e => ref.unsafeRunSet(e) }) { _ => ref.get }}
 
   def parallelTraverse[A,B](s: Seq[A])(f: A => F[B]): F[Vector[B]] =
     flatMap(traverse(s)(f andThen start)) { tasks => traverse(tasks)(identity) }
@@ -120,7 +120,7 @@ object Async {
     def setPure(a: A): F[Unit] = set(F.pure(a))
 
     /** Actually run the effect of setting the ref. Has side effects. */
-    private[fs2] def runSet(a: Either[Throwable,A]): Unit
+    def unsafeRunSet(a: Either[Throwable,A]): Unit
 
   }
 

--- a/core/src/main/scala/fs2/StreamCore.scala
+++ b/core/src/main/scala/fs2/StreamCore.scala
@@ -112,7 +112,7 @@ sealed trait StreamCore[F[_],O] { self =>
     lazy val rootCleanup: Free[F,Either[Throwable,Unit]] = Free.suspend { resources.closeAll(noopWaiters) match {
       case Left(waiting) =>
         Free.eval(F.sequence(Vector.fill(waiting)(F.ref[Unit]))) flatMap { gates =>
-          resources.closeAll(gates.toStream.map(gate => () => gate.runSet(Right(())))) match {
+          resources.closeAll(gates.toStream.map(gate => () => gate.unsafeRunSet(Right(())))) match {
             case Left(_) => Free.eval(F.traverse(gates)(_.get)) flatMap { _ =>
               resources.closeAll(noopWaiters) match {
                 case Left(_) => println("likely FS2 bug - resources still being acquired after Resources.closeAll call")

--- a/core/src/main/scala/fs2/task.scala
+++ b/core/src/main/scala/fs2/task.scala
@@ -357,7 +357,7 @@ object Task extends Instances {
       Task.delay { S { t.unsafeRunAsync { r => actor ! Msg.Set(r) } }}
     def setFree(t: Free[Task,A]): Task[Unit] =
       set(t.run(F))
-    def runSet(e: Either[Throwable,A]): Unit =
+    def unsafeRunSet(e: Either[Throwable,A]): Unit =
       actor ! Msg.Set(e)
 
     private def getStamped(msg: MsgId): Task[(A,Long)] =


### PR DESCRIPTION
…s can delegate to them (for instance remotely Response Async typeclass is a ). It's understood the reasoning for wanting to keep this contained within the implementation but given it is a method that must be implemented by those creating  instances, perhaps renaming to unsafeRunSet, as I did here, would suffice?  Any alternative suggestions are welcome.