### PR TITLE
Added distinctConsecutive and various related pipes

### DIFF
--- a/core/jvm/src/test/scala/fs2/PipeSpec.scala
+++ b/core/jvm/src/test/scala/fs2/PipeSpec.scala
@@ -91,6 +91,14 @@ class PipeSpec extends Fs2Spec {
       runLog(s.get.delete(_ == i)) shouldBe v.diff(Vector(i))
     }
 
+    "distinctConsecutive" in {
+      Stream.empty.covary[Pure].distinctConsecutive.toList shouldBe Nil
+      Stream(1, 2, 3, 4).distinctConsecutive.toList shouldBe List(1, 2, 3, 4)
+      Stream(1, 1, 2, 2, 3, 3, 4, 3).distinctConsecutive.toList shouldBe List(1, 2, 3, 4, 3)
+      Stream("1", "2", "33", "44", "5", "66").distinctConsecutiveBy(_.length).toList shouldBe
+        List("1", "33", "5", "66")
+    }
+
     "drop" in forAll { (s: PureStream[Int], negate: Boolean, n0: SmallNonnegative) =>
       val n = if (negate) -n0.get else n0.get
       runLog(s.get.through(drop(n))) shouldBe runLog(s.get).drop(n)

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -128,8 +128,8 @@ final class Stream[+F[_],+O] private (private val coreRef: Stream.CoreRef[F,O]) 
   /** Alias for `self through [[pipe.filter]]`. */
   def filter(f: O => Boolean): Stream[F,O] = self through pipe.filter(f)
 
-  /** Alias for `self through [[pipe.filterWithLast]]`. */
-  def filterWithLast(f: (O, O) => Boolean): Stream[F,O] = self through pipe.filterWithLast(f)
+  /** Alias for `self through [[pipe.filterWithPrevious]]`. */
+  def filterWithPrevious(f: (O, O) => Boolean): Stream[F,O] = self through pipe.filterWithPrevious(f)
 
   /** Alias for `self through [[pipe.find]]`. */
   def find(f: O => Boolean): Stream[F,O] = self through pipe.find(f)

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -85,6 +85,13 @@ final class Stream[+F[_],+O] private (private val coreRef: Stream.CoreRef[F,O]) 
   /** Alias for `self through [[pipe.delete]]`. */
   def delete(f: O => Boolean): Stream[F,O] = self through pipe.delete(f)
 
+  /** Alias for `self through [[pipe.distinctConsecutive]]`. */
+  def distinctConsecutive: Stream[F,O] = self through pipe.distinctConsecutive
+
+  /** Alias for `self through [[pipe.distinctConsecutiveBy]]`. */
+  def distinctConsecutiveBy[O2](f: O => O2): Stream[F,O] =
+    self through pipe.distinctConsecutiveBy(f)
+
   def drain: Stream[F, Nothing] = flatMap { _ => Stream.empty }
 
   /** Alias for `self through [[pipe.drop]]`. */
@@ -120,6 +127,9 @@ final class Stream[+F[_],+O] private (private val coreRef: Stream.CoreRef[F,O]) 
 
   /** Alias for `self through [[pipe.filter]]`. */
   def filter(f: O => Boolean): Stream[F,O] = self through pipe.filter(f)
+
+  /** Alias for `self through [[pipe.filterBy2]]`. */
+  def filterBy2(f: (O, O) => Boolean): Stream[F,O] = self through pipe.filterBy2(f)
 
   /** Alias for `self through [[pipe.find]]`. */
   def find(f: O => Boolean): Stream[F,O] = self through pipe.find(f)

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -128,8 +128,8 @@ final class Stream[+F[_],+O] private (private val coreRef: Stream.CoreRef[F,O]) 
   /** Alias for `self through [[pipe.filter]]`. */
   def filter(f: O => Boolean): Stream[F,O] = self through pipe.filter(f)
 
-  /** Alias for `self through [[pipe.filterBy2]]`. */
-  def filterBy2(f: (O, O) => Boolean): Stream[F,O] = self through pipe.filterBy2(f)
+  /** Alias for `self through [[pipe.filterWithLast]]`. */
+  def filterWithLast(f: (O, O) => Boolean): Stream[F,O] = self through pipe.filterWithLast(f)
 
   /** Alias for `self through [[pipe.find]]`. */
   def find(f: O => Boolean): Stream[F,O] = self through pipe.find(f)

--- a/core/shared/src/main/scala/fs2/pipe.scala
+++ b/core/shared/src/main/scala/fs2/pipe.scala
@@ -80,7 +80,7 @@ object pipe {
    * using natural equality for comparison.
    */
   def distinctConsecutive[F[_],I]: Stream[F,I] => Stream[F,I] =
-    filterWithLast((i1, i2) => i1 != i2)
+    filterWithPrevious((i1, i2) => i1 != i2)
 
   /**
    * Emits only elements that are distinct from their immediate predecessors
@@ -92,7 +92,7 @@ object pipe {
    * consider something like: `src.map(i => (i, f(i))).distinctConsecutiveBy(_._2).map(_._1)`
    */
   def distinctConsecutiveBy[F[_],I,I2](f: I => I2): Stream[F,I] => Stream[F,I] =
-    filterWithLast((i1, i2) => f(i1) != f(i2))
+    filterWithPrevious((i1, i2) => f(i1) != f(i2))
 
   /** Drop `n` elements of the input, then echo the rest. */
   def drop[F[_],I](n: Long): Stream[F,I] => Stream[F,I] =
@@ -150,7 +150,7 @@ object pipe {
    * Like `filter`, but the predicate `f` depends on the previously emitted and
    * current elements.
    */
-  def filterWithLast[F[_],I](f: (I, I) => Boolean): Stream[F,I] => Stream[F,I] = {
+  def filterWithPrevious[F[_],I](f: (I, I) => Boolean): Stream[F,I] => Stream[F,I] = {
     def go(last: I): Handle[F,I] => Pull[F,I,Unit] =
       _.receive { (c, h) =>
         // Check if we can emit this chunk unmodified

--- a/core/shared/src/main/scala/fs2/pipe.scala
+++ b/core/shared/src/main/scala/fs2/pipe.scala
@@ -75,6 +75,20 @@ object pipe {
   def delete[F[_],I](p: I => Boolean): Stream[F,I] => Stream[F,I] =
     _ pull { h => h.takeWhile((i:I) => !p(i)).flatMap(_.drop(1)).flatMap(_.echo) }
 
+  /**
+   * Emits only elements that are distinct from their immediate predecessors,
+   * using natural equality for comparison.
+   */
+  def distinctConsecutive[F[_],I]: Stream[F,I] => Stream[F,I] =
+    filterBy2((i1, i2) => i1 != i2)
+
+  /**
+   * Emits only elements that are distinct from their immediate predecessors
+   * according to `f`, using natural equality for comparison.
+   */
+  def distinctConsecutiveBy[F[_],I,I2](f: I => I2): Stream[F,I] => Stream[F,I] =
+    filterBy2((i1, i2) => f(i1) != f(i2))
+
   /** Drop `n` elements of the input, then echo the rest. */
   def drop[F[_],I](n: Long): Stream[F,I] => Stream[F,I] =
     _ pull { h => h.drop(n).flatMap(_.echo) }
@@ -126,6 +140,30 @@ object pipe {
   /** Emit only inputs which match the supplied predicate. */
   def filter[F[_], I](f: I => Boolean): Stream[F,I] => Stream[F,I] =
     mapChunks(_ filter f)
+
+  /**
+   * Like `filter`, but the predicate `f` depends on the previously emitted and
+   * current elements.
+   */
+  def filterBy2[F[_],I](f: (I, I) => Boolean): Stream[F,I] => Stream[F,I] = {
+    def go(last: I): Handle[F,I] => Pull[F,I,Unit] =
+      _.receive { (c, h) =>
+        // Check if we can emit this chunk unmodified
+        val (allPass, newLast) = c.foldLeft((true, last)) { case ((acc, last), i) =>
+          (acc && f(last, i), i)
+        }
+        if (allPass) {
+          Pull.output(c) >> go(newLast)(h)
+        } else {
+          val (acc, newLast) = c.foldLeft((Vector.empty[I], last)) { case ((acc, last), i) =>
+            if (f(last, i)) (acc :+ i, i)
+            else (acc, last)
+          }
+          Pull.output(Chunk.indexedSeq(acc)) >> go(newLast)(h)
+        }
+      }
+    _ pull { h => h.receive1 { (i, h) => Pull.output1(i) >> go(i)(h) } }
+  }
 
   /** Emits the first input (if any) which matches the supplied predicate, to the output of the returned `Pull` */
   def find[F[_],I](f: I => Boolean): Stream[F,I] => Stream[F,I] =


### PR DESCRIPTION
Both `distinctConsecutive` and `distinctConsecutiveBy` use natural equality instead of relying on type class based equality. We can add type class variants in fs2-cats and fs2-scalaz by delegating to `filterBy2`. I don't love the name `filterBy2` but I don't have any other suggestions I like better -- e.g. `filterSliding2`, `filterWithLast` -- so I stuck with the name from 0.8.

The implementation of `filterBy2` is optimized for chunks where most elements are distinct. Specifically, it attempts to preserve the chunk structure if possible and only if not does it build a new filtered chunk.