### PR TITLE
Removed a performance optimization in Free#step.

### DIFF
--- a/core/src/main/scala/fs2/StreamDerived.scala
+++ b/core/src/main/scala/fs2/StreamDerived.scala
@@ -233,8 +233,8 @@ trait StreamDerived extends PipeDerived { self: fs2.Stream.type =>
 
   implicit class StreamPureOps[+A](s: Stream[Pure,A]) {
     def toList: List[A] =
-      s.covary[Attempt].runFold(List.empty[A])((b, a) => a :: b).fold(t => throw t, identity).reverse
-    def toVector: Vector[A] = s.covary[Attempt].runLog.fold(t => throw t, identity)
+      s.covary[Task].runFold(List.empty[A])((b, a) => a :: b).unsafeRun.reverse
+    def toVector: Vector[A] = s.covary[Task].runLog.unsafeRun
   }
 
   implicit def covaryPure[F[_],A](s: Stream[Pure,A]): Stream[F,A] = s.covary[F]

--- a/core/src/main/scala/fs2/util/Free.scala
+++ b/core/src/main/scala/fs2/util/Free.scala
@@ -57,25 +57,12 @@ sealed trait Free[+F[_],+A] {
   @annotation.tailrec
   private[fs2] final def _step(iteration: Int): Free[F,A] = this match {
     case Bind(Bind(x, f), g) => (x flatMap (a => f(a) flatMap g))._step(0)
-    case Bind(Pure(x), f) =>
-      // NB: Performance trick - eagerly step through flatMap/pure streams, but yield after so many iterations
-      if (iteration < Free.eagerBindStepDepth) f(x)._step(iteration + 1) else this
     case _ => this
   }
 }
 
 object Free {
-  private val EagerBindStepDepthPropKey = "FreeEagerBindStepDepth"
-  private val EagerBindStepDepthDefault = 250
-  val eagerBindStepDepth = sys.props.get(EagerBindStepDepthPropKey) match {
-    case Some(value) => try value.toInt catch {
-      case _: NumberFormatException =>
-        println(s"Warning: The system property $EagerBindStepDepthPropKey is set to a illegal value ($value) - continuing with the default ($EagerBindStepDepthDefault).")
-        EagerBindStepDepthDefault
-    }
-    case None => EagerBindStepDepthDefault
-  }
-
+  
   trait B[F[_],G[_],A] {
     def f[x]: Either[(F[x], Attempt[x] => G[A]), (x, x => G[A])] => G[A]
   }

--- a/core/src/test/scala/fs2/ResourceSafetySpec.scala
+++ b/core/src/test/scala/fs2/ResourceSafetySpec.scala
@@ -175,6 +175,12 @@ class ResourceSafetySpec extends Fs2Spec with org.scalatest.concurrent.Eventuall
       eventually { c.get shouldBe 0L }
     }
 
+    "evaluating a bracketed stream multiple times is safe" in {
+      val s = Stream.bracket(Task.now(()))(Stream.emit, _ => Task.now(())).run
+      s.unsafeRun
+      s.unsafeRun
+    }
+
     def bracket[A](c: AtomicLong)(s: Stream[Task,A]): Stream[Task,A] = Stream.suspend {
       Stream.bracket(Task.delay { c.decrementAndGet })(
         _ => s,


### PR DESCRIPTION
The performance optimzation eagerly applied `Bind(Pure(x), f)`
while stepping. IIRC, this optimization gave ~20% performance
improvement in some benchmarks. Unfortunately, it is unprincipled. More
specifically, the optimization assumed that `f` is pure. However,
`Free.suspend` (and `Stream.suspend`) are implemented as
`pure(()).flatMap(_ => s)`, so we either need to introduce `suspend` as
a new primitive in `Free` (and `Stream` and maybe other places) or we
need to avoid the assumption that `f` is pure.

Note that the optimization allowed us to use `Either[Throwable,?]` in
the evaluation of pure streams in a stack safe way. Removal of the
optimization requires the effect type to provide its own stack safety.
For now, I've changed pure streams to use `Task` again, though I'm
considering introducing an `fs2.IO` type that provides an `Effect[IO]`
instance along with trampolined synchronous evaluation.