### PR TITLE
Async type class cleanup

### DIFF
--- a/core/src/main/scala/fs2/ScopedFuture.scala
+++ b/core/src/main/scala/fs2/ScopedFuture.scala
@@ -1,6 +1,6 @@
 package fs2
 
-import fs2.util.{Functor,Monad}
+import fs2.util.{Async,Functor,Monad}
 import fs2.util.syntax._
 
 /**

--- a/core/src/main/scala/fs2/ScopedFuture.scala
+++ b/core/src/main/scala/fs2/ScopedFuture.scala
@@ -1,0 +1,107 @@
+package fs2
+
+import fs2.util.{Functor,Monad}
+import fs2.util.syntax._
+
+/**
+ * Future that evaluates to a value of type `A` and a `Scope[F,Unit]`.
+ *
+ * To use a `Future`, convert to a `Pull` (via `f.pull`) or a `Stream` (via `f.stream`).
+ */
+sealed trait ScopedFuture[F[_],A] { self =>
+
+  private[fs2] def get: F[(A, Scope[F,Unit])]
+
+  private[fs2] def cancellableGet: F[(F[(A, Scope[F,Unit])], F[Unit])]
+
+  private[fs2] def appendOnForce(p: Scope[F,Unit])(implicit F: Functor[F]): ScopedFuture[F,A] = new ScopedFuture[F,A] {
+    def get = self.get.map { case (a,s0) => (a, s0 flatMap { _ => p }) }
+    def cancellableGet =
+      self.cancellableGet.map { case (f,cancel) =>
+        (f.map { case (a,s0) => (a, s0 flatMap { _ => p }) }, cancel)
+      }
+  }
+
+  def pull: Pull[F,Nothing,A] = Pull.eval(get) flatMap { case (a,onForce) => Pull.evalScope(onForce as a) }
+
+  def stream: Stream[F,A] = Stream.eval(get) flatMap { case (a,onForce) => Stream.evalScope(onForce as a) }
+
+  def map[B](f: A => B)(implicit F: Async[F]): ScopedFuture[F,B] = new ScopedFuture[F,B] {
+    def get = self.get.map { case (a,onForce) => (f(a), onForce) }
+    def cancellableGet = self.cancellableGet.map { case (a,cancelA) =>
+      (a.map { case (a,onForce) => (f(a),onForce) }, cancelA)
+    }
+  }
+
+  def race[B](b: ScopedFuture[F,B])(implicit F: Async[F]): ScopedFuture[F,Either[A,B]] = new ScopedFuture[F, Either[A,B]] {
+    def get = cancellableGet.flatMap(_._1)
+    def cancellableGet = for {
+      ref <- F.ref[Either[(A,Scope[F,Unit]),(B,Scope[F,Unit])]]
+      t0 <- self.cancellableGet
+      (a, cancelA) = t0
+      t1 <- b.cancellableGet
+      (b, cancelB) = t1
+      _ <- ref.set(a.map(Left(_)))
+      _ <- ref.set(b.map(Right(_)))
+    } yield {
+      (ref.get.flatMap {
+        case Left((a,onForce)) => cancelB.as((Left(a),onForce))
+        case Right((b,onForce)) => cancelA.as((Right(b),onForce))
+      }, cancelA >> cancelB)
+    }
+  }
+
+  def raceSame(b: ScopedFuture[F,A])(implicit F: Async[F]): ScopedFuture[F, ScopedFuture.RaceResult[A,ScopedFuture[F,A]]] =
+    self.race(b).map {
+      case Left(a) => ScopedFuture.RaceResult(a, b)
+      case Right(a) => ScopedFuture.RaceResult(a, self)
+    }
+}
+
+object ScopedFuture {
+
+  case class RaceResult[+A,+B](winner: A, loser: B)
+
+  case class Focus[A,B](get: A, index: Int, v: Vector[B]) {
+    def replace(b: B): Vector[B] = v.patch(index, List(b), 1)
+    def delete: Vector[B] = v.patch(index, List(), 1)
+  }
+
+  def pure[F[_],A](a: A)(implicit F: Monad[F]): ScopedFuture[F,A] = new ScopedFuture[F,A] {
+    def get = F.pure(a -> Scope.pure(()))
+    def cancellableGet = F.pure((get, F.pure(())))
+  }
+
+  def readRef[F[_],A](r: Async.Ref[F,A])(implicit F: Async[F]): ScopedFuture[F,A] =
+    new ScopedFuture[F,A] {
+      def get = r.get.map((_,Scope.pure(())))
+      def cancellableGet = r.cancellableGet.map { case (f,cancel) =>
+        (f.map((_,Scope.pure(()))), cancel)
+      }
+    }
+
+  def race[F[_]:Async,A](es: Vector[ScopedFuture[F,A]]): ScopedFuture[F,Focus[A,ScopedFuture[F,A]]] =
+    indexedRace(es) map { case (a, i) => Focus(a, i, es) }
+
+  private[fs2] def indexedRace[F[_],A](es: Vector[ScopedFuture[F,A]])(implicit F: Async[F]): ScopedFuture[F,(A,Int)]
+    = new ScopedFuture[F,(A,Int)] {
+      def cancellableGet =
+        F.ref[((A,Scope[F,Unit]),Int)].flatMap { ref =>
+          val cancels: F[Vector[(F[Unit],Int)]] = (es zip (0 until es.size)).traverse { case (a,i) =>
+            a.cancellableGet.flatMap { case (a, cancelA) =>
+              ref.set(a.map((_,i))).as((cancelA,i))
+            }
+          }
+          cancels.flatMap { cancels =>
+            F.pure {
+              val get = ref.get.flatMap { case (a,i) =>
+                F.sequence(cancels.collect { case (a,j) if j != i => a }).map(_ => (a,i))
+              }
+              val cancel = cancels.traverse(_._1).as(())
+              (get.map { case ((a,onForce),i) => ((a,i),onForce) }, cancel)
+            }
+          }
+        }
+      def get = cancellableGet.flatMap(_._1)
+    }
+}

