### PR TITLE
Removed onComplete from Stream

### DIFF
--- a/core/jvm/src/main/scala/fs2/hash/hash.scala
+++ b/core/jvm/src/main/scala/fs2/hash/hash.scala
@@ -18,6 +18,6 @@ package object hash {
         d.update(bytes.values, bytes.offset, bytes.size)
       case c =>
         d.update(c.toArray)
-    }.drain.onComplete(Stream.chunk(Chunk.bytes(d.digest())))
+    }.drain ++ Stream.chunk(Chunk.bytes(d.digest()))
   }
 }

--- a/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
+++ b/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
@@ -28,13 +28,9 @@ object AppendSanityTest extends App {
   (Stream.constant(1).covary[Task] ++ Stream.empty).pull(_.echo).run.unsafeRun()
 }
 
-object OnCompleteSanityTest extends App {
-  Stream.constant(1).covary[Task].onComplete(Stream.empty).pull(_.echo).run.unsafeRun()
-}
-
 object DrainOnCompleteSanityTest extends App {
   import TestUtil.S
-  val s = Stream.repeatEval(Task.delay(1)).pull(_.echo).drain.onComplete(Stream.eval_(Task.delay(println("done"))))
+  val s = Stream.repeatEval(Task.delay(1)).pull(_.echo).drain ++ Stream.eval_(Task.delay(println("done")))
   (Stream.empty[Task, Unit] merge s).run.unsafeRun()
 }
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -4,7 +4,7 @@ This markdown file contains code examples which can be compiled using tut. Switc
 
 # FS2: The Official Guide
 
-This is the official FS2 guide. It gives an overview of the library and its features and it's kept up to date with the code. If you spot a problem with this guide, a nonworking example, or simply have some suggested improvments, open a pull request! It's very much a WIP.
+This is the official FS2 guide. It gives an overview of the library and its features and it's kept up to date with the code. If you spot a problem with this guide, a nonworking example, or simply have some suggested improvements, open a pull request! It's very much a WIP.
 
 ### Table of contents
 
@@ -711,7 +711,7 @@ Regarding 3:
 
 * A stream will never be interrupted while it is acquiring a resource (via `bracket`) or while it is releasing a resource. The `bracket` function guarantees that if FS2 starts acquiring the resource, the corresponding release action will be run.
 * Other than that, Streams can be interrupted in between any two 'steps' of the stream. The steps themselves are atomic from the perspective of FS2. `Stream.eval(eff)` is a single step, `Stream.emit(1)` is a single step, `Stream(1,2,3)` is a single step (emitting a chunk), and all other operations (like `onError`, `++`, and `flatMap`) are multiple steps and can be interrupted. But importantly, user-provided effects that are passed to `eval` are never interrupted once they are started (and FS2 does not have enough knowledge of user-provided effects to know how to interrupt them anyway).
-* _Always use `bracket` or a `bracket`-based function like `onFinalize` for supplying resource cleanup logic or any other logic you want to be run regardless of how the stream terminates. Don't use `onComplete`, `onError`, or `++` for this purpose._
+* _Always use `bracket` or a `bracket`-based function like `onFinalize` for supplying resource cleanup logic or any other logic you want to be run regardless of how the stream terminates. Don't use `onError` or `++` for this purpose._
 
 Let's look at some examples of how this plays out, starting with the synchronous interruption case:
 
@@ -730,7 +730,9 @@ The `take 1` uses `Pull` but doesn't examine the entire stream, and neither of t
 
 ```scala
 scala> (Stream(1) onComplete Stream.fail(Err)).take(1).toList
-res56: List[Int] = List(1)
+<console>:22: error: value onComplete is not a member of fs2.Stream[Nothing,Int]
+       (Stream(1) onComplete Stream.fail(Err)).take(1).toList
+                  ^
 ```
 
 The reason is simple: the consumer (the `take(1)`) terminates as soon as it has an element. Once it has that element, it is done consuming the stream and doesn't bother running any further steps of it, so the stream never actually completes normally---it has been interrupted before that can occur. We may be able to see in this case that nothing follows the emitted `1`, but FS2 doesn't know this until it actually runs another step of the stream.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -729,10 +729,8 @@ res55: List[Int] = List(1)
 The `take 1` uses `Pull` but doesn't examine the entire stream, and neither of these examples will ever throw an error. This makes sense. A bit more subtle is that this code will _also_ never throw an error:
 
 ```scala
-scala> (Stream(1) onComplete Stream.fail(Err)).take(1).toList
-<console>:22: error: value onComplete is not a member of fs2.Stream[Nothing,Int]
-       (Stream(1) onComplete Stream.fail(Err)).take(1).toList
-                  ^
+scala> (Stream(1) ++ Stream.fail(Err)).take(1).toList
+res56: List[Int] = List(1)
 ```
 
 The reason is simple: the consumer (the `take(1)`) terminates as soon as it has an element. Once it has that element, it is done consuming the stream and doesn't bother running any further steps of it, so the stream never actually completes normally---it has been interrupted before that can occur. We may be able to see in this case that nothing follows the emitted `1`, but FS2 doesn't know this until it actually runs another step of the stream.

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -20,7 +20,7 @@ Stateful transformations like `take` and so/on are defined in a completely diffe
 [pull]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-core_2.11/0.9.0-M1/fs2-core_2.11-0.9.0-M1-javadoc.jar/!/index.html#fs2.Pull
 [async]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-core_2.11/0.9.0-M1/fs2-core_2.11-0.9.0-M1-javadoc.jar/!/index.html#fs2.Async
 
-All resources should be acquired using `bracket`. Placing finalizers / cleanup actions in an `onComplete` will not guarantee they are run if a stream is being consumed asynchronously or is terminated early by its consumer.
+All resources should be acquired using `bracket`. Standalone cleanup actions should be placed in an `onFinalize`. The `onComplete` method has been removed as it did not guarantee that its parameter would be run if a stream was consumed asynchronously or was terminated early by its consumer.
 
 ## Small stuff
 
@@ -40,3 +40,4 @@ All resources should be acquired using `bracket`. Placing finalizers / cleanup a
   * Example - Before: `s.wye(s2)(wye.blah)` After `s.through2(s2)(pipe2.blah)`
   * TODO: explanation of `throughv` and `through2v` if needed
 * Use `t.onFinalize(eff)` instead of `t.onComplete(Stream.eval_(eff))`
+* `onHalt` no longer exists

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -4,7 +4,7 @@ This markdown file contains code examples which can be compiled using tut. Switc
 
 # FS2: The Official Guide
 
-This is the official FS2 guide. It gives an overview of the library and its features and it's kept up to date with the code. If you spot a problem with this guide, a nonworking example, or simply have some suggested improvments, open a pull request! It's very much a WIP.
+This is the official FS2 guide. It gives an overview of the library and its features and it's kept up to date with the code. If you spot a problem with this guide, a nonworking example, or simply have some suggested improvements, open a pull request! It's very much a WIP.
 
 ### Table of contents
 
@@ -563,7 +563,7 @@ Regarding 3:
 
 * A stream will never be interrupted while it is acquiring a resource (via `bracket`) or while it is releasing a resource. The `bracket` function guarantees that if FS2 starts acquiring the resource, the corresponding release action will be run.
 * Other than that, Streams can be interrupted in between any two 'steps' of the stream. The steps themselves are atomic from the perspective of FS2. `Stream.eval(eff)` is a single step, `Stream.emit(1)` is a single step, `Stream(1,2,3)` is a single step (emitting a chunk), and all other operations (like `onError`, `++`, and `flatMap`) are multiple steps and can be interrupted. But importantly, user-provided effects that are passed to `eval` are never interrupted once they are started (and FS2 does not have enough knowledge of user-provided effects to know how to interrupt them anyway).
-* _Always use `bracket` or a `bracket`-based function like `onFinalize` for supplying resource cleanup logic or any other logic you want to be run regardless of how the stream terminates. Don't use `onComplete`, `onError`, or `++` for this purpose._
+* _Always use `bracket` or a `bracket`-based function like `onFinalize` for supplying resource cleanup logic or any other logic you want to be run regardless of how the stream terminates. Don't use `onError` or `++` for this purpose._
 
 Let's look at some examples of how this plays out, starting with the synchronous interruption case:
 

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -577,7 +577,7 @@ case object Err extends Throwable
 The `take 1` uses `Pull` but doesn't examine the entire stream, and neither of these examples will ever throw an error. This makes sense. A bit more subtle is that this code will _also_ never throw an error:
 
 ```tut
-(Stream(1) onComplete Stream.fail(Err)).take(1).toList
+(Stream(1) ++ Stream.fail(Err)).take(1).toList
 ```
 
 The reason is simple: the consumer (the `take(1)`) terminates as soon as it has an element. Once it has that element, it is done consuming the stream and doesn't bother running any further steps of it, so the stream never actually completes normally---it has been interrupted before that can occur. We may be able to see in this case that nothing follows the emitted `1`, but FS2 doesn't know this until it actually runs another step of the stream.


### PR DESCRIPTION
This avoids any temptation of using `onComplete` for resource cleanup. Note the slight behavior change in the `hash` module -- old implementation erroneously masked errors in the stream.