### PR TITLE
Introduced Suspendable type class

### DIFF
--- a/core/shared/src/main/scala/fs2/util/Effect.scala
+++ b/core/shared/src/main/scala/fs2/util/Effect.scala
@@ -1,17 +1,7 @@
 package fs2.util
 
-trait Effect[F[_]] extends Catchable[F] {
-
-  /**
-   * Returns an `F[A]` that evaluates and runs the provided `fa` on each run.
-   */
-  def suspend[A](fa: => F[A]): F[A]
-
-  /**
-   * Promotes a non-strict value to an `F`, catching exceptions in the process.
-   * Evaluates `a` each time the returned effect is run.
-   */
-  def delay[A](a: => A): F[A] = suspend(pure(a))
+/** Monad which supports catching exceptions, suspending evaluation, and potentially asynchronous evaluation. */
+trait Effect[F[_]] extends Catchable[F] with Suspendable[F] {
 
   /**
    * Evaluates the specified `F[A]`, possibly asynchronously, and calls the specified

--- a/core/shared/src/main/scala/fs2/util/Suspendable.scala
+++ b/core/shared/src/main/scala/fs2/util/Suspendable.scala
@@ -4,8 +4,9 @@ package fs2.util
  * Monad which supports capturing a deferred evaluation of a by-name `F[A]`.
  *
  * Evaluation is suspended until a value is extracted, typically via the `unsafeRunAsync`
- * method on the related [[Effect]] or [[Async]] type classes. Side-effects that occur
- * while evaluating a suspension are evaluated exactly once at the time of extraction.
+ * method on the related [[Effect]] type class or via a type constructor specific extraction
+ * method (e.g., `unsafeRunSync` on `Task`). Side-effects that occur while evaluating a
+ * suspension are evaluated exactly once at the time of extraction.
  */
 trait Suspendable[F[_]] extends Monad[F] {
 

--- a/core/shared/src/main/scala/fs2/util/Suspendable.scala
+++ b/core/shared/src/main/scala/fs2/util/Suspendable.scala
@@ -1,0 +1,23 @@
+package fs2.util
+
+/**
+ * Monad which supports capturing a deferred evaluation of a by-name `F[A]`.
+ *
+ * Evaluation is suspended until a value is extracted, typically via the `unsafeRunAsync`
+ * method on the related [[Effect]] or [[Async]] type classes. Side-effects that occur
+ * while evaluating a suspension are evaluated exactly once at the time of extraction.
+ */
+trait Suspendable[F[_]] extends Monad[F] {
+
+  /**
+   * Returns an `F[A]` that evaluates and runs the provided `fa` on each run.
+   */
+  def suspend[A](fa: => F[A]): F[A]
+
+  /**
+   * Promotes a non-strict value to an `F`, catching exceptions in the process.
+   * Evaluates `a` each time the returned effect is run.
+   */
+  def delay[A](a: => A): F[A] = suspend(pure(a))
+}
+

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -108,7 +108,7 @@ val eff = Stream.eval(Task.delay { println("TASK BEING RUN!!"); 1 + 1 })
 
 [`Task`](../core/shared/src/main/scala/fs2/Task.scala) is an effect type we'll see a lot in these examples. Creating a `Task` has no side effects, and `Stream.eval` doesn't do anything at the time of creation, it's just a description of what needs to happen when the stream is eventually interpreted. Notice the type of `eff` is now `Stream[Task,Int]`.
 
-The `eval` function works for any effect type, not just `Task`. FS2 does not care what effect type you use for your streams. You may use the included [`Task` type][Task] for effects or bring your own, just by implementing a few interfaces for your effect type ([`Catchable`][Catchable], [`Suspendable`][Suspendable], [`Effect`][Effect], and optional [`Async`][Async] if you wish to use various concurrent operations discussed later). Here's the signature of `eval`:
+The `eval` function works for any effect type, not just `Task`. FS2 does not care what effect type you use for your streams. You may use the included [`Task` type][Task] for effects or bring your own, just by implementing a few interfaces for your effect type ([`Catchable`][Catchable], [`Suspendable`][Suspendable], [`Effect`][Effect], and optionally [`Async`][Async] if you wish to use various concurrent operations discussed later). Here's the signature of `eval`:
 
 ```Scala
 def eval[F[_],A](f: F[A]): Stream[F,A]

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -108,7 +108,7 @@ val eff = Stream.eval(Task.delay { println("TASK BEING RUN!!"); 1 + 1 })
 
 [`Task`](../core/shared/src/main/scala/fs2/Task.scala) is an effect type we'll see a lot in these examples. Creating a `Task` has no side effects, and `Stream.eval` doesn't do anything at the time of creation, it's just a description of what needs to happen when the stream is eventually interpreted. Notice the type of `eff` is now `Stream[Task,Int]`.
 
-The `eval` function works for any effect type, not just `Task`. FS2 does not care what effect type you use for your streams. You may use the included [`Task` type][Task] for effects or bring your own, just by implementing a few interfaces for your effect type ([`Catchable`][Catchable] and optionally [`Effect`][Effect] or [`Async`][Async] if you wish to use various concurrent operations discussed later). Here's the signature of `eval`:
+The `eval` function works for any effect type, not just `Task`. FS2 does not care what effect type you use for your streams. You may use the included [`Task` type][Task] for effects or bring your own, just by implementing a few interfaces for your effect type ([`Catchable`][Catchable], [`Suspendable`][Suspendable], [`Effect`][Effect], and optional [`Async`][Async] if you wish to use various concurrent operations discussed later). Here's the signature of `eval`:
 
 ```Scala
 def eval[F[_],A](f: F[A]): Stream[F,A]
@@ -116,6 +116,7 @@ def eval[F[_],A](f: F[A]): Stream[F,A]
 
 [Task]: ../core/shared/src/main/scala/fs2/Task.scala
 [Catchable]: ../core/shared/src/main/scala/fs2/util/Catchable.scala
+[Suspendable]: ../core/shared/src/main/scala/fs2/util/Suspendable.scala
 [Effect]: ../core/shared/src/main/scala/fs2/util/Effect.scala
 [Async]: ../core/shared/src/main/scala/fs2/util/Async.scala
 
@@ -290,7 +291,7 @@ scala> Stream.bracket(acquire)(_ => Stream(1,2,3) ++ err, _ => release).run.unsa
 incremented: 1
 decremented: 0
 java.lang.Exception: oh noes!
-  ... 818 elided
+  ... 822 elided
 ```
 
 The inner stream fails, but notice the `release` action is still run:

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -80,7 +80,7 @@ val eff = Stream.eval(Task.delay { println("TASK BEING RUN!!"); 1 + 1 })
 
 [`Task`](../core/shared/src/main/scala/fs2/Task.scala) is an effect type we'll see a lot in these examples. Creating a `Task` has no side effects, and `Stream.eval` doesn't do anything at the time of creation, it's just a description of what needs to happen when the stream is eventually interpreted. Notice the type of `eff` is now `Stream[Task,Int]`.
 
-The `eval` function works for any effect type, not just `Task`. FS2 does not care what effect type you use for your streams. You may use the included [`Task` type][Task] for effects or bring your own, just by implementing a few interfaces for your effect type ([`Catchable`][Catchable], [`Suspendable`][Suspendable], [`Effect`][Effect], and optional [`Async`][Async] if you wish to use various concurrent operations discussed later). Here's the signature of `eval`:
+The `eval` function works for any effect type, not just `Task`. FS2 does not care what effect type you use for your streams. You may use the included [`Task` type][Task] for effects or bring your own, just by implementing a few interfaces for your effect type ([`Catchable`][Catchable], [`Suspendable`][Suspendable], [`Effect`][Effect], and optionally [`Async`][Async] if you wish to use various concurrent operations discussed later). Here's the signature of `eval`:
 
 ```Scala
 def eval[F[_],A](f: F[A]): Stream[F,A]

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -80,7 +80,7 @@ val eff = Stream.eval(Task.delay { println("TASK BEING RUN!!"); 1 + 1 })
 
 [`Task`](../core/shared/src/main/scala/fs2/Task.scala) is an effect type we'll see a lot in these examples. Creating a `Task` has no side effects, and `Stream.eval` doesn't do anything at the time of creation, it's just a description of what needs to happen when the stream is eventually interpreted. Notice the type of `eff` is now `Stream[Task,Int]`.
 
-The `eval` function works for any effect type, not just `Task`. FS2 does not care what effect type you use for your streams. You may use the included [`Task` type][Task] for effects or bring your own, just by implementing a few interfaces for your effect type ([`Catchable`][Catchable] and optionally [`Effect`][Effect] or [`Async`][Async] if you wish to use various concurrent operations discussed later). Here's the signature of `eval`:
+The `eval` function works for any effect type, not just `Task`. FS2 does not care what effect type you use for your streams. You may use the included [`Task` type][Task] for effects or bring your own, just by implementing a few interfaces for your effect type ([`Catchable`][Catchable], [`Suspendable`][Suspendable], [`Effect`][Effect], and optional [`Async`][Async] if you wish to use various concurrent operations discussed later). Here's the signature of `eval`:
 
 ```Scala
 def eval[F[_],A](f: F[A]): Stream[F,A]
@@ -88,6 +88,7 @@ def eval[F[_],A](f: F[A]): Stream[F,A]
 
 [Task]: ../core/shared/src/main/scala/fs2/Task.scala
 [Catchable]: ../core/shared/src/main/scala/fs2/util/Catchable.scala
+[Suspendable]: ../core/shared/src/main/scala/fs2/util/Suspendable.scala
 [Effect]: ../core/shared/src/main/scala/fs2/util/Effect.scala
 [Async]: ../core/shared/src/main/scala/fs2/util/Async.scala
 

--- a/io/src/main/scala/fs2/io/file/FileHandle.scala
+++ b/io/src/main/scala/fs2/io/file/FileHandle.scala
@@ -5,7 +5,7 @@ package file
 import java.nio.ByteBuffer
 import java.nio.channels.{AsynchronousFileChannel, FileChannel, FileLock}
 
-import fs2.util.{Async,Effect}
+import fs2.util.{Async,Suspendable}
 import fs2.util.syntax._
 
 trait FileHandle[F[_]] {
@@ -142,7 +142,7 @@ object FileHandle {
   /**
     * Creates a `FileHandle[F]` from a `java.nio.channels.FileChannel`.
     */
-  private[fs2] def fromFileChannel[F[_]](chan: FileChannel)(implicit F: Effect[F]): FileHandle[F] = {
+  private[fs2] def fromFileChannel[F[_]](chan: FileChannel)(implicit F: Suspendable[F]): FileHandle[F] = {
     new FileHandle[F] {
       type Lock = FileLock
 

--- a/io/src/main/scala/fs2/io/file/file.scala
+++ b/io/src/main/scala/fs2/io/file/file.scala
@@ -4,7 +4,7 @@ package io
 import java.nio.channels.CompletionHandler
 import java.nio.file.{Path, StandardOpenOption}
 
-import fs2.util.{Async, Effect}
+import fs2.util.{Async, Suspendable}
 
 package object file {
 
@@ -27,7 +27,7 @@ package object file {
   /**
     * Reads all data synchronously from the file at the specified `java.nio.file.Path`.
     */
-  def readAll[F[_]](path: Path, chunkSize: Int)(implicit F: Effect[F]): Stream[F, Byte] =
+  def readAll[F[_]: Suspendable](path: Path, chunkSize: Int): Stream[F, Byte] =
     pulls.fromPath(path, List(StandardOpenOption.READ)).flatMap(pulls.readAllFromFileHandle(chunkSize)).close
 
   /**
@@ -41,7 +41,7 @@ package object file {
     *
     * Adds the WRITE flag to any other `OpenOption` flags specified. By default, also adds the CREATE flag.
     */
-  def writeAll[F[_]](path: Path, flags: Seq[StandardOpenOption] = List(StandardOpenOption.CREATE))(implicit F: Effect[F]): Sink[F, Byte] =
+  def writeAll[F[_]: Suspendable](path: Path, flags: Seq[StandardOpenOption] = List(StandardOpenOption.CREATE)): Sink[F, Byte] =
     s => (for {
       in <- s.open
       out <- pulls.fromPath(path, StandardOpenOption.WRITE :: flags.toList)

--- a/io/src/main/scala/fs2/io/package.scala
+++ b/io/src/main/scala/fs2/io/package.scala
@@ -1,6 +1,6 @@
 package fs2
 
-import fs2.util.{Async, Effect}
+import fs2.util.{Async, Suspendable}
 import fs2.util.syntax._
 import java.io.{InputStream, OutputStream}
 
@@ -13,7 +13,7 @@ package object io {
     *
     * Blocks the current thread.
     */
-  def readInputStream[F[_]](fis: F[InputStream], chunkSize: Int, closeAfterUse: Boolean = true)(implicit F: Effect[F]): Stream[F, Byte] =
+  def readInputStream[F[_]: Suspendable](fis: F[InputStream], chunkSize: Int, closeAfterUse: Boolean = true): Stream[F, Byte] =
     readInputStreamGeneric(fis, chunkSize, readBytesFromInputStream[F], closeAfterUse)
 
   /**
@@ -36,7 +36,7 @@ package object io {
     *
     * Blocks the current thread.
     */
-  def writeOutputStream[F[_]](fos: F[OutputStream], closeAfterUse: Boolean = true)(implicit F: Effect[F]): Sink[F, Byte] =
+  def writeOutputStream[F[_]: Suspendable](fos: F[OutputStream], closeAfterUse: Boolean = true): Sink[F, Byte] =
     writeOutputStreamGeneric(fos, closeAfterUse, writeBytesToOutputStream[F])
 
   /**
@@ -56,13 +56,13 @@ package object io {
   //
   // STDIN/STDOUT Helpers
 
-  def stdin[F[_]](bufSize: Int)(implicit F: Effect[F]): Stream[F, Byte] =
+  def stdin[F[_]](bufSize: Int)(implicit F: Suspendable[F]): Stream[F, Byte] =
     readInputStream(F.delay(System.in), bufSize, false)
 
   def stdinAsync[F[_]](bufSize: Int)(implicit F: Async[F]): Stream[F, Byte] =
     readInputStreamAsync(F.delay(System.in), bufSize, false)
 
-  def stdout[F[_]](implicit F: Effect[F]): Sink[F, Byte] =
+  def stdout[F[_]](implicit F: Suspendable[F]): Sink[F, Byte] =
     writeOutputStream(F.delay(System.out), false)
 
   def stdoutAsync[F[_]](implicit F: Async[F]): Sink[F, Byte] =


### PR DESCRIPTION
This PR moves `suspend` and `delay` from the `Effect` type class to a
new `Suspendable` type class. There are two motivations for doing this:

 - Exposing `unsafeRunAsync` to any function that requires `suspend`
   or `delay` gives up a lot of parametricity.

 - Some type constructors have `Suspendable` instances but do not
   support value extraction. This came up in the [port of Doobie to
   FS2](https://github.com/tpolecat/doobie/pull/323#issuecomment-239822666).

This [came up on Gitter a while back as
well](http://www.gitterforum.com/discussion/scalaz-scalaz-stream?page=143).

/cc @tpolecat @guersam