### PR TITLE
add stateless effectful unfold 

### DIFF
--- a/core/src/main/scala/fs2/StreamDerived.scala
+++ b/core/src/main/scala/fs2/StreamDerived.scala
@@ -161,6 +161,16 @@ trait StreamDerived extends PipeDerived { self: fs2.Stream.type =>
     suspend(go(s0))
   }
 
+  /** Like [[unfoldEval]], but takes an effecful computation that manages its state internally. */
+  def unfoldEval0[F[_], A](f: F[Option[A]]): Stream[F,A] = {
+    def go: Stream[F, A] =
+      eval(f).flatMap {
+        case Some(a) => emit(a) ++ go
+        case None    => empty
+      }
+    suspend(go)
+  }
+
   implicit class HandleOps[+F[_],+A](h: Handle[F,A]) {
     def push[A2>:A](c: Chunk[A2])(implicit A2: RealSupertype[A,A2]): Handle[F,A2] =
       self.push(h: Handle[F,A2])(c)

--- a/core/src/test/scala/fs2/StreamSpec.scala
+++ b/core/src/test/scala/fs2/StreamSpec.scala
@@ -123,6 +123,17 @@ class StreamSpec extends Fs2Spec {
         .runLog.unsafeRun().toList shouldBe List.range(10, 0, -1)
     }
 
+    "unfoldEval0" in {
+      val next = {
+        var n = 11
+        Task.delay {  
+          n = n - 1
+          Some(n).filter(_ > 0)
+        }
+      }
+      Stream.unfoldEval0(next).runLog.unsafeRun().toList shouldBe List.range(10, 0, -1)
+    }
+
     "translate stack safety" in {
       import fs2.util.{~>}
       Stream.repeatEval(Task.delay(0)).translate(new (Task ~> Task) { def apply[X](x: Task[X]) = Task.suspend(x) }).take(1000000).run.unsafeRun()


### PR DESCRIPTION
This adds a method to unfold an effectful computation `F[Option[A]]` into `Stream[F,A]`.

resolves #690