### PR TITLE
Introduced NonEmptyChunk

### DIFF
--- a/core/jvm/src/main/scala/fs2/compress.scala
+++ b/core/jvm/src/main/scala/fs2/compress.scala
@@ -20,7 +20,7 @@ object compress {
               bufferSize: Int = 1024 * 32,
               strategy: Int = Deflater.DEFAULT_STRATEGY): Pipe[F,Byte,Byte] = {
     val pure: Pipe[Pure,Byte,Byte] =
-      _ pull { _.awaitNonEmpty flatMap { step =>
+      _ pull { _.await flatMap { step =>
         val deflater = new Deflater(level, nowrap)
         deflater.setStrategy(strategy)
         val buffer = new Array[Byte](bufferSize)
@@ -35,7 +35,7 @@ object compress {
       Pull.output(Chunk.bytes(result)) >> _deflate_handle(deflater, buffer)(h)
   }
   private def _deflate_handle(deflater: Deflater, buffer: Array[Byte]): Handle[Pure, Byte] => Pull[Pure, Byte, Handle[Pure, Byte]] =
-    _.awaitNonEmpty flatMap _deflate_step(deflater, buffer) or _deflate_finish(deflater, buffer)
+    _.await flatMap _deflate_step(deflater, buffer) or _deflate_finish(deflater, buffer)
   @tailrec
   private def _deflate_collect(deflater: Deflater, buffer: Array[Byte], acc: ArrayBuffer[Byte], fin: Boolean): ArrayBuffer[Byte] = {
     if ((fin && deflater.finished) || (!fin && deflater.needsInput)) acc
@@ -62,7 +62,7 @@ object compress {
   def inflate[F[_]](nowrap: Boolean = false,
               bufferSize: Int = 1024 * 32): Pipe[F,Byte,Byte] = {
     val pure: Pipe[Pure,Byte,Byte] =
-      _ pull { _.awaitNonEmpty flatMap { case (c, h) =>
+      _ pull { _.await flatMap { case (c, h) =>
         val inflater = new Inflater(nowrap)
         val buffer = new Array[Byte](bufferSize)
         inflater.setInput(c.toArray)
@@ -78,7 +78,7 @@ object compress {
       Pull.output(Chunk.bytes(result)) >> _inflate_handle(inflater, buffer)(h)
   }
   private def _inflate_handle(inflater: Inflater, buffer: Array[Byte]): Handle[Pure, Byte] => Pull[Pure, Byte, Handle[Pure, Byte]] =
-    _.awaitNonEmpty flatMap _inflate_step(inflater, buffer) or _inflate_finish(inflater)
+    _.await flatMap _inflate_step(inflater, buffer) or _inflate_finish(inflater)
   @tailrec
   private def _inflate_collect(inflater: Inflater, buffer: Array[Byte], acc: ArrayBuffer[Byte]): ArrayBuffer[Byte] = {
     if (inflater.finished || inflater.needsInput) acc

--- a/core/jvm/src/main/scala/fs2/hash/hash.scala
+++ b/core/jvm/src/main/scala/fs2/hash/hash.scala
@@ -13,11 +13,9 @@ package object hash {
 
   def digest[F[_]](digest: => MessageDigest): Pipe[F,Byte,Byte] = in => Stream.suspend {
     val d = digest
-    in.chunks.map {
-      case bytes: Chunk.Bytes =>
-        d.update(bytes.values, bytes.offset, bytes.size)
-      case c =>
-        d.update(c.toArray)
+    in.chunks.map { c =>
+      val bytes = c.toBytes
+      d.update(bytes.values, bytes.offset, bytes.size)
     }.drain ++ Stream.chunk(Chunk.bytes(d.digest()))
   }
 }

--- a/core/jvm/src/test/scala/fs2/ResourceSafetySpec.scala
+++ b/core/jvm/src/test/scala/fs2/ResourceSafetySpec.scala
@@ -170,7 +170,7 @@ class ResourceSafetySpec extends Fs2Spec with EventuallySupport {
           _ => Task.delay { c.decrementAndGet; () }
         ).evalMap { _ => Task.async[Unit](_ => ()) }.interruptWhen(signal.discrete).run
       }}}
-      eventually(timeout(1.second)) { c.get shouldBe 0L }
+      eventually { c.get shouldBe 0L }
     }
 
     "evaluating a bracketed stream multiple times is safe" in {

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -829,6 +829,10 @@ object NonEmptyChunk {
       def foldRight[B](z: B)(f: (A, B) => B): B = c.foldRight(z)(f)
       def size: Int = c.size
       def take(n: Int): Chunk[A] = c.take(n)
+      override def toBooleans[B >: A](implicit ev: B =:= Boolean): Chunk.Booleans = c.toBooleans(ev)
+      override def toBytes[B >: A](implicit ev: B =:= Byte): Chunk.Bytes = c.toBytes(ev)
+      override def toLongs[B >: A](implicit ev: B =:= Long): Chunk.Longs = c.toLongs(ev)
+      override def toDoubles[B >: A](implicit ev: B =:= Double): Chunk.Doubles = c.toDoubles(ev)
     }
   }
 }

--- a/core/shared/src/main/scala/fs2/Handle.scala
+++ b/core/shared/src/main/scala/fs2/Handle.scala
@@ -6,7 +6,7 @@ import fs2.util.{Async,RealSupertype,Sub1}
  * A currently open `Stream[F,A]`, allowing chunks to be pulled or pushed.
  */
 final class Handle[+F[_],+A](
-  private[fs2] val buffer: List[Chunk[A]],
+  private[fs2] val buffer: List[NonEmptyChunk[A]],
   private[fs2] val underlying: Stream[F,A]
 ) {
 
@@ -22,18 +22,18 @@ final class Handle[+F[_],+A](
 
   def push[A2>:A](c: Chunk[A2])(implicit A2: RealSupertype[A,A2]): Handle[F,A2] =
     if (c.isEmpty) this
-    else new Handle(c :: buffer, underlying)
+    else new Handle(NonEmptyChunk.fromChunkUnsafe(c) :: buffer, underlying)
 
   def push1[A2>:A](a: A2)(implicit A2: RealSupertype[A,A2]): Handle[F,A2] =
     push(Chunk.singleton(a))
 
-  def await: Pull[F,Nothing,(Chunk[A],Handle[F,A])] =
+  def await: Pull[F,Nothing,(NonEmptyChunk[A],Handle[F,A])] =
     buffer match {
-      case List() => underlying.step
+      case Nil => underlying.step
       case hb :: tb => Pull.pure((hb, new Handle(tb, underlying)))
     }
 
-  /** Await a single element from this `Handle`. */
+  /** Awaits a single element from this `Handle`. */
   def await1: Pull[F,Nothing,(A,Handle[F,A])] =
     await flatMap { case (hd, tl) => hd.uncons match {
       case None => tl.await1
@@ -43,7 +43,7 @@ final class Handle[+F[_],+A](
   def awaitAsync[F2[_],A2>:A](implicit S: Sub1[F,F2], F2: Async[F2], A2: RealSupertype[A,A2]): Pull[F2, Nothing, Handle.AsyncStep[F2,A2]] = {
     val h = Sub1.substHandle(this)(S)
     h.buffer match {
-      case List() => h.underlying.stepAsync
+      case Nil => h.underlying.stepAsync
       case hb :: tb => Pull.pure(ScopedFuture.pure(Pull.pure((hb, new Handle(tb, h.underlying)))))
     }
   }
@@ -57,52 +57,46 @@ final class Handle[+F[_],+A](
       }
   }
 
-  /** Like `await`, but return a `Chunk` of no more than `maxChunkSize` elements. */
-  def awaitLimit(maxChunkSize: Int): Pull[F,Nothing,(Chunk[A],Handle[F,A])] =
+  /** Like `await`, but returns a `NonEmptyChunk` of no more than `maxChunkSize` elements. */
+  def awaitLimit(maxChunkSize: Int): Pull[F,Nothing,(NonEmptyChunk[A],Handle[F,A])] = {
+    require(maxChunkSize > 0)
     await.map { case s @ (hd, tl) =>
       if (hd.size <= maxChunkSize) s
-      else (hd.take(maxChunkSize), tl.push(hd.drop(maxChunkSize)))
+      else (NonEmptyChunk.fromChunkUnsafe(hd.take(maxChunkSize)), tl.push(hd.drop(maxChunkSize)))
     }
+  }
 
-  /** Return a `List[Chunk[I]]` from the input whose combined size has a maximum value `n`. */
-  def awaitN(n: Int, allowFewer: Boolean = false): Pull[F,Nothing,(List[Chunk[A]],Handle[F,A])] =
+  /** Returns a `List[NonEmptyChunk[A]]` from the input whose combined size has a maximum value `n`. */
+  def awaitN(n: Int, allowFewer: Boolean = false): Pull[F,Nothing,(List[NonEmptyChunk[A]],Handle[F,A])] =
     if (n <= 0) Pull.pure((Nil, this))
     else for {
       (hd, tl) <- awaitLimit(n)
       (hd2, tl) <- _awaitN0(n, allowFewer)((hd, tl))
     } yield ((hd :: hd2), tl)
 
-  private def _awaitN0[G[_], X](n: Int, allowFewer: Boolean): ((Chunk[X],Handle[G,X])) => Pull[G, Nothing, (List[Chunk[X]], Handle[G,X])] = {
+  private def _awaitN0[G[_], X](n: Int, allowFewer: Boolean): ((NonEmptyChunk[X],Handle[G,X])) => Pull[G, Nothing, (List[NonEmptyChunk[X]], Handle[G,X])] = {
     case (hd, tl) =>
       val next = tl.awaitN(n - hd.size, allowFewer)
       if (allowFewer) next.optional.map(_.getOrElse((Nil, Handle.empty))) else next
   }
 
-  /** Await the next available non-empty `Chunk`. */
-  def awaitNonEmpty: Pull[F,Nothing,(Chunk[A],Handle[F,A])] =
-    this.receive { case s @ (hd, tl) => if (hd.isEmpty) tl.awaitNonEmpty else Pull.pure(s) }
-
-  /** Await the next available chunk from the input, or `None` if the input is exhausted. */
-  def awaitOption: Pull[F,Nothing,Option[(Chunk[A],Handle[F,A])]] =
+  /** Awaits the next available chunk from the input, or `None` if the input is exhausted. */
+  def awaitOption: Pull[F,Nothing,Option[(NonEmptyChunk[A],Handle[F,A])]] =
     await.map(Some(_)) or Pull.pure(None)
 
-  /** Await the next available element from the input, or `None` if the input is exhausted. */
+  /** Awaits the next available element from the input, or `None` if the input is exhausted. */
   def await1Option: Pull[F,Nothing,Option[(A,Handle[F,A])]] =
     await1.map(Some(_)) or Pull.pure(None)
 
-  /** Await the next available non-empty chunk from the input, or `None` if the input is exhausted. */
-  def awaitNonEmptyOption: Pull[F, Nothing, Option[(Chunk[A], Handle[F,A])]] =
-    awaitNonEmpty.map(Some(_)) or Pull.pure(None)
-
-  /** Copy the next available chunk to the output. */
+  /** Copies the next available chunk to the output. */
   def copy: Pull[F,A,Handle[F,A]] =
     this.receive { (chunk, h) => Pull.output(chunk) >> Pull.pure(h) }
 
-  /** Copy the next available element to the output. */
+  /** Copies the next available element to the output. */
   def copy1: Pull[F,A,Handle[F,A]] =
     this.receive1 { (hd, h) => Pull.output1(hd) >> Pull.pure(h) }
 
-  /** Drop the first `n` elements of this `Handle`, and return the new `Handle`. */
+  /** Drops the first `n` elements of this `Handle`, and returns the new `Handle`. */
   def drop(n: Long): Pull[F, Nothing, Handle[F, A]] =
     if (n <= 0) Pull.pure(this)
     else awaitLimit(if (n <= Int.MaxValue) n.toInt else Int.MaxValue).flatMap {
@@ -110,7 +104,7 @@ final class Handle[+F[_],+A](
     }
 
   /**
-   * Drop elements of the this `Handle` until the predicate `p` fails, and return the new `Handle`.
+   * Drops elements of the this `Handle` until the predicate `p` fails, and returns the new `Handle`.
    * If non-empty, the first element of the returned `Handle` will fail `p`.
    */
   def dropWhile(p: A => Boolean): Pull[F,Nothing,Handle[F,A]] =
@@ -122,15 +116,15 @@ final class Handle[+F[_],+A](
       }
     }
 
-  /** Write all inputs to the output of the returned `Pull`. */
+  /** Writes all inputs to the output of the returned `Pull`. */
   def echo: Pull[F,A,Nothing] =
     echoChunk.flatMap(_.echo)
 
-  /** Read a single element from the input and emit it to the output. Returns the new `Handle`. */
+  /** Reads a single element from the input and emits it to the output. Returns the new `Handle`. */
   def echo1: Pull[F,A,Handle[F,A]] =
     this.receive1 { (a, h) => Pull.output1(a) >> Pull.pure(h) }
 
-  /** Read the next available chunk from the input and emit it to the output. Returns the new `Handle`. */
+  /** Reads the next available chunk from the input and emits it to the output. Returns the new `Handle`. */
   def echoChunk: Pull[F,A,Handle[F,A]] =
     this.receive { (c, h) => Pull.output(c) >> Pull.pure(h) }
 
@@ -138,7 +132,7 @@ final class Handle[+F[_],+A](
   def fetchN(n: Int): Pull[F,Nothing,Handle[F,A]] =
     awaitN(n) map { case (buf, h) => buf.reverse.foldLeft(h)(_ push _) }
 
-  /** Await the next available element where the predicate returns true */
+  /** Awaits the next available element where the predicate returns true. */
   def find(f: A => Boolean): Pull[F,Nothing,(A,Handle[F,A])] =
     this.receive { (chunk, h) =>
       chunk.indexWhere(f) match {
@@ -165,7 +159,7 @@ final class Handle[+F[_],+A](
   def fold1[A2 >: A](f: (A2, A2) => A2): Pull[F,Nothing,A2] =
     this.receive1 { (o, h) => h.fold[A2](o)(f) }
 
-  /** Write a single `true` value if all input matches the predicate, false otherwise */
+  /** Writes a single `true` value if all input matches the predicate, `false` otherwise. */
   def forall(p: A => Boolean): Pull[F,Nothing,Boolean] = {
     await1.optional flatMap {
       case Some((a, h)) =>
@@ -175,7 +169,7 @@ final class Handle[+F[_],+A](
     }
   }
 
-  /** Return the last element of the input, if non-empty. */
+  /** Returns the last element of the input, if non-empty. */
   def last: Pull[F,Nothing,Option[A]] = {
     def go(prev: Option[A]): Handle[F,A] => Pull[F,Nothing,Option[A]] =
       h => h.await.optional.flatMap {
@@ -202,7 +196,7 @@ final class Handle[+F[_],+A](
       }
     }
 
-  /** Emit the first `n` elements of the input and return the new `Handle`. */
+  /** Emits the first `n` elements of the input and return the new `Handle`. */
   def take(n: Long): Pull[F,A,Handle[F,A]] =
     if (n <= 0) Pull.pure(this)
     else awaitLimit(if (n <= Int.MaxValue) n.toInt else Int.MaxValue).flatMap {
@@ -233,8 +227,8 @@ final class Handle[+F[_],+A](
     }
 
   /**
-   * Emit the elements of this `Handle` until the predicate `p` fails,
-   * and return the new `Handle`. If non-empty, the returned `Handle` will have
+   * Emits the elements of this `Handle` until the predicate `p` fails,
+   * and returns the new `Handle`. If non-empty, the returned `Handle` will have
    * a first element `i` for which `p(i)` is `false`. */
   def takeWhile(p: A => Boolean): Pull[F,A,Handle[F,A]] =
     this.receive { (chunk, h) =>
@@ -251,7 +245,7 @@ final class Handle[+F[_],+A](
 }
 
 object Handle {
-  def empty[F[_],A]: Handle[F,A] = new Handle(List(), Stream.empty)
+  def empty[F[_],A]: Handle[F,A] = new Handle(Nil, Stream.empty)
 
   implicit class HandleInvariantEffectOps[F[_],+A](private val self: Handle[F,A]) extends AnyVal {
 
@@ -268,11 +262,8 @@ object Handle {
     /** Apply `f` to the next available element, or `None` if the input is exhausted. */
     def receive1Option[O,B](f: Option[(A,Handle[F,A])] => Pull[F,O,B]): Pull[F,O,B] =
       self.await1Option.flatMap(f)
-
-    def receiveNonEmptyOption[O,B](f: Option[(Chunk[A],Handle[F,A])] => Pull[F,O,B]): Pull[F,O,B] =
-      self.awaitNonEmptyOption.flatMap(f)
   }
 
-  type AsyncStep[F[_],A] = ScopedFuture[F, Pull[F, Nothing, (Chunk[A], Handle[F,A])]]
+  type AsyncStep[F[_],A] = ScopedFuture[F, Pull[F, Nothing, (NonEmptyChunk[A], Handle[F,A])]]
   type AsyncStep1[F[_],A] = ScopedFuture[F, Pull[F, Nothing, (Option[A], Handle[F,A])]]
 }

--- a/core/shared/src/main/scala/fs2/StreamCore.scala
+++ b/core/shared/src/main/scala/fs2/StreamCore.scala
@@ -8,7 +8,7 @@ private[fs2] sealed trait StreamCore[F[_],O] { self =>
   type O0
 
   def push[G[_],O2](u: NT[F,G], stack: Stack[G,O,O2]): Scope[G,Stack[G,O0,O2]]
-  def pushEmit(c: Chunk[O]): StreamCore[F,O] = StreamCore.append(StreamCore.chunk(c), self)
+  def pushEmit(c: Chunk[O]): StreamCore[F,O] = if (c.isEmpty) this else StreamCore.append(StreamCore.chunk(c), self)
 
   def render: String
 

--- a/core/shared/src/main/scala/fs2/util/Free.scala
+++ b/core/shared/src/main/scala/fs2/util/Free.scala
@@ -57,6 +57,8 @@ sealed trait Free[+F[_],+A] {
     case Bind(Bind(x, f), g) => (x flatMap (a => f(a) flatMap g)).step
     case _ => this
   }
+
+  override def toString = "Free"
 }
 
 object Free {

--- a/core/shared/src/test/scala/fs2/Fs2Spec.scala
+++ b/core/shared/src/test/scala/fs2/Fs2Spec.scala
@@ -22,7 +22,7 @@ trait Fs2SpecLike extends Suite
   with TestUtil {
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
-    PropertyCheckConfiguration(minSuccessful = 100, workers = 4)
+    PropertyCheckConfiguration(minSuccessful = 25, workers = 4)
 
   override def runTest(testName: String, args: Args): Status = {
     println("Starting " + testName)

--- a/core/shared/src/test/scala/fs2/Fs2Spec.scala
+++ b/core/shared/src/test/scala/fs2/Fs2Spec.scala
@@ -22,7 +22,7 @@ trait Fs2SpecLike extends Suite
   with TestUtil {
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
-    PropertyCheckConfiguration(minSuccessful = 25, workers = 1)
+    PropertyCheckConfiguration(minSuccessful = 100, workers = 4)
 
   override def runTest(testName: String, args: Args): Status = {
     println("Starting " + testName)

--- a/core/shared/src/test/scala/fs2/TextSpec.scala
+++ b/core/shared/src/test/scala/fs2/TextSpec.scala
@@ -177,8 +177,10 @@ class TextSpec extends Fs2Spec {
 
       "grouped in 3 characater chunks" in forAll { (lines0: PureStream[String]) =>
         val lines = lines0.get.map(escapeCrLf)
-        if (lines.toList.nonEmpty) {
-          val s = lines.intersperse("\r\n").toList.mkString.grouped(3).toList
+        val s = lines.intersperse("\r\n").toList.mkString.grouped(3).toList
+        if (s.isEmpty) {
+          Stream.emits(s).throughPure(text.lines).toList shouldBe Nil
+        } else {
           Stream.emits(s).throughPure(text.lines).toList shouldBe lines.toList
           Stream.emits(s).unchunk.throughPure(text.lines).toList shouldBe lines.toList
         }

--- a/core/shared/src/test/scala/fs2/time/TimeSpec.scala
+++ b/core/shared/src/test/scala/fs2/time/TimeSpec.scala
@@ -9,8 +9,9 @@ class TimeSpec extends AsyncFs2Spec {
   "time" - {
 
     "awakeEvery" in {
-      runLogF(time.awakeEvery[Task](500.millis).map(_.toMillis/500).take(5)).map {
-        _ shouldBe Vector(1,2,3,4,5)
+      runLogF(time.awakeEvery[Task](500.millis).map(_.toMillis).take(5)).map { r =>
+        r.zipWithIndex.foreach { case (n, idx) => n shouldBe ((idx + 1) * 500L) +- 50 }
+        Succeeded
       }
     }
 

--- a/core/shared/src/test/scala/fs2/time/TimeSpec.scala
+++ b/core/shared/src/test/scala/fs2/time/TimeSpec.scala
@@ -10,7 +10,7 @@ class TimeSpec extends AsyncFs2Spec {
 
     "awakeEvery" in {
       runLogF(time.awakeEvery[Task](500.millis).map(_.toMillis).take(5)).map { r =>
-        r.zipWithIndex.foreach { case (n, idx) => n shouldBe ((idx + 1) * 500L) +- 50 }
+        r.zipWithIndex.foreach { case (n, idx) => n shouldBe ((idx + 1) * 500L) +- 150 }
         Succeeded
       }
     }

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -138,9 +138,10 @@ import fs2.Chunk
 
 val s1c = Stream.chunk(Chunk.doubles(Array(1.0, 2.0, 3.0)))
 
-s1c.mapChunks {
-  case ds : Chunk.Doubles => /* do things unboxed */ ds
-  case ds => ds.map(_ + 1)
+s1c.mapChunks { ds =>
+  val doubles = ds.toDoubles
+  /* do things unboxed using doubles.{values,offset,size} */
+  doubles
 }
 ```
 
@@ -277,9 +278,9 @@ Let's break it down line by line:
 There's a lot going on in this one line:
 
 * If `n <= 0`, we're done, and stop pulling.
-* Otherwise we have more values to `take`, so we `h.awaitLimit(n)`, which returns a `(Chunk[A],Handle[F,I])` (again, inside of the `Pull` effect).
-* The `h.awaitLimit(n)` reads from the handle but gives us a `Chunk[O]` with _no more than_ `n` elements. (We can also `h.await1` to read just a single element, `h.await` to read a single `Chunk` of however many are available, `h.awaitN(n)` to obtain a `List[Chunk[A]]` totaling exactly `n` elements, and even `h.awaitAsync` and various other _asynchronous_ awaiting functions which we'll discuss in the [Concurrency](#concurrency) section.)
-* Using the pattern `(chunk, h)`, we destructure this step to its `chunk: Chunk[O]` and its `h: Handle[F,O]`. This shadows the outer `h`, which is fine here since it isn't relevant anymore. (Note: nothing stops us from keeping the old `h` around and awaiting from it again if we like, though this isn't usually what we want since it will repeat all the effects of that await.)
+* Otherwise we have more values to `take`, so we `h.awaitLimit(n)`, which returns a `(NonEmptyChunk[A],Handle[F,I])` (again, inside of the `Pull` effect).
+* The `h.awaitLimit(n)` reads from the handle but gives us a `NonEmptyChunk[O]` with _no more than_ `n` elements. (We can also `h.await1` to read just a single element, `h.await` to read a single `NonEmptyChunk` of however many are available, `h.awaitN(n)` to obtain a `List[NonEmptyChunk[A]]` totaling exactly `n` elements, and even `h.awaitAsync` and various other _asynchronous_ awaiting functions which we'll discuss in the [Concurrency](#concurrency) section.)
+* Using the pattern `(chunk, h)`, we destructure this step to its `chunk: NonEmptyChunk[O]` and its `h: Handle[F,O]`. This shadows the outer `h`, which is fine here since it isn't relevant anymore. (Note: nothing stops us from keeping the old `h` around and awaiting from it again if we like, though this isn't usually what we want since it will repeat all the effects of that await.)
 
 Moving on, the `Pull.output(chunk)` writes the chunk we just read to the _output_ of the `Pull`. This binds the `O` type in our `Pull[F,O,R]` we are constructing:
 
@@ -381,7 +382,7 @@ The `Async` bound on `F` is required anywhere concurrency is used in the library
 If you examine the implementations of the above functions, you'll see a few primitive functions used. Let's look at those. First, `h.awaitAsync` requests the next step of a `Handle h` asynchronously. Its signature is:
 
 ```Scala
-type AsyncStep[F[_],A] = ScopedFuture[F, Pull[F, Nothing, (Chunk[A], Handle[F,A])]]
+type AsyncStep[F[_],A] = ScopedFuture[F, Pull[F, Nothing, (NonEmptyChunk[A], Handle[F,A])]]
 
 def awaitAsync[F2[_],A2>:A](implicit S: Sub1[F,F2], F2: Async[F2], A2: RealSupertype[A,A2]): Pull[F2, Nothing, Handle.AsyncStep[F2,A2]]
 ```


### PR DESCRIPTION
This PR introduces the `NonEmptyChunk` type and changes `step` and `stepAsync` to return `NonEmptyChunk` instead of `Chunk`. Removed the non-empty variants of `await` and `receive` since this PR makes them redundant.

Note that folks can't pattern match on a subtype of `Chunk` now but that's okay -- instead, they can call `c.toBytes` to unify the code that works on the underlying array.

Fixes #708 

@pchiusano Sorry for the delay on this one. Busy week. ;)