--- a/core/src/main/scala/fs2/Stream.scala
+++ b/core/src/main/scala/fs2/Stream.scala
@@ -1,6 +1,6 @@
 package fs2
 
-import fs2.util.{Free,RealSupertype,Sub1,~>}
+import fs2.util.{Async,Free,RealSupertype,Sub1,~>}
 
 /**
  * A stream producing output of type `O`, which may evaluate `F`

--- a/core/src/main/scala/fs2/Stream.scala
+++ b/core/src/main/scala/fs2/Stream.scala
@@ -1,7 +1,6 @@
 package fs2
 
 import fs2.util.{Free,RealSupertype,Sub1,~>}
-import Async.Future
 
 /**
  * A stream producing output of type `O`, which may evaluate `F`
@@ -12,7 +11,7 @@ abstract class Stream[+F[_],+O] extends StreamOps[F,O] { self =>
 
   def get[F2[_],O2>:O](implicit S: Sub1[F,F2], T: RealSupertype[O,O2]): StreamCore[F2,O2]
 
-  final def fetchAsync[F2[_],O2>:O](implicit F2: Async[F2], S: Sub1[F,F2], T: RealSupertype[O,O2]): Stream[F2, Future[F2,Stream[F2,O2]]] =
+  final def fetchAsync[F2[_],O2>:O](implicit F2: Async[F2], S: Sub1[F,F2], T: RealSupertype[O,O2]): Stream[F2, ScopedFuture[F2,Stream[F2,O2]]] =
     Stream.mk { StreamCore.evalScope(get[F2,O2].fetchAsync).map(_ map (Stream.mk(_))) }
 
   override final def mapChunks[O2](f: Chunk[O] => Chunk[O2]): Stream[F,O2] =
@@ -35,7 +34,7 @@ abstract class Stream[+F[_],+O] extends StreamOps[F,O] { self =>
 
   final def stepAsync[F2[_],O2>:O](
     implicit S: Sub1[F,F2], F2: Async[F2], T: RealSupertype[O,O2])
-    : Pull[F2,Nothing,Future[F2,Pull[F2,Nothing,Step[Chunk[O2], Handle[F2,O2]]]]]
+    : Pull[F2,Nothing,ScopedFuture[F2,Pull[F2,Nothing,Step[Chunk[O2], Handle[F2,O2]]]]]
     =
     Pull.evalScope { get.unconsAsync.map { _ map { case (leftovers,o) =>
       val inner: Pull[F2,Nothing,Step[Chunk[O2], Handle[F2,O2]]] = o match {
@@ -95,7 +94,7 @@ object Stream extends Streams[Stream] with StreamDerived {
   def awaitAsync[F[_],W](h: Handle[F,W])(implicit F: Async[F]) =
     h.buffer match {
       case List() => h.underlying.stepAsync
-      case hb :: tb => Pull.pure(Future.pure(Pull.pure(Step(hb, new Handle(tb, h.underlying)))))
+      case hb :: tb => Pull.pure(ScopedFuture.pure(Pull.pure(Step(hb, new Handle(tb, h.underlying)))))
     }
 
   def bracket[F[_],R,A](r: F[R])(use: R => Stream[F,A], release: R => F[Unit]): Stream[F,A] = Stream.mk {

--- a/core/src/main/scala/fs2/StreamCore.scala
+++ b/core/src/main/scala/fs2/StreamCore.scala
@@ -1,7 +1,7 @@
 package fs2
 
 import fs2.internal.Resources
-import fs2.util.{Catenable,Eq,Free,Sub1,~>,RealSupertype}
+import fs2.util.{Async,Catenable,Eq,Free,Sub1,~>,RealSupertype}
 import StreamCore.{Env,NT,Stack,Token}
 
 private[fs2]

--- a/core/src/main/scala/fs2/StreamCore.scala
+++ b/core/src/main/scala/fs2/StreamCore.scala
@@ -112,7 +112,7 @@ sealed trait StreamCore[F[_],O] { self =>
     lazy val rootCleanup: Free[F,Either[Throwable,Unit]] = Free.suspend { resources.closeAll(noopWaiters) match {
       case Left(waiting) =>
         Free.eval(F.sequence(Vector.fill(waiting)(F.ref[Unit]))) flatMap { gates =>
-          resources.closeAll(gates.toStream.map(gate => () => gate.runSet(Right(())))) match {
+          resources.closeAll(gates.toStream.map(gate => () => F.unsafeRunAsync(gate.setPure(()))(_ => ()))) match {
             case Left(_) => Free.eval(F.traverse(gates)(_.get)) flatMap { _ =>
               resources.closeAll(noopWaiters) match {
                 case Left(_) => println("likely FS2 bug - resources still being acquired after Resources.closeAll call")

--- a/core/src/main/scala/fs2/StreamDerived.scala
+++ b/core/src/main/scala/fs2/StreamDerived.scala
@@ -1,6 +1,6 @@
 package fs2
 
-import fs2.util.{Catchable,RealSupertype,Sub1}
+import fs2.util.{Async,Catchable,RealSupertype,Sub1}
 
 /** Various derived operations that are mixed into the `Stream` companion object. */
 private[fs2]

--- a/core/src/main/scala/fs2/StreamOps.scala
+++ b/core/src/main/scala/fs2/StreamOps.scala
@@ -1,6 +1,6 @@
 package fs2
 
-import fs2.util.{Free,Lub1,Monad,RealSupertype,Sub1,~>}
+import fs2.util.{Async,Free,Lub1,Monad,RealSupertype,Sub1,~>}
 
 /**
  * Mixin trait for various non-primitive operations exposed on `Stream`

--- a/core/src/main/scala/fs2/StreamPipe2Ops.scala
+++ b/core/src/main/scala/fs2/StreamPipe2Ops.scala
@@ -1,6 +1,6 @@
 package fs2
 
-import fs2.util.{RealSupertype,Sub1}
+import fs2.util.{Async,RealSupertype,Sub1}
 
 /**
  * Mixin trait for various non-primitive operations exposed on `Stream`

--- a/core/src/main/scala/fs2/StreamPipeOps.scala
+++ b/core/src/main/scala/fs2/StreamPipeOps.scala
@@ -1,6 +1,6 @@
 package fs2
 
-import fs2.util.Sub1
+import fs2.util.{Async,Sub1}
 
 /**
  * Mixin trait for various non-primitive operations exposed on `Stream`

--- a/core/src/main/scala/fs2/Streams.scala
+++ b/core/src/main/scala/fs2/Streams.scala
@@ -1,7 +1,6 @@
 package fs2
 
-import fs2.util.Free
-import fs2.util.~>
+import fs2.util.{~>,Async,Free}
 
 /**
 Laws (using infix syntax):

--- a/core/src/main/scala/fs2/Streams.scala
+++ b/core/src/main/scala/fs2/Streams.scala
@@ -71,8 +71,8 @@ trait Streams[Stream[+_[_],+_]] { self =>
 
   def Pull: Pulls[Pull]
 
-  type AsyncStep[F[_],A] = Async.Future[F, Pull[F, Nothing, Step[Chunk[A], Handle[F,A]]]]
-  type AsyncStep1[F[_],A] = Async.Future[F, Pull[F, Nothing, Step[Option[A], Handle[F,A]]]]
+  type AsyncStep[F[_],A] = ScopedFuture[F, Pull[F, Nothing, Step[Chunk[A], Handle[F,A]]]]
+  type AsyncStep1[F[_],A] = ScopedFuture[F, Pull[F, Nothing, Step[Option[A], Handle[F,A]]]]
 
   def push[F[_],A](h: Handle[F,A])(c: Chunk[A]): Handle[F,A]
   def cons[F[_],A](h: Stream[F,A])(c: Chunk[A]): Stream[F,A]
@@ -89,4 +89,3 @@ trait Streams[Stream[+_[_],+_]] { self =>
   def runFoldFree[F[_],A,B](s: Stream[F,A], z: B)(f: (B,A) => B): Free[F,B]
   def runFoldTraceFree[F[_],A,B](t: Trace)(s: Stream[F,A], z: B)(f: (B,A) => B): Free[F,B]
 }
-

--- a/core/src/main/scala/fs2/async/async.scala
+++ b/core/src/main/scala/fs2/async/async.scala
@@ -1,5 +1,6 @@
 package fs2
 
+import fs2.util.Async
 import fs2.async.mutable.Topic
 
 package object async {

--- a/core/src/main/scala/fs2/async/channel.scala
+++ b/core/src/main/scala/fs2/async/channel.scala
@@ -2,6 +2,7 @@ package fs2
 package async
 
 import fs2.async.mutable.Queue
+import fs2.util.Async
 import fs2.util.syntax._
 
 object channel {

--- a/core/src/main/scala/fs2/async/immutable/Signal.scala
+++ b/core/src/main/scala/fs2/async/immutable/Signal.scala
@@ -1,8 +1,7 @@
 package fs2.async.immutable
 
-import fs2.{pipe, Async, Stream}
-import fs2.util.Functor
-import fs2.Async
+import fs2.{pipe,Stream}
+import fs2.util.{Async,Functor}
 import fs2.async.immutable
 
 /** A holder of a single value of type `A` that can be read in the effect `F`. */

--- a/core/src/main/scala/fs2/async/mutable/Queue.scala
+++ b/core/src/main/scala/fs2/async/mutable/Queue.scala
@@ -2,7 +2,7 @@ package fs2
 package async
 package mutable
 
-import fs2.util.Functor
+import fs2.util.{Async,Functor}
 import fs2.util.syntax._
 
 /**

--- a/core/src/main/scala/fs2/async/mutable/Semaphore.scala
+++ b/core/src/main/scala/fs2/async/mutable/Semaphore.scala
@@ -2,6 +2,7 @@ package fs2
 package async
 package mutable
 
+import fs2.util.Async
 import fs2.util.syntax._
 
 /**

--- a/core/src/main/scala/fs2/async/mutable/Topic.scala
+++ b/core/src/main/scala/fs2/async/mutable/Topic.scala
@@ -3,6 +3,7 @@ package async
 package mutable
 
 import fs2.Stream._
+import fs2.util.Async
 import fs2.util.syntax._
 
 /**

--- a/core/src/main/scala/fs2/concurrent.scala
+++ b/core/src/main/scala/fs2/concurrent.scala
@@ -1,5 +1,6 @@
 package fs2
 
+import fs2.util.Async
 import fs2.util.syntax._
 
 object concurrent {

--- a/core/src/main/scala/fs2/pipe.scala
+++ b/core/src/main/scala/fs2/pipe.scala
@@ -1,7 +1,7 @@
 package fs2
 
 import Stream.Handle
-import fs2.util.{Free,Functor,Sub1}
+import fs2.util.{Async,Free,Functor,Sub1}
 
 object pipe {
 

--- a/core/src/main/scala/fs2/pipe2.scala
+++ b/core/src/main/scala/fs2/pipe2.scala
@@ -1,6 +1,5 @@
 package fs2
 
-import Async.Future
 import Stream.Handle
 import fs2.{Pull => P}
 import fs2.util.{Free,Functor,Sub1}
@@ -216,15 +215,15 @@ object pipe2 {
    * elements of `s` first.
    */
   def merge[F[_]:Async,O]: Pipe2[F,O,O,O] = (s1, s2) => {
-    def go(l: Future[F, Pull[F, Nothing, Step[Chunk[O], Handle[F,O]]]],
-           r: Future[F, Pull[F, Nothing, Step[Chunk[O], Handle[F,O]]]]): Pull[F,O,Nothing] =
-      (l race r).force flatMap {
+    def go(l: ScopedFuture[F, Pull[F, Nothing, Step[Chunk[O], Handle[F,O]]]],
+           r: ScopedFuture[F, Pull[F, Nothing, Step[Chunk[O], Handle[F,O]]]]): Pull[F,O,Nothing] =
+      (l race r).pull flatMap {
         case Left(l) => l.optional flatMap {
-          case None => r.force.flatMap(identity).flatMap { case hd #: tl => P.output(hd) >> P.echo(tl) }
+          case None => r.pull.flatMap(identity).flatMap { case hd #: tl => P.output(hd) >> P.echo(tl) }
           case Some(hd #: l) => P.output(hd) >> l.awaitAsync.flatMap(go(_, r))
         }
         case Right(r) => r.optional flatMap {
-          case None => l.force.flatMap(identity).flatMap { case hd #: tl => P.output(hd) >> P.echo(tl) }
+          case None => l.pull.flatMap(identity).flatMap { case hd #: tl => P.output(hd) >> P.echo(tl) }
           case Some(hd #: r) => P.output(hd) >> r.awaitAsync.flatMap(go(l, _))
         }
       }

--- a/core/src/main/scala/fs2/pipe2.scala
+++ b/core/src/main/scala/fs2/pipe2.scala
@@ -2,7 +2,7 @@ package fs2
 
 import Stream.Handle
 import fs2.{Pull => P}
-import fs2.util.{Free,Functor,Sub1}
+import fs2.util.{Async,Free,Functor,Sub1}
 
 object pipe2 {
 

--- a/core/src/main/scala/fs2/pull1.scala
+++ b/core/src/main/scala/fs2/pull1.scala
@@ -1,5 +1,7 @@
 package fs2
 
+import fs2.util.Async
+
 private[fs2] trait pull1 {
   import Stream.Handle
 

--- a/core/src/main/scala/fs2/pull1.scala
+++ b/core/src/main/scala/fs2/pull1.scala
@@ -150,7 +150,7 @@ private[fs2] trait pull1 {
    */
   def prefetch[F[_]:Async,I](h: Handle[F,I]): Pull[F,Nothing,Pull[F,Nothing,Handle[F,I]]] =
     h.awaitAsync map { fut =>
-      fut.force flatMap { p =>
+      fut.pull flatMap { p =>
         p map { case hd #: h => h push hd }
       }
     }
@@ -179,7 +179,7 @@ private[fs2] trait pull1 {
     if (n <= 0) Pull.pure(h)
     else Pull.awaitLimit(if (n <= Int.MaxValue) n.toInt else Int.MaxValue)(h).flatMap {
       case chunk #: h => Pull.output(chunk) >> take(n - chunk.size.toLong)(h)
-    } 
+    }
 
   /** Emits the last `n` elements of the input. */
   def takeRight[F[_],I](n: Long)(h: Handle[F,I]): Pull[F,Nothing,Vector[I]]  = {

--- a/core/src/main/scala/fs2/task.scala
+++ b/core/src/main/scala/fs2/task.scala
@@ -1,7 +1,7 @@
 package fs2
 
 import fs2.internal.{Actor,Future,LinkedMap}
-import fs2.util.{Effect}
+import fs2.util.{Async,Effect}
 import java.util.concurrent.atomic.{AtomicBoolean,AtomicReference}
 
 import scala.concurrent.duration._

--- a/core/src/main/scala/fs2/task.scala
+++ b/core/src/main/scala/fs2/task.scala
@@ -1,8 +1,8 @@
 package fs2
 
-import fs2.internal.{Actor, Future, LinkedMap}
-import fs2.util.Effect
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+import fs2.internal.{Actor,Future,LinkedMap}
+import fs2.util.{Effect}
+import java.util.concurrent.atomic.{AtomicBoolean,AtomicReference}
 
 import scala.concurrent.duration._
 

--- a/core/src/main/scala/fs2/time/time.scala
+++ b/core/src/main/scala/fs2/time/time.scala
@@ -30,7 +30,7 @@ package object time {
    * @param S           Strategy to run the stream
    * @param scheduler   Scheduler used to schedule tasks
    */
-  def awakeEvery[F[_]](d: FiniteDuration)(implicit F: Async[F], FR: Async.Run[F], S: Strategy, scheduler: Scheduler): Stream[F,FiniteDuration] = {
+  def awakeEvery[F[_]](d: FiniteDuration)(implicit F: Async[F], S: Strategy, scheduler: Scheduler): Stream[F,FiniteDuration] = {
     def metronomeAndSignal: F[(()=>Unit,async.mutable.Signal[F,FiniteDuration])] = {
       async.signalOf[F, FiniteDuration](FiniteDuration(0, NANOSECONDS)).flatMap { signal =>
         val lock = new java.util.concurrent.Semaphore(1)
@@ -39,7 +39,7 @@ package object time {
           val cancel = scheduler.scheduleAtFixedRate(d, d) {
             val d = FiniteDuration(System.nanoTime, NANOSECONDS) - t0
             if (lock.tryAcquire)
-              FR.unsafeRunAsyncEffects(signal.set(d) >> F.delay(lock.release))(_ => ())
+              F.unsafeRunAsync(signal.set(d) >> F.delay(lock.release))(_ => ())
           }
           (cancel, signal)
         }
@@ -78,6 +78,6 @@ package object time {
    * A single-element `Stream` that waits for the duration `d` before emitting its value. This uses the implicit
    * `Scheduler` to signal duration and avoid blocking on thread. After the signal, the execution continues with `S` strategy.
    */
-  def sleep[F[_]: Async : Async.Run](d: FiniteDuration)(implicit S: Strategy, scheduler: Scheduler): Stream[F, Nothing] =
+  def sleep[F[_]: Async](d: FiniteDuration)(implicit S: Strategy, scheduler: Scheduler): Stream[F, Nothing] =
     awakeEvery(d).take(1).drain
 }

--- a/core/src/main/scala/fs2/time/time.scala
+++ b/core/src/main/scala/fs2/time/time.scala
@@ -2,6 +2,7 @@ package fs2
 
 import scala.concurrent.duration._
 
+import fs2.util.Async
 import fs2.util.syntax._
 
 package object time {

--- a/core/src/main/scala/fs2/util/Async.scala
+++ b/core/src/main/scala/fs2/util/Async.scala
@@ -1,6 +1,6 @@
 package fs2
+package util
 
-import fs2.util.Effect
 import fs2.util.syntax._
 
 @annotation.implicitNotFound("No implicit `Async[${F}]` found.\nNote that the implicit `Async[fs2.Task]` requires an implicit `fs2.Strategy` in scope.")
@@ -24,6 +24,9 @@ trait Async[F[_]] extends Effect[F] { self =>
 
   def parallelTraverse[A,B](s: Seq[A])(f: A => F[B]): F[Vector[B]] =
     flatMap(traverse(s)(f andThen start)) { tasks => traverse(tasks)(identity) }
+
+  def parallelSequence[A](v: Seq[F[A]]): F[Vector[A]] =
+    parallelTraverse(v)(identity)
 
   /**
    * Begin asynchronous evaluation of `f` when the returned `F[F[A]]` is
@@ -125,6 +128,4 @@ object Async {
     def modified: Boolean = previous != now
     def map[B](f: A => B): Change[B] = Change(f(previous), f(now))
   }
-
-
 }

--- a/core/src/main/scala/fs2/util/Catchable.scala
+++ b/core/src/main/scala/fs2/util/Catchable.scala
@@ -1,5 +1,6 @@
 package fs2.util
 
+/** Monad which tracks exceptions thrown during evaluation. */
 trait Catchable[F[_]] extends Monad[F] {
   def fail[A](err: Throwable): F[A]
   def attempt[A](fa: F[A]): F[Either[Throwable,A]]

--- a/core/src/main/scala/fs2/util/Effect.scala
+++ b/core/src/main/scala/fs2/util/Effect.scala
@@ -12,4 +12,10 @@ trait Effect[F[_]] extends Catchable[F] {
    * Evaluates `a` each time the returned effect is run.
    */
   def delay[A](a: => A): F[A] = suspend(pure(a))
+
+  /**
+   * Evaluates the specified `F[A]`, possibly asynchronously, and calls the specified
+   * callback with the result of the evaluation.
+   */
+  def unsafeRunAsync[A](fa: F[A])(cb: Either[Throwable, A] => Unit): Unit
 }

--- a/core/src/main/scala/fs2/util/syntax.scala
+++ b/core/src/main/scala/fs2/util/syntax.scala
@@ -23,4 +23,17 @@ object syntax {
   implicit class CatchableOps[F[_],A](val self: F[A]) extends AnyVal {
     def attempt(implicit F: Catchable[F]): F[Either[Throwable,A]] = F.attempt(self)
   }
+
+  implicit class EffectOps[F[_],A](val self: F[A]) extends AnyVal {
+    def unsafeRunAsync(cb: Either[Throwable, A] => Unit)(implicit F: Effect[F]): Unit = F.unsafeRunAsync(self)(cb)
+  }
+
+  implicit class AsyncOps[F[_],A](val self: F[A]) extends AnyVal {
+    def start(implicit F: Async[F]): F[F[A]] = F.start(self)
+  }
+
+  implicit class ParallelTraverseOps[F[_],A](val self: Seq[A]) extends AnyVal {
+    def parallelTraverse[B](f: A => F[B])(implicit F: Async[F]): F[Vector[B]] = F.parallelTraverse(self)(f)
+    def parallelSequence[B](implicit F: Async[F], ev: A =:= F[B]): F[Vector[B]] = F.parallelSequence(self.asInstanceOf[Seq[F[B]]])
+  }
 }

--- a/core/src/test/scala/fs2/TestUtil.scala
+++ b/core/src/test/scala/fs2/TestUtil.scala
@@ -108,7 +108,7 @@ trait TestUtil {
       Failure("failure-in-pure-pull", Stream.emit[Task,Int](42).pull(h => throw Err)),
       Failure("failure-in-async-code",
         Stream.eval[Task,Int](Task.delay(throw Err)).pull { h =>
-          h.invAwaitAsync.flatMap(_.force).flatMap(identity) })
+          h.invAwaitAsync.flatMap(_.pull).flatMap(identity) })
     )
   )
 

--- a/core/src/test/scala/fs2/async/ChannelSpec.scala
+++ b/core/src/test/scala/fs2/async/ChannelSpec.scala
@@ -2,6 +2,7 @@ package fs2
 package async
 
 import java.util.concurrent.atomic.AtomicLong
+import fs2.util.Async
 
 class ChannelSpec extends Fs2Spec {
 
@@ -81,9 +82,8 @@ class ChannelSpec extends Fs2Spec {
 
   def trace[F[_],A](msg: String)(s: Stream[F,A]) = s mapChunks { a => println(msg + ": " + a.toList); a }
 
-  import Async.Future
   def merge2[F[_]:Async,A](a: Stream[F,A], a2: Stream[F,A]): Stream[F,A] = {
-    type FS = Future[F,Stream[F,A]] // Option[Step[Chunk[A],Stream[F,A]]]]
+    type FS = ScopedFuture[F,Stream[F,A]] // Option[Step[Chunk[A],Stream[F,A]]]]
     def go(fa: FS, fa2: FS): Stream[F,A] = (fa race fa2).stream.flatMap {
       case Left(sa) => sa.uncons.flatMap {
         case Some(hd #: sa) => Stream.chunk(hd) ++ (sa.fetchAsync flatMap (go(_,fa2)))

--- a/core/src/test/scala/fs2/async/SemaphoreSpec.scala
+++ b/core/src/test/scala/fs2/async/SemaphoreSpec.scala
@@ -1,6 +1,8 @@
 package fs2
 package async
 
+import fs2.util.Async
+
 class SemaphoreSpec extends Fs2Spec {
 
   override implicit val S: Strategy = fs2.Strategy.fromCachedDaemonPool("SemaphoreSpec")

--- a/io/src/main/scala/fs2/io/file/FileHandle.scala
+++ b/io/src/main/scala/fs2/io/file/FileHandle.scala
@@ -93,7 +93,7 @@ object FileHandle {
     *
     * Uses a `java.nio.Channels.CompletionHandler` to handle callbacks from IO operations.
     */
-  private[fs2] def fromAsynchronousFileChannel[F[_]](chan: AsynchronousFileChannel)(implicit F: Async[F], FR: Async.Run[F]): FileHandle[F] = {
+  private[fs2] def fromAsynchronousFileChannel[F[_]](chan: AsynchronousFileChannel)(implicit F: Async[F]): FileHandle[F] = {
     new FileHandle[F] {
       type Lock = FileLock
 
@@ -160,7 +160,7 @@ object FileHandle {
 
       override def read(numBytes: Int, offset: Long): F[Option[Chunk[Byte]]] = {
         val buf = ByteBuffer.allocate(numBytes)
-        F.delay(chan.read(buf, offset)).map { len => 
+        F.delay(chan.read(buf, offset)).map { len =>
           if (len < 0) None else if (len == 0) Some(Chunk.empty) else Some(Chunk.bytes(buf.array.take(len)))
         }
       }

--- a/io/src/main/scala/fs2/io/file/FileHandle.scala
+++ b/io/src/main/scala/fs2/io/file/FileHandle.scala
@@ -5,7 +5,7 @@ package file
 import java.nio.ByteBuffer
 import java.nio.channels.{AsynchronousFileChannel, FileChannel, FileLock}
 
-import fs2.util.Effect
+import fs2.util.{Async,Effect}
 import fs2.util.syntax._
 
 trait FileHandle[F[_]] {

--- a/io/src/main/scala/fs2/io/file/file.scala
+++ b/io/src/main/scala/fs2/io/file/file.scala
@@ -12,11 +12,11 @@ package object file {
   /**
     * Provides a handler for NIO methods which require a `java.nio.channels.CompletionHandler` instance.
     */
-  private[fs2] def asyncCompletionHandler[F[_], O](f: CompletionHandler[O, Null] => F[Unit])(implicit F: Async[F], FR: Async.Run[F]): F[O] = {
+  private[fs2] def asyncCompletionHandler[F[_], O](f: CompletionHandler[O, Null] => F[Unit])(implicit F: Async[F]): F[O] = {
     F.async[O] { cb =>
       f(new CompletionHandler[O, Null] {
-        override def completed(result: O, attachment: Null): Unit = FR.unsafeRunAsyncEffects(F.delay(cb(Right(result))))(_ => ())
-        override def failed(exc: Throwable, attachment: Null): Unit = FR.unsafeRunAsyncEffects(F.delay(cb(Left(exc))))(_ => ())
+        override def completed(result: O, attachment: Null): Unit = F.unsafeRunAsync(F.delay(cb(Right(result))))(_ => ())
+        override def failed(exc: Throwable, attachment: Null): Unit = F.unsafeRunAsync(F.delay(cb(Left(exc))))(_ => ())
       })
     }
   }
@@ -34,7 +34,7 @@ package object file {
   /**
     * Reads all data asynchronously from the file at the specified `java.nio.file.Path`.
     */
-  def readAllAsync[F[_]](path: Path, chunkSize: Int)(implicit F: Async[F], FR: Async.Run[F]): Stream[F, Byte] =
+  def readAllAsync[F[_]](path: Path, chunkSize: Int)(implicit F: Async[F]): Stream[F, Byte] =
     pulls.fromPathAsync(path, List(StandardOpenOption.READ)).flatMap(pulls.readAllFromFileHandle(chunkSize)).close
 
   //
@@ -58,7 +58,7 @@ package object file {
     *
     * Adds the WRITE flag to any other `OpenOption` flags specified. By default, also adds the CREATE flag.
     */
-  def writeAllAsync[F[_]](path: Path, flags: Seq[StandardOpenOption] = List(StandardOpenOption.CREATE))(implicit F: Async[F], FR: Async.Run[F]): Sink[F, Byte] =
+  def writeAllAsync[F[_]](path: Path, flags: Seq[StandardOpenOption] = List(StandardOpenOption.CREATE))(implicit F: Async[F]): Sink[F, Byte] =
     s => (for {
       in <- s.open
       out <- pulls.fromPathAsync(path, StandardOpenOption.WRITE :: flags.toList)

--- a/io/src/main/scala/fs2/io/file/file.scala
+++ b/io/src/main/scala/fs2/io/file/file.scala
@@ -1,11 +1,11 @@
-package fs2.io
+package fs2
+package io
 
 import java.nio.channels.CompletionHandler
 import java.nio.file.{Path, StandardOpenOption}
 
-import fs2._
 import fs2.Stream.Handle
-import fs2.util.Effect
+import fs2.util.{Async,Effect}
 
 package object file {
 

--- a/io/src/main/scala/fs2/io/file/pulls.scala
+++ b/io/src/main/scala/fs2/io/file/pulls.scala
@@ -59,7 +59,7 @@ object pulls {
     *
     * The `Pull` closes the acquired `java.nio.channels.AsynchronousFileChannel` when it is done.
     */
-  def fromPathAsync[F[_]](path: Path, flags: Seq[OpenOption])(implicit F: Async[F], FR: Async.Run[F]): Pull[F, Nothing, FileHandle[F]] =
+  def fromPathAsync[F[_]](path: Path, flags: Seq[OpenOption])(implicit F: Async[F]): Pull[F, Nothing, FileHandle[F]] =
     fromAsynchronousFileChannel(F.delay(AsynchronousFileChannel.open(path, flags: _*)))
 
   /**
@@ -75,6 +75,6 @@ object pulls {
     *
     * The `Pull` closes the provided `java.nio.channels.AsynchronousFileChannel` when it is done.
     */
-  def fromAsynchronousFileChannel[F[_]](channel: F[AsynchronousFileChannel])(implicit F: Async[F], FR: Async.Run[F]): Pull[F, Nothing, FileHandle[F]] =
+  def fromAsynchronousFileChannel[F[_]](channel: F[AsynchronousFileChannel])(implicit F: Async[F]): Pull[F, Nothing, FileHandle[F]] =
     Pull.acquire(channel.map(FileHandle.fromAsynchronousFileChannel[F]))(_.close())
 }

--- a/io/src/main/scala/fs2/io/file/pulls.scala
+++ b/io/src/main/scala/fs2/io/file/pulls.scala
@@ -6,7 +6,7 @@ import java.nio.channels._
 import java.nio.file._
 
 import fs2.Stream.Handle
-import fs2.util.Effect
+import fs2.util.{Async,Effect}
 import fs2.util.syntax._
 
 object pulls {

--- a/io/src/main/scala/fs2/io/tcp/Socket.scala
+++ b/io/src/main/scala/fs2/io/tcp/Socket.scala
@@ -109,7 +109,6 @@ protected[tcp] object Socket {
     implicit
     AG: AsynchronousChannelGroup
     , F:Async[F]
-    , FR:Async.Run[F]
   ): Stream[F,Socket[F]] = Stream.suspend {
 
     def setup: Stream[F,AsynchronousSocketChannel] = Stream.suspend {
@@ -125,8 +124,8 @@ protected[tcp] object Socket {
     def connect(ch: AsynchronousSocketChannel): F[AsynchronousSocketChannel] = F.async { cb =>
       F.delay {
         ch.connect(to, null, new CompletionHandler[Void, Void] {
-          def completed(result: Void, attachment: Void): Unit = FR.unsafeRunAsyncEffects(F.delay(cb(Right(ch))))(_ => ())
-          def failed(rsn: Throwable, attachment: Void): Unit = FR.unsafeRunAsyncEffects(F.delay(cb(Left(rsn))))(_ => ())
+          def completed(result: Void, attachment: Void): Unit = F.unsafeRunAsync(F.delay(cb(Right(ch))))(_ => ())
+          def failed(rsn: Throwable, attachment: Void): Unit = F.unsafeRunAsync(F.delay(cb(Left(rsn))))(_ => ())
         })
       }
     }
@@ -147,7 +146,6 @@ protected[tcp] object Socket {
     , receiveBufferSize: Int )(
     implicit AG: AsynchronousChannelGroup
     , F:Async[F]
-    , FR:Async.Run[F]
   ): Stream[F, Either[InetSocketAddress, Stream[F, Socket[F]]]] = Stream.suspend {
 
       def setup: F[AsynchronousServerSocketChannel] = F.delay {
@@ -167,8 +165,8 @@ protected[tcp] object Socket {
           def acceptChannel: F[AsynchronousSocketChannel] =
             F.async[AsynchronousSocketChannel] { cb => F.pure {
               sch.accept(null, new CompletionHandler[AsynchronousSocketChannel, Void] {
-                def completed(ch: AsynchronousSocketChannel, attachment: Void): Unit = FR.unsafeRunAsyncEffects(F.delay(cb(Right(ch))))(_ => ())
-                def failed(rsn: Throwable, attachment: Void): Unit = FR.unsafeRunAsyncEffects(F.delay(cb(Left(rsn))))(_ => ())
+                def completed(ch: AsynchronousSocketChannel, attachment: Void): Unit = F.unsafeRunAsync(F.delay(cb(Right(ch))))(_ => ())
+                def failed(rsn: Throwable, attachment: Void): Unit = F.unsafeRunAsync(F.delay(cb(Left(rsn))))(_ => ())
               })
             }}
 
@@ -193,7 +191,7 @@ protected[tcp] object Socket {
   }
 
 
-  def mkSocket[F[_]](ch:AsynchronousSocketChannel)(implicit F:Async[F], FR:Async.Run[F]):Socket[F] = {
+  def mkSocket[F[_]](ch:AsynchronousSocketChannel)(implicit F:Async[F]):Socket[F] = {
 
     // Reads data to remaining capacity of supplied bytebuffer
     // Also measures time the read took returning this as tuple
@@ -203,9 +201,9 @@ protected[tcp] object Socket {
       ch.read(buff, timeoutMs, TimeUnit.MILLISECONDS, (), new CompletionHandler[Integer, Unit] {
         def completed(result: Integer, attachment: Unit): Unit =  {
           val took = System.currentTimeMillis() - started
-          FR.unsafeRunAsyncEffects(F.delay(cb(Right((result, took)))))(_ => ())
+          F.unsafeRunAsync(F.delay(cb(Right((result, took)))))(_ => ())
         }
-        def failed(err: Throwable, attachment: Unit): Unit = FR.unsafeRunAsyncEffects(F.delay(cb(Left(err))))(_ => ())
+        def failed(err: Throwable, attachment: Unit): Unit = F.unsafeRunAsync(F.delay(cb(Left(err))))(_ => ())
       })
     }}
 
@@ -234,12 +232,12 @@ protected[tcp] object Socket {
           val start = System.currentTimeMillis()
           ch.write(buff, remains, TimeUnit.MILLISECONDS, (), new CompletionHandler[Integer, Unit] {
             def completed(result: Integer, attachment: Unit): Unit = {
-              FR.unsafeRunAsyncEffects(F.delay(cb(Right(
+              F.unsafeRunAsync(F.delay(cb(Right(
                 if (buff.remaining() <= 0) None
                 else Some(System.currentTimeMillis() - start)
               ))))(_ => ())
             }
-            def failed(err: Throwable, attachment: Unit): Unit = FR.unsafeRunAsyncEffects(F.delay(cb(Left(err))))(_ => ())
+            def failed(err: Throwable, attachment: Unit): Unit = F.unsafeRunAsync(F.delay(cb(Left(err))))(_ => ())
           })
         }}.flatMap {
           case None => F.pure(())

--- a/io/src/main/scala/fs2/io/tcp/Socket.scala
+++ b/io/src/main/scala/fs2/io/tcp/Socket.scala
@@ -2,7 +2,6 @@ package fs2
 package io
 package tcp
 
-
 import java.net.{StandardSocketOptions, InetSocketAddress, SocketAddress}
 import java.nio.ByteBuffer
 import java.nio.channels.spi.AsynchronousChannelProvider
@@ -10,6 +9,7 @@ import java.nio.channels.{AsynchronousCloseException, AsynchronousServerSocketCh
 import java.util.concurrent.TimeUnit
 
 import fs2.Stream._
+import fs2.util.Async
 import fs2.util.syntax._
 
 import scala.concurrent.duration._

--- a/io/src/main/scala/fs2/io/tcp/tcp.scala
+++ b/io/src/main/scala/fs2/io/tcp/tcp.scala
@@ -1,9 +1,9 @@
-package fs2.io
+package fs2
+package io
 
 import java.net.InetSocketAddress
 import java.nio.channels.AsynchronousChannelGroup
-import fs2._
-
+import fs2.util.Async
 
 package object tcp {
 

--- a/io/src/main/scala/fs2/io/tcp/tcp.scala
+++ b/io/src/main/scala/fs2/io/tcp/tcp.scala
@@ -24,7 +24,7 @@ package object tcp {
     , receiveBufferSize: Int = 256 * 1024
     , keepAlive: Boolean = false
     , noDelay: Boolean = false
-  )( implicit AG: AsynchronousChannelGroup, F: Async[F], FR: Async.Run[F]): Stream[F,Socket[F]] =
+  )( implicit AG: AsynchronousChannelGroup, F: Async[F]): Stream[F,Socket[F]] =
   Socket.client(to,reuseAddress,sendBufferSize,receiveBufferSize,keepAlive,noDelay)
 
   /**
@@ -48,7 +48,7 @@ package object tcp {
     , maxQueued: Int = 0
     , reuseAddress: Boolean = true
     , receiveBufferSize: Int = 256 * 1024)(
-    implicit AG: AsynchronousChannelGroup, F: Async[F], FR: Async.Run[F]
+    implicit AG: AsynchronousChannelGroup, F: Async[F]
   ): Stream[F, Stream[F, Socket[F]]] =
     serverWithLocalAddress(flatMap, maxQueued, reuseAddress, receiveBufferSize).collect { case Right(s) => s }
 
@@ -60,7 +60,7 @@ package object tcp {
     , maxQueued: Int = 0
     , reuseAddress: Boolean = true
     , receiveBufferSize: Int = 256 * 1024)(
-    implicit AG: AsynchronousChannelGroup, F: Async[F], FR: Async.Run[F]
+    implicit AG: AsynchronousChannelGroup, F: Async[F]
   ): Stream[F, Either[InetSocketAddress, Stream[F, Socket[F]]]] =
     Socket.server(flatMap,maxQueued,reuseAddress,receiveBufferSize)
 }

--- a/io/src/main/scala/fs2/io/udp/Socket.scala
+++ b/io/src/main/scala/fs2/io/udp/Socket.scala
@@ -91,12 +91,12 @@ sealed trait Socket[F[_]] {
 
 object Socket {
 
-  private[fs2] def mkSocket[F[_]](channel: DatagramChannel)(implicit AG: AsynchronousSocketGroup, F: Async[F], FR: Async.Run[F]): F[Socket[F]] = F.delay {
+  private[fs2] def mkSocket[F[_]](channel: DatagramChannel)(implicit AG: AsynchronousSocketGroup, F: Async[F]): F[Socket[F]] = F.delay {
     new Socket[F] {
       private val ctx = AG.register(channel)
 
       private def invoke(f: => Unit): Unit =
-        FR.unsafeRunAsyncEffects(F.delay(f))(_ => ())
+        F.unsafeRunAsync(F.delay(f))(_ => ())
 
       def localAddress: F[InetSocketAddress] =
         F.delay(Option(channel.socket.getLocalSocketAddress.asInstanceOf[InetSocketAddress]).getOrElse(throw new ClosedChannelException))
@@ -138,4 +138,3 @@ object Socket {
     }
   }
 }
-

--- a/io/src/main/scala/fs2/io/udp/Socket.scala
+++ b/io/src/main/scala/fs2/io/udp/Socket.scala
@@ -1,11 +1,13 @@
-package fs2.io.udp
+package fs2
+package io
+package udp
 
 import java.net.{InetAddress,NetworkInterface,InetSocketAddress}
 import java.nio.channels.{ClosedChannelException,DatagramChannel}
 
 import scala.concurrent.duration.FiniteDuration
 
-import fs2._
+import fs2.util.Async
 
 sealed trait Socket[F[_]] {
 

--- a/io/src/main/scala/fs2/io/udp/udp.scala
+++ b/io/src/main/scala/fs2/io/udp/udp.scala
@@ -40,7 +40,7 @@ package object udp {
     , multicastInterface: Option[NetworkInterface] = None
     , multicastTTL: Option[Int] = None
     , multicastLoopback: Boolean = true
-  )(implicit AG: AsynchronousSocketGroup, F: Async[F], FR: Async.Run[F]): Stream[F,Socket[F]] = {
+  )(implicit AG: AsynchronousSocketGroup, F: Async[F]): Stream[F,Socket[F]] = {
     val mkChannel = F.delay {
       val channel = protocolFamily.map { pf => DatagramChannel.open(pf) }.getOrElse(DatagramChannel.open())
       channel.setOption[java.lang.Boolean](StandardSocketOptions.SO_REUSEADDR, reuseAddress)

--- a/io/src/main/scala/fs2/io/udp/udp.scala
+++ b/io/src/main/scala/fs2/io/udp/udp.scala
@@ -4,6 +4,7 @@ package io
 import java.net.{InetSocketAddress,NetworkInterface,ProtocolFamily,StandardSocketOptions}
 import java.nio.channels.DatagramChannel
 
+import fs2.util.Async
 import fs2.util.syntax._
 
 package object udp {


### PR DESCRIPTION
This PR includes a number of changes related to the `Async` and `Effect` type classes.

1. The `Effect` type class has a new member, `unsafeRunAsync`, allowing (potentially asynchronous) evaluation of the effect.
2. The `Async.Run` type class has been deleted in favor of using `Effect#unsafeRunAsync`.
3. The `setRun` method has been removed from `Async`, replaced by calling `unsafeRunAsync(F.set(e.fold(F.fail,F.pure)))(_ => ())`.
4. The `setFree` method has been removed from `Async`, replaced with nothing (it was not used).
5. The `Async` type class has been moved to `fs2.util` package and syntax has been added to `fs2.util.syntax`.
6. The `Async.Future` type has been moved to `fs2.ScopedFuture`, making its dependence on `Stream` and `Pull` clearer, and leaving the `Async` type class free of any dependency on stream primitives. Note this includes moving the `read` method from the `Ref` trait to the `ScopedFuture` companion.
7. The `ScopedFuture#force` method was renamed to `pull` to align with the existing `stream` method. I could see calling these `forceAsPull`/`forceAsStream` instead.

For some background discussion of these changes, see #677.