### PR TITLE
Moved methods from Pull => Handle that returned a Handle => Pull

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/StreamBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/StreamBenchmark.scala
@@ -36,7 +36,7 @@ class StreamBenchmark extends BenchmarkUtils {
   def awaitPull(N: Int): Int = {
     (Stream.chunk(Chunk.seq(0 to 256000)).pure).repeatPull { s =>
       for {
-        (h,t) <- Pull.awaitN(N)(s)
+        (h,t) <- s.awaitN(N)
         _  <- Pull.output(h.head)
       } yield t
     }.covary[Task].runLast.unsafeRun().get

--- a/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
+++ b/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
@@ -11,7 +11,7 @@ object ResourceTrackerSanityTest extends App {
 }
 
 object RepeatPullSanityTest extends App {
-  def id[A]: Pipe[Pure, A, A] = _ repeatPull Pull.receive1 { (h, t) => Pull.output1(h) as t }
+  def id[A]: Pipe[Pure, A, A] = _ repeatPull { _.receive1 { (h, t) => Pull.output1(h) as t } }
   Stream.constant(1).covary[Task].throughPure(id).run.unsafeRun()
 }
 
@@ -25,16 +25,16 @@ object RepeatEvalSanityTest extends App {
 }
 
 object AppendSanityTest extends App {
-  (Stream.constant(1).covary[Task] ++ Stream.empty).pull(Pull.echo).run.unsafeRun()
+  (Stream.constant(1).covary[Task] ++ Stream.empty).pull(_.echo).run.unsafeRun()
 }
 
 object OnCompleteSanityTest extends App {
-  Stream.constant(1).covary[Task].onComplete(Stream.empty).pull(Pull.echo).run.unsafeRun()
+  Stream.constant(1).covary[Task].onComplete(Stream.empty).pull(_.echo).run.unsafeRun()
 }
 
 object DrainOnCompleteSanityTest extends App {
   import TestUtil.S
-  val s = Stream.repeatEval(Task.delay(1)).pull(Pull.echo).drain.onComplete(Stream.eval_(Task.delay(println("done"))))
+  val s = Stream.repeatEval(Task.delay(1)).pull(_.echo).drain.onComplete(Stream.eval_(Task.delay(println("done"))))
   (Stream.empty[Task, Unit] merge s).run.unsafeRun()
 }
 

--- a/core/shared/src/main/scala/fs2/Handle.scala
+++ b/core/shared/src/main/scala/fs2/Handle.scala
@@ -33,23 +33,12 @@ final class Handle[+F[_],+A](
       case hb :: tb => Pull.pure((hb, new Handle(tb, underlying)))
     }
 
+  /** Await a single element from this `Handle`. */
   def await1: Pull[F,Nothing,(A,Handle[F,A])] =
     await flatMap { case (hd, tl) => hd.uncons match {
       case None => tl.await1
       case Some((h,hs)) => Pull.pure((h, tl push hs))
     }}
-
-  def awaitNonempty: Pull[F, Nothing, (Chunk[A], Handle[F,A])] = Pull.awaitNonempty(this)
-
-  def echo1: Pull[F,A,Handle[F,A]] = Pull.echo1(this)
-
-  def echoChunk: Pull[F,A,Handle[F,A]] = Pull.echoChunk(this)
-
-  def peek: Pull[F, Nothing, (Chunk[A], Handle[F,A])] =
-    await flatMap { case (hd, tl) => Pull.pure((hd, tl.push(hd))) }
-
-  def peek1: Pull[F, Nothing, (A, Handle[F,A])] =
-    await1 flatMap { case (hd, tl) => Pull.pure((hd, tl.push1(hd))) }
 
   def awaitAsync[F2[_],A2>:A](implicit S: Sub1[F,F2], F2: Async[F2], A2: RealSupertype[A,A2]): Pull[F2, Nothing, Handle.AsyncStep[F2,A2]] = {
     val h = Sub1.substHandle(this)(S)
@@ -68,7 +57,195 @@ final class Handle[+F[_],+A](
       }
   }
 
-  def covary[F2[_]](implicit S: Sub1[F,F2]): Handle[F2,A] = Sub1.substHandle(this)
+  /** Like `await`, but return a `Chunk` of no more than `maxChunkSize` elements. */
+  def awaitLimit(maxChunkSize: Int): Pull[F,Nothing,(Chunk[A],Handle[F,A])] =
+    await.map { case s @ (hd, tl) =>
+      if (hd.size <= maxChunkSize) s
+      else (hd.take(maxChunkSize), tl.push(hd.drop(maxChunkSize)))
+    }
+
+  /** Return a `List[Chunk[I]]` from the input whose combined size has a maximum value `n`. */
+  def awaitN(n: Int, allowFewer: Boolean = false): Pull[F,Nothing,(List[Chunk[A]],Handle[F,A])] =
+    if (n <= 0) Pull.pure((Nil, this))
+    else for {
+      (hd, tl) <- awaitLimit(n)
+      (hd2, tl) <- _awaitN0(n, allowFewer)((hd, tl))
+    } yield ((hd :: hd2), tl)
+
+  private def _awaitN0[G[_], X](n: Int, allowFewer: Boolean): ((Chunk[X],Handle[G,X])) => Pull[G, Nothing, (List[Chunk[X]], Handle[G,X])] = {
+    case (hd, tl) =>
+      val next = tl.awaitN(n - hd.size, allowFewer)
+      if (allowFewer) next.optional.map(_.getOrElse((Nil, Handle.empty))) else next
+  }
+
+  /** Await the next available nonempty `Chunk`. */
+  def awaitNonempty: Pull[F,Nothing,(Chunk[A],Handle[F,A])] =
+    this.receive { case s @ (hd, tl) => if (hd.isEmpty) tl.awaitNonempty else Pull.pure(s) }
+
+  /** Await the next available chunk from the input, or `None` if the input is exhausted. */
+  def awaitOption: Pull[F,Nothing,Option[(Chunk[A],Handle[F,A])]] =
+    await.map(Some(_)) or Pull.pure(None)
+
+  /** Await the next available element from the input, or `None` if the input is exhausted. */
+  def await1Option: Pull[F,Nothing,Option[(A,Handle[F,A])]] =
+    await1.map(Some(_)) or Pull.pure(None)
+
+  /** Await the next available non-empty chunk from the input, or `None` if the input is exhausted. */
+  def awaitNonemptyOption: Pull[F, Nothing, Option[(Chunk[A], Handle[F,A])]] =
+    awaitNonempty.map(Some(_)) or Pull.pure(None)
+
+  /** Copy the next available chunk to the output. */
+  def copy: Pull[F,A,Handle[F,A]] =
+    this.receive { (chunk, h) => Pull.output(chunk) >> Pull.pure(h) }
+
+  /** Copy the next available element to the output. */
+  def copy1: Pull[F,A,Handle[F,A]] =
+    this.receive1 { (hd, h) => Pull.output1(hd) >> Pull.pure(h) }
+
+  /** Drop the first `n` elements of this `Handle`, and return the new `Handle`. */
+  def drop(n: Long): Pull[F, Nothing, Handle[F, A]] =
+    if (n <= 0) Pull.pure(this)
+    else awaitLimit(if (n <= Int.MaxValue) n.toInt else Int.MaxValue).flatMap {
+      case (chunk, h) => h.drop(n - chunk.size)
+    }
+
+  /**
+   * Drop elements of the this `Handle` until the predicate `p` fails, and return the new `Handle`.
+   * If nonempty, the first element of the returned `Handle` will fail `p`.
+   */
+  def dropWhile(p: A => Boolean): Pull[F,Nothing,Handle[F,A]] =
+    this.receive { (chunk, h) =>
+      chunk.indexWhere(!p(_)) match {
+        case Some(0) => Pull.pure(h push chunk)
+        case Some(i) => Pull.pure(h push chunk.drop(i))
+        case None    => h.dropWhile(p)
+      }
+    }
+
+  /** Write all inputs to the output of the returned `Pull`. */
+  def echo: Pull[F,A,Nothing] =
+    echoChunk.flatMap(_.echo)
+
+  /** Read a single element from the input and emit it to the output. Returns the new `Handle`. */
+  def echo1: Pull[F,A,Handle[F,A]] =
+    this.receive1 { (a, h) => Pull.output1(a) >> Pull.pure(h) }
+
+  /** Read the next available chunk from the input and emit it to the output. Returns the new `Handle`. */
+  def echoChunk: Pull[F,A,Handle[F,A]] =
+    this.receive { (c, h) => Pull.output(c) >> Pull.pure(h) }
+
+  /** Like `[[awaitN]]`, but leaves the buffered input unconsumed. */
+  def fetchN(n: Int): Pull[F,Nothing,Handle[F,A]] =
+    awaitN(n) map { case (buf, h) => buf.reverse.foldLeft(h)(_ push _) }
+
+  /** Await the next available element where the predicate returns true */
+  def find(f: A => Boolean): Pull[F,Nothing,(A,Handle[F,A])] =
+    this.receive { (chunk, h) =>
+      chunk.indexWhere(f) match {
+        case None => h.find(f)
+        case Some(a) if a + 1 < chunk.size => Pull.pure((chunk(a), h.push(chunk.drop(a + 1))))
+        case Some(a) => Pull.pure((chunk(a), h))
+      }
+    }
+
+  /**
+   * Folds all inputs using an initial value `z` and supplied binary operator, and writes the final
+   * result to the output of the supplied `Pull` when the stream has no more values.
+   */
+  def fold[B](z: B)(f: (B, A) => B): Pull[F,Nothing,B] =
+    await.optional flatMap {
+      case Some((c, h)) => h.fold(c.foldLeft(z)(f))(f)
+      case None => Pull.pure(z)
+    }
+
+  /**
+   * Folds all inputs using the supplied binary operator, and writes the final result to the output of
+   * the supplied `Pull` when the stream has no more values.
+   */
+  def fold1[A2 >: A](f: (A2, A2) => A2): Pull[F,Nothing,A2] =
+    this.receive1 { (o, h) => h.fold[A2](o)(f) }
+
+  /** Write a single `true` value if all input matches the predicate, false otherwise */
+  def forall(p: A => Boolean): Pull[F,Nothing,Boolean] = {
+    await1.optional flatMap {
+      case Some((a, h)) =>
+        if (!p(a)) Pull.pure(false)
+        else h.forall(p)
+      case None => Pull.pure(true)
+    }
+  }
+
+  /** Return the last element of the input, if nonempty. */
+  def last: Pull[F,Nothing,Option[A]] = {
+    def go(prev: Option[A]): Handle[F,A] => Pull[F,Nothing,Option[A]] =
+      h => h.await.optional.flatMap {
+        case None => Pull.pure(prev)
+        case Some((c, h)) => go(c.foldLeft(prev)((_,a) => Some(a)))(h)
+      }
+    go(None)(this)
+  }
+
+  def peek: Pull[F, Nothing, (Chunk[A], Handle[F,A])] =
+    await flatMap { case (hd, tl) => Pull.pure((hd, tl.push(hd))) }
+
+  def peek1: Pull[F, Nothing, (A, Handle[F,A])] =
+    await1 flatMap { case (hd, tl) => Pull.pure((hd, tl.push1(hd))) }
+
+  /**
+   * Like `[[await]]`, but runs the `await` asynchronously. A `flatMap` into
+   * inner `Pull` logically blocks until this await completes.
+   */
+  def prefetch[F2[_]](implicit sub: Sub1[F,F2], F: Async[F2]): Pull[F2,Nothing,Pull[F2,Nothing,Handle[F2,A]]] =
+    awaitAsync map { fut =>
+      fut.pull flatMap { p =>
+        p map { case (hd, h) => h push hd }
+      }
+    }
+
+  /** Emit the first `n` elements of the input and return the new `Handle`. */
+  def take(n: Long): Pull[F,A,Handle[F,A]] =
+    if (n <= 0) Pull.pure(this)
+    else awaitLimit(if (n <= Int.MaxValue) n.toInt else Int.MaxValue).flatMap {
+      case (chunk, h) => Pull.output(chunk) >> h.take(n - chunk.size.toLong)
+    }
+
+  /** Emits the last `n` elements of the input. */
+  def takeRight(n: Long): Pull[F,Nothing,Vector[A]]  = {
+    def go(acc: Vector[A])(h: Handle[F,A]): Pull[F,Nothing,Vector[A]] = {
+      h.awaitN(if (n <= Int.MaxValue) n.toInt else Int.MaxValue, true).optional.flatMap {
+        case None => Pull.pure(acc)
+        case Some((cs, h)) =>
+          val vector = cs.toVector.flatMap(_.toVector)
+          go(acc.drop(vector.length) ++ vector)(h)
+      }
+    }
+    if (n <= 0) Pull.pure(Vector())
+    else go(Vector())(this)
+  }
+
+  /** Like `takeWhile`, but emits the first value which tests false. */
+  def takeThrough(p: A => Boolean): Pull[F,A,Handle[F,A]] =
+    this.receive { (chunk, h) =>
+      chunk.indexWhere(!p(_)) match {
+        case Some(a) => Pull.output(chunk.take(a+1)) >> Pull.pure(h.push(chunk.drop(a+1)))
+        case None => Pull.output(chunk) >> h.takeThrough(p)
+      }
+    }
+
+  /**
+   * Emit the elements of this `Handle` until the predicate `p` fails,
+   * and return the new `Handle`. If nonempty, the returned `Handle` will have
+   * a first element `i` for which `p(i)` is `false`. */
+  def takeWhile(p: A => Boolean): Pull[F,A,Handle[F,A]] =
+    this.receive { (chunk, h) =>
+      chunk.indexWhere(!p(_)) match {
+        case Some(0) => Pull.pure(h.push(chunk))
+        case Some(a) => Pull.output(chunk.take(a)) >> Pull.pure(h.push(chunk.drop(a)))
+        case None    => Pull.output(chunk) >> h.takeWhile(p)
+      }
+    }
+
+  implicit def covary[F2[_]](implicit S: Sub1[F,F2]): Handle[F2,A] = Sub1.substHandle(this)
 
   override def toString = s"Handle($buffer, $underlying)"
 }
@@ -78,18 +255,22 @@ object Handle {
 
   implicit class HandleInvariantEffectOps[F[_],+A](private val self: Handle[F,A]) extends AnyVal {
 
+    /** Apply `f` to the next available `Chunk`. */
     def receive[O,B](f: (Chunk[A],Handle[F,A]) => Pull[F,O,B]): Pull[F,O,B] = self.await.flatMap(f.tupled)
 
+    /** Apply `f` to the next available element. */
     def receive1[O,B](f: (A,Handle[F,A]) => Pull[F,O,B]): Pull[F,O,B] = self.await1.flatMap(f.tupled)
 
+    /** Apply `f` to the next available chunk, or `None` if the input is exhausted. */
     def receiveOption[O,B](f: Option[(Chunk[A],Handle[F,A])] => Pull[F,O,B]): Pull[F,O,B] =
-      Pull.receiveOption(f)(self)
+      self.awaitOption.flatMap(f)
 
+    /** Apply `f` to the next available element, or `None` if the input is exhausted. */
     def receive1Option[O,B](f: Option[(A,Handle[F,A])] => Pull[F,O,B]): Pull[F,O,B] =
-      Pull.receive1Option(f)(self)
+      self.await1Option.flatMap(f)
 
     def receiveNonemptyOption[O,B](f: Option[(Chunk[A],Handle[F,A])] => Pull[F,O,B]): Pull[F,O,B] =
-      Pull.receiveNonemptyOption(f)(self)
+      self.awaitNonemptyOption.flatMap(f)
   }
 
   type AsyncStep[F[_],A] = ScopedFuture[F, Pull[F, Nothing, (Chunk[A], Handle[F,A])]]

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -1,6 +1,6 @@
 package fs2
 
-import fs2.util.{Async,Attempt,Free,NonFatal,RealSupertype,Sub1}
+import fs2.util.{Attempt,Free,NonFatal,RealSupertype,Sub1}
 import StreamCore.Token
 import Pull._
 
@@ -42,7 +42,6 @@ final class Pull[+F[_],+O,+R] private (private val get: Free[AlgebraF[F,O]#f,Opt
       }}
     )(Sub1.sub1[AlgebraF[F,O]#f], implicitly[RealSupertype[Out,Out]])
   }; if (asStep) s else StreamCore.scope(s) }
-
 
   /** Interpret this `Pull` to produce a `Stream`. The result type `R` is discarded. */
   def close: Stream[F,O] = close_(false)
@@ -122,104 +121,15 @@ object Pull {
       case ((token, r), _) => Pull.pure((Pull.release(List(token)), r))
     }}
 
-
   def attemptEval[F[_],R](f: F[R]): Pull[F,Nothing,Attempt[R]] =
     new Pull(Free.attemptEval[AlgebraF[F,Nothing]#f,R](Algebra.Eval(Scope.eval(f))).map(e => Some(Right(e))))
 
   private def attemptPull[F[_],O,R](p: => Pull[F,O,R]): Pull[F,O,R] =
     try p catch { case NonFatal(e) => fail(e) }
 
-  /** Await the next available `Chunk` from the `Handle`. The `Chunk` may be empty. */
-  def await[F[_],I]: Handle[F,I] => Pull[F,Nothing,(Chunk[I],Handle[F,I])] =
-    _.await
-
-  /** Await the next available nonempty `Chunk`. */
-  def awaitNonempty[F[_],I]: Handle[F,I] => Pull[F,Nothing,(Chunk[I],Handle[F,I])] =
-    receive { case s @ (hd, tl) => if (hd.isEmpty) awaitNonempty(tl) else Pull.pure(s) }
-
-  /** Await a single element from the `Handle`. */
-  def await1[F[_],I]: Handle[F,I] => Pull[F,Nothing,(I,Handle[F,I])] =
-    _.await1
-
-  /** Like `await`, but return a `Chunk` of no more than `maxChunkSize` elements. */
-  def awaitLimit[F[_],I](maxChunkSize: Int)
-    : Handle[F,I] => Pull[F,Nothing,(Chunk[I],Handle[F,I])]
-    = _.await.map { case s @ (hd, tl) =>
-        if (hd.size <= maxChunkSize) s
-        else (hd.take(maxChunkSize), tl.push(hd.drop(maxChunkSize)))
-      }
-
-  /** Return a `List[Chunk[I]]` from the input whose combined size has a maximum value `n`. */
-  def awaitN[F[_],I](n: Int, allowFewer: Boolean = false)
-    : Handle[F,I] => Pull[F,Nothing,(List[Chunk[I]],Handle[F,I])]
-    = h =>
-        if (n <= 0) Pull.pure((Nil, h))
-        else for {
-          (hd, tl) <- awaitLimit(n)(h)
-          (hd2, tl) <- _awaitN0(n, allowFewer)((hd, tl))
-        } yield ((hd :: hd2), tl)
-  private def _awaitN0[F[_],I](n: Int, allowFewer: Boolean): ((Chunk[I],Handle[F,I])) => Pull[F, Nothing, (List[Chunk[I]], Handle[F,I])] = {
-    case (hd, tl) =>
-      val next = awaitN(n - hd.size, allowFewer)(tl)
-      if (allowFewer) next.optional.map(_.getOrElse((Nil, Handle.empty))) else next
-  }
-
-  /** Await the next available chunk from the input, or `None` if the input is exhausted. */
-  def awaitOption[F[_],I]: Handle[F,I] => Pull[F,Nothing,Option[(Chunk[I],Handle[F,I])]] =
-    h => h.await.map(Some(_)) or Pull.pure(None)
-
-  /** Await the next available element from the input, or `None` if the input is exhausted. */
-  def await1Option[F[_],I]: Handle[F,I] => Pull[F,Nothing,Option[(I,Handle[F,I])]] =
-    h => h.await1.map(Some(_)) or Pull.pure(None)
-
-  /** Await the next available non-empty chunk from the input, or `None` if the input is exhausted. */
-  def awaitNonemptyOption[F[_],I]: Handle[F, I] => Pull[F, Nothing, Option[(Chunk[I], Handle[F,I])]] =
-    h => awaitNonempty(h).map(Some(_)) or Pull.pure(None)
-
-  /** Copy the next available chunk to the output. */
-  def copy[F[_],I]: Handle[F,I] => Pull[F,I,Handle[F,I]] =
-    receive { (chunk, h) => Pull.output(chunk) >> Pull.pure(h) }
-
-  /** Copy the next available element to the output. */
-  def copy1[F[_],I]: Handle[F,I] => Pull[F,I,Handle[F,I]] =
-    receive1 { (hd, h) => Pull.output1(hd) >> Pull.pure(h) }
-
   /** The completed `Pull`. Reads and outputs nothing. */
   def done: Pull[Nothing,Nothing,Nothing] =
     new Pull(Free.pure(None))
-
-  /** Drop the first `n` elements of the input `Handle`, and return the new `Handle`. */
-  def drop[F[_], I](n: Long): Handle[F, I] => Pull[F, Nothing, Handle[F, I]] =
-    h =>
-      if (n <= 0) Pull.pure(h)
-      else awaitLimit(if (n <= Int.MaxValue) n.toInt else Int.MaxValue)(h).flatMap {
-        case (chunk, h) => drop(n - chunk.size)(h)
-      }
-
-  /**
-   * Drop the elements of the input `Handle` until the predicate `p` fails, and return the new `Handle`.
-   * If nonempty, the first element of the returned `Handle` will fail `p`.
-   */
-  def dropWhile[F[_], I](p: I => Boolean): Handle[F,I] => Pull[F,Nothing,Handle[F,I]] =
-    receive { (chunk, h) =>
-      chunk.indexWhere(!p(_)) match {
-        case Some(0) => Pull.pure(h push chunk)
-        case Some(i) => Pull.pure(h push chunk.drop(i))
-        case None    => dropWhile(p)(h)
-      }
-    }
-
-  /** Write all inputs to the output of the returned `Pull`. */
-  def echo[F[_],I]: Handle[F,I] => Pull[F,I,Nothing] =
-    h => echoChunk(h) flatMap (echo)
-
-  /** Read a single element from the input and emit it to the output. Returns the new `Handle`. */
-  def echo1[F[_],I]: Handle[F,I] => Pull[F,I,Handle[F,I]] =
-    receive1 { (i, h) => Pull.output1(i) >> Pull.pure(h) }
-
-  /** Read the next available chunk from the input and emit it to the output. Returns the new `Handle`. */
-  def echoChunk[F[_],I]: Handle[F,I] => Pull[F,I,Handle[F,I]] =
-    receive { (c, h) => Pull.output(c) >> Pull.pure(h) }
 
   /** Promote an effect to a `Pull`. */
   def eval[F[_],R](f: F[R]): Pull[F,Nothing,R] =
@@ -231,57 +141,6 @@ object Pull {
   /** The `Pull` that reads and outputs nothing, and fails with the given error. */
   def fail(err: Throwable): Pull[Nothing,Nothing,Nothing] =
     new Pull(Free.pure(Some(Left(err))))
-
-  /** Like `[[awaitN]]`, but leaves the buffered input unconsumed. */
-  def fetchN[F[_],I](n: Int): Handle[F,I] => Pull[F,Nothing,Handle[F,I]] =
-    h => awaitN(n)(h) map { case (buf, h) => buf.reverse.foldLeft(h)(_ push _) }
-
-  /** Await the next available element where the predicate returns true */
-  def find[F[_],I](f: I => Boolean): Handle[F,I] => Pull[F,Nothing,(I,Handle[F,I])] =
-    receive { (chunk, h) =>
-      chunk.indexWhere(f) match {
-        case None => find(f).apply(h)
-        case Some(i) if i + 1 < chunk.size => Pull.pure((chunk(i), h.push(chunk.drop(i + 1))))
-        case Some(i) => Pull.pure((chunk(i), h))
-      }
-    }
-
-  /**
-   * Folds all inputs using an initial value `z` and supplied binary operator, and writes the final
-   * result to the output of the supplied `Pull` when the stream has no more values.
-   */
-  def fold[F[_],I,O](z: O)(f: (O, I) => O): Handle[F,I] => Pull[F,Nothing,O] =
-    h => h.await.optional flatMap {
-      case Some((c, h)) => fold(c.foldLeft(z)(f))(f)(h)
-      case None => Pull.pure(z)
-    }
-
-  /**
-   * Folds all inputs using the supplied binary operator, and writes the final result to the output of
-   * the supplied `Pull` when the stream has no more values.
-   */
-  def fold1[F[_],I](f: (I, I) => I): Handle[F,I] => Pull[F,Nothing,I] =
-    receive1 { (o, h) => fold(o)(f)(h) }
-
-  /** Write a single `true` value if all input matches the predicate, false otherwise */
-  def forall[F[_],I](p: I => Boolean): Handle[F,I] => Pull[F,Nothing,Boolean] = {
-    h => h.await1.optional flatMap {
-      case Some((i, h)) =>
-        if (!p(i)) Pull.pure(false)
-        else forall(p).apply(h)
-      case None => Pull.pure(true)
-    }
-  }
-
-  /** Return the last element of the input `Handle`, if nonempty. */
-  def last[F[_],I]: Handle[F,I] => Pull[F,Nothing,Option[I]] = {
-    def go(prev: Option[I]): Handle[F,I] => Pull[F,Nothing,Option[I]] =
-      h => h.await.optional.flatMap {
-        case None => Pull.pure(prev)
-        case Some((c, h)) => go(c.foldLeft(prev)((_,i) => Some(i)))(h)
-      }
-    go(None)
-  }
 
   /**
    * Repeatedly use the output of the `Pull` as input for the next step of the pull.
@@ -300,7 +159,6 @@ object Pull {
       }
     )
 
-
   /** Write a `Chunk[W]` to the output of this `Pull`. */
   def output[F[_],W](w: Chunk[W]): Pull[F,W,Unit] = outputs(Stream.chunk(w))
 
@@ -315,83 +173,10 @@ object Pull {
   def pure[R](r: R): Pull[Nothing,Nothing,R] =
     new Pull(Free.pure(Some(Right(r))))
 
-  /**
-   * Like `[[await]]`, but runs the `await` asynchronously. A `flatMap` into
-   * inner `Pull` logically blocks until this await completes.
-   */
-  def prefetch[F[_]:Async,I](h: Handle[F,I]): Pull[F,Nothing,Pull[F,Nothing,Handle[F,I]]] =
-    h.awaitAsync map { fut =>
-      fut.pull flatMap { p =>
-        p map { case (hd, h) => h push hd }
-      }
-    }
-
-  /** Apply `f` to the next available `Chunk`. */
-  def receive[F[_],I,O,R](f: (Chunk[I],Handle[F,I]) => Pull[F,O,R]): Handle[F,I] => Pull[F,O,R] =
-    _.await.flatMap(f.tupled)
-
-  /** Apply `f` to the next available element. */
-  def receive1[F[_],I,O,R](f: (I,Handle[F,I]) => Pull[F,O,R]): Handle[F,I] => Pull[F,O,R] =
-    _.await1.flatMap(f.tupled)
-
-  /** Apply `f` to the next available chunk, or `None` if the input is exhausted. */
-  def receiveOption[F[_],I,O,R](f: Option[(Chunk[I],Handle[F,I])] => Pull[F,O,R]): Handle[F,I] => Pull[F,O,R] =
-    awaitOption(_).flatMap(f)
-
-  /** Apply `f` to the next available element, or `None` if the input is exhausted. */
-  def receive1Option[F[_],I,O,R](f: Option[(I,Handle[F,I])] => Pull[F,O,R]): Handle[F,I] => Pull[F,O,R] =
-    await1Option(_).flatMap(f)
-
-  def receiveNonemptyOption[F[_],I,O,R](f: Option[(Chunk[I], Handle[F,I])] => Pull[F,O,R]): Handle[F,I] => Pull[F,O,R] =
-    awaitNonemptyOption(_).flatMap(f)
-
   private[fs2] def release(ts: List[Token]): Pull[Nothing,Nothing,Unit] =
     outputs(Stream.mk(StreamCore.release(ts).drain))
 
   def suspend[F[_],O,R](p: => Pull[F,O,R]): Pull[F,O,R] = Pull.pure(()) flatMap { _ => p }
-
-  /** Emit the first `n` elements of the input `Handle` and return the new `Handle`. */
-  def take[F[_],I](n: Long)(h: Handle[F,I]): Pull[F,I,Handle[F,I]] =
-    if (n <= 0) Pull.pure(h)
-    else Pull.awaitLimit(if (n <= Int.MaxValue) n.toInt else Int.MaxValue)(h).flatMap {
-      case (chunk, h) => Pull.output(chunk) >> take(n - chunk.size.toLong)(h)
-    }
-
-  /** Emits the last `n` elements of the input. */
-  def takeRight[F[_],I](n: Long)(h: Handle[F,I]): Pull[F,Nothing,Vector[I]]  = {
-    def go(acc: Vector[I])(h: Handle[F,I]): Pull[F,Nothing,Vector[I]] = {
-      Pull.awaitN(if (n <= Int.MaxValue) n.toInt else Int.MaxValue, true)(h).optional.flatMap {
-        case None => Pull.pure(acc)
-        case Some((cs, h)) =>
-          val vector = cs.toVector.flatMap(_.toVector)
-          go(acc.drop(vector.length) ++ vector)(h)
-      }
-    }
-    if (n <= 0) Pull.pure(Vector())
-    else go(Vector())(h)
-  }
-
-  /** Like `takeWhile`, but emits the first value which tests false. */
-  def takeThrough[F[_],I](p: I => Boolean): Handle[F,I] => Pull[F,I,Handle[F,I]] =
-    receive { (chunk, h) =>
-      chunk.indexWhere(!p(_)) match {
-        case Some(i) => Pull.output(chunk.take(i+1)) >> Pull.pure(h.push(chunk.drop(i+1)))
-        case None => Pull.output(chunk) >> takeThrough(p)(h)
-      }
-    }
-
-  /**
-   * Emit the elements of the input `Handle` until the predicate `p` fails,
-   * and return the new `Handle`. If nonempty, the returned `Handle` will have
-   * a first element `i` for which `p(i)` is `false`. */
-  def takeWhile[F[_],I](p: I => Boolean): Handle[F,I] => Pull[F,I,Handle[F,I]] =
-    receive { (chunk, h) =>
-      chunk.indexWhere(!p(_)) match {
-        case Some(0) => Pull.pure(h.push(chunk))
-        case Some(i) => Pull.output(chunk.take(i)) >> Pull.pure(h.push(chunk.drop(i)))
-        case None    => Pull.output(chunk) >> takeWhile(p)(h)
-      }
-    }
 
   implicit def covaryPure[F[_],W,R](p: Pull[Pure,W,R]): Pull[F,W,R] = p.covary[F]
 }

--- a/core/shared/src/main/scala/fs2/pipe2.scala
+++ b/core/shared/src/main/scala/fs2/pipe2.scala
@@ -38,25 +38,25 @@ object pipe2 {
                             }
                        }
       def go1(c1r: Chunk[I], h1: Handle[F,I], h2: Handle[F,I2]): Pull[F, O, Nothing] = {
-        P.receiveNonemptyOption[F,I2,O,Nothing]{
+        h2.receiveNonemptyOption {
           case Some(s2) => zipChunksGo((c1r, h1), s2)
           case None => k1(Left((c1r, h1)))
-        }(h2)
+        }
       }
       def go2(c2r: Chunk[I2], h1: Handle[F,I], h2: Handle[F,I2]): Pull[F, O, Nothing] = {
-        P.receiveNonemptyOption[F,I,O,Nothing]{
+        h1.receiveNonemptyOption {
           case Some(s1) => zipChunksGo(s1, (c2r, h2))
           case None => k2(Left((c2r, h2)))
-        }(h1)
+        }
       }
       def goB(h1 : Handle[F,I], h2: Handle[F,I2]): Pull[F, O, Nothing] = {
-        P.receiveNonemptyOption[F,I,O,Nothing]{
-          case Some(s1) => P.receiveNonemptyOption[F,I2,O,Nothing] {
+        h1.receiveNonemptyOption {
+          case Some(s1) => h2.receiveNonemptyOption {
             case Some(s2) => zipChunksGo(s1, s2)
             case None => k1(Left(s1))
-          }(h2)
+          }
           case None => k2(Right(h2))
-        }(h1)
+        }
       }
       _.pull2(_)(goB)
   }
@@ -217,11 +217,11 @@ object pipe2 {
            r: ScopedFuture[F, Pull[F, Nothing, (Chunk[O], Handle[F,O])]]): Pull[F,O,Nothing] =
       (l race r).pull flatMap {
         case Left(l) => l.optional flatMap {
-          case None => r.pull.flatMap(identity).flatMap { case (hd, tl) => P.output(hd) >> P.echo(tl) }
+          case None => r.pull.flatMap(identity).flatMap { case (hd, tl) => P.output(hd) >> tl.echo }
           case Some((hd, l)) => P.output(hd) >> l.awaitAsync.flatMap(go(_, r))
         }
         case Right(r) => r.optional flatMap {
-          case None => l.pull.flatMap(identity).flatMap { case (hd, tl) => P.output(hd) >> P.echo(tl) }
+          case None => l.pull.flatMap(identity).flatMap { case (hd, tl) => P.output(hd) >> tl.echo }
           case Some((hd, r)) => P.output(hd) >> r.awaitAsync.flatMap(go(l, _))
         }
       }

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -249,7 +249,7 @@ Regardless of how complex the job, the `fs2.Pull` and `fs2.Handle` types can usu
 def open[F[_],I](s: Stream[F,I]): Pull[F,Nothing,Handle[F,I]]
 ```
 
-The `trait Pull[+F[_],+O,+R]` represents a program that may pull values from one or more `Handle` values, write _output_ of type `O`, and return a _result_ of type `R`. It forms a monad in `R` and comes equipped with lots of other useful operations. See the [`Pulls` trait](../core/shared/src/main/scala/fs2/Pulls.scala) for the full set of primitive operations on `Pull`.
+The `trait Pull[+F[_],+O,+R]` represents a program that may pull values from one or more `Handle` values, write _output_ of type `O`, and return a _result_ of type `R`. It forms a monad in `R` and comes equipped with lots of other useful operations. See the [`Pull` class](../core/shared/src/main/scala/fs2/Pull.scala) for the full set of operations on `Pull`.
 
 Let's look at the core operation for implementing `take`. It's just a recursive function:
 
@@ -259,7 +259,7 @@ object Pull_ {
 
   def take[F[_],O](n: Int)(h: Handle[F,O]): Pull[F,O,Nothing] =
     for {
-      (chunk, h) <- if (n <= 0) Pull.done else Pull.awaitLimit(n)(h)
+      (chunk, h) <- if (n <= 0) Pull.done else h.awaitLimit(n)
       tl <- Pull.output(chunk) >> take(n - chunk.size)(h)
     } yield tl
 }
@@ -276,8 +276,8 @@ Let's break it down line by line:
 There's a lot going on in this one line:
 
 * If `n <= 0`, we're done, and stop pulling.
-* Otherwise we have more values to `take`, so we `Pull.awaitLimit(n)(h)`, which returns a `(Chunk[A],Handle[F,I])` (again, inside of the `Pull` effect).
-* The `Pull.awaitLimit(n)(h)` reads from the handle but gives us a `Chunk[O]` with _no more than_ `n` elements. (We can also `h.await1` to read just a single element, `h.await` to read a single `Chunk` of however many are available, `Pull.awaitN(n)(h)` to obtain a `List[Chunk[A]]` totaling exactly `n` elements, and even `h.awaitAsync` and various other _asynchronous_ awaiting functions which we'll discuss in the [Concurrency](#concurrency) section.)
+* Otherwise we have more values to `take`, so we `h.awaitLimit(n)`, which returns a `(Chunk[A],Handle[F,I])` (again, inside of the `Pull` effect).
+* The `h.awaitLimit(n)` reads from the handle but gives us a `Chunk[O]` with _no more than_ `n` elements. (We can also `h.await1` to read just a single element, `h.await` to read a single `Chunk` of however many are available, `h.awaitN(n)` to obtain a `List[Chunk[A]]` totaling exactly `n` elements, and even `h.awaitAsync` and various other _asynchronous_ awaiting functions which we'll discuss in the [Concurrency](#concurrency) section.)
 * Using the pattern `(chunk, h)`, we destructure this step to its `chunk: Chunk[O]` and its `h: Handle[F,O]`. This shadows the outer `h`, which is fine here since it isn't relevant anymore. (Note: nothing stops us from keeping the old `h` around and awaiting from it again if we like, though this isn't usually what we want since it will repeat all the effects of that await.)
 
 Moving on, the `Pull.output(chunk)` writes the chunk we just read to the _output_ of the `Pull`. This binds the `O` type in our `Pull[F,O,R]` we are constructing:
@@ -289,7 +289,7 @@ def output[O](c: Chunk[O]): Pull[Nothing,O,Unit]
 
 It returns a result of `Unit`, which we generally don't care about. The `p >> p2` operator is equivalent to `p flatMap { _ => p2 }`; it just runs `p` for its effects but ignores its result.
 
-So this line is writing the chunk we read, ignoring the `Unit` result, then recusively calling `take` with the new `Handle`, `h`:
+So this line is writing the chunk we read, ignoring the `Unit` result, then recursively calling `take` with the new `Handle`, `h`:
 
 ```Scala
       ...
@@ -313,7 +313,7 @@ _Note:_ The `.pure` converts a `Stream[Nothing,A]` to a `Stream[Pure,A]`. Scala 
 The `pull` method on `Stream` just calls `open` then `close`. We could express the above as:
 
 ```tut
-Stream(1,2,3,4).pure.open.flatMap { Pull_.take(2) }.close
+Stream(1,2,3,4).pure.open.flatMap { _.take(2) }.close
 ```
 
 FS2 takes care to guarantee that any resources allocated by the `Pull` are released when the `close` completes. Note again that _nothing happens_ when we call `.close` on a `Pull`, it is merely establishing a scope in which all resource allocations are tracked so that they may be appropriately freed.
@@ -377,15 +377,15 @@ It flattens the nested stream, letting up to `maxOpen` inner streams run at a ti
 
 The `Async` bound on `F` is required anywhere concurrency is used in the library. As mentioned earlier, though FS2 provides the [`fs2.Task`][Task] type for convenience, and `Task` has an `Async`, users can bring their own effect types provided they also supply an `Async` instance.
 
-If you examine the implementations of the above functions, you'll see a few primitive functions used. Let's look at those. First, `Stream.awaitAsync` requests the next step of a `Handle` asynchronously. Its signature is:
+If you examine the implementations of the above functions, you'll see a few primitive functions used. Let's look at those. First, `h.awaitAsync` requests the next step of a `Handle h` asynchronously. Its signature is:
 
 ```Scala
-type AsyncStep[F[_],A] = Async.Future[F, Pull[F, Nothing, Step[Chunk[A], Handle[F,A]]]]
+type AsyncStep[F[_],A] = ScopedFuture[F, Pull[F, Nothing, (Chunk[A], Handle[F,A])]]
 
-def awaitAsync[F[_],A](h: Handle[F,A])(implicit F: Async[F]): Pull[F, Nothing, AsyncStep[F,A]]
+def awaitAsync[F2[_],A2>:A](implicit S: Sub1[F,F2], F2: Async[F2], A2: RealSupertype[A,A2]): Pull[F2, Nothing, Handle.AsyncStep[F2,A2]]
 ```
 
-A `Future[F,A]` represents a running computation that will eventually yield an `A`. A `Future[F,A]` has a method `.force`, of type `Pull[F,Nothing,A]` that can be used to block until the result is available. A `Future[F,A]` may be raced with another `Future` also---see the implementation of [`pipe2.merge`](../core/shared/src/main/scala/fs2/pipe2.scala).
+A `ScopedFuture[F,A]` represents a running computation that will eventually yield an `A`. A `ScopedFuture[F,A]` has a method `.pull`, of type `Pull[F,Nothing,A]` that can be used to block until the result is available. A `ScopedFuture[F,A]` may be raced with another `ScopedFuture` also---see the implementation of [`pipe2.merge`](../core/shared/src/main/scala/fs2/pipe2.scala).
 
 In addition, there are a number of other concurrency primitives---asynchronous queues, signals, and semaphores. See the [`async` package object](../core/shared/src/main/scala/fs2/async/async.scala) for more details. We'll make use of some of these in the next section when discussing how to talk to the external world.
 


### PR DESCRIPTION
As a result of the recent work on API usability, `Handle` is more of a Real Type in the API. As a result, we can move all of the methods from `Pull` that returned functions of `Handle => Pull` directly on to the handle class.

This has a number of advantages:
 - there's only one way to invoke these functions (e.g., `h.receive { ... }`) instead of two (e.g., `Pull.receive { ... }`)
 - there's only one place to define these functions. Previously, we defined everything on `Pull` (mostly) but then added forwarders from `Handle` for the really common functions
 - the functions are easier to find for folks using IDEs or browsing ScalaDoc
 - the API footprint of the `Pull` object is much smaller
 - we generally get better type inference
 - arguably, it's more intuitive that methods on `Pull` return only instances of `Pull` and not `Handle => Pull`

Suggested by @prange on Gitter: 
> A quick two cents on the api: Would it not be more consistent to move a lot of the convenience functions on `Pull`over to `Handle`? As a newbie, its not very clear why i should turn to `Pull`to implement functions `Handle => Pull`. When i look at some of the functions on Stream, i see they are implemnteted using `Pull, which in turn use functions on `Handle`.  