### PR TITLE
Add dequeueAvailable and supporting code.

### DIFF
--- a/core/jvm/src/test/scala/fs2/async/QueueSpec.scala
+++ b/core/jvm/src/test/scala/fs2/async/QueueSpec.scala
@@ -21,5 +21,23 @@ class QueueSpec extends Fs2Spec {
         }
       }
     }
+    "dequeueBatch unbounded" in {
+      forAll { (s: PureStream[Int], batchSize: SmallPositive) =>
+        withClue(s.tag) {
+          runLog(Stream.eval(async.unboundedQueue[Task,Option[Int]]).flatMap { q =>
+            s.get.noneTerminate.evalMap(q.enqueue1).drain ++ Stream.constant(batchSize.get).through(q.dequeueBatch).through(pipe.unNoneTerminate)
+          }) shouldBe s.get.toVector
+        }
+      }
+    }
+    "dequeueBatch circularBuffer" in {
+      forAll { (s: PureStream[Int], maxSize: SmallPositive, batchSize: SmallPositive) =>
+        withClue(s.tag) {
+          runLog(Stream.eval(async.circularBuffer[Task,Option[Int]](maxSize.get + 1)).flatMap { q =>
+            s.get.noneTerminate.evalMap(q.enqueue1).drain ++ Stream.constant(batchSize.get).through(q.dequeueBatch).through(pipe.unNoneTerminate)
+          }) shouldBe s.get.toVector.takeRight(maxSize.get)
+        }
+      }
+    }
   }
 }

--- a/core/shared/src/main/scala/fs2/async/mutable/Queue.scala
+++ b/core/shared/src/main/scala/fs2/async/mutable/Queue.scala
@@ -43,8 +43,22 @@ trait Queue[F[_], A] { self =>
   /** Like `dequeue1` but provides a way to cancel the dequeue. */
   def cancellableDequeue1: F[(F[A], F[Unit])]
 
+  /** Dequeue `A`s from this queue. Completes once any values are ready. */
+  def dequeueBatch1(batchSize: Int): F[Chunk[A]]
+
+  /** Like `dequeueAvailable1` but provides a way to cancel the dequeue. */
+  def cancellableDequeueBatch1(batchSize: Int): F[(F[Chunk[A]], F[Unit])]
+
   /** Repeatedly call `dequeue1` forever. */
   def dequeue: Stream[F, A] = Stream.bracket(cancellableDequeue1)(d => Stream.eval(d._1), d => d._2).repeat
+
+  /** Call `dequeueBatch1` once with a provided bound on the elements dequeued. */
+  def dequeueBatch: Pipe[F, Int, A] = _.flatMap { batchSize =>
+    Stream.bracket(cancellableDequeueBatch1(batchSize))(d => Stream.eval(d._1).flatMap(Stream.chunk), d => d._2)
+  }
+
+  /** Call `dequeueBatch1` repeatedly with a bound of `Int.MaxValue` */
+  def dequeueAvailable: Stream[F, A] = Stream.constant(Int.MaxValue).through(dequeueBatch)
 
   /**
    * The time-varying size of this `Queue`. This signal refreshes
@@ -83,6 +97,10 @@ trait Queue[F[_], A] { self =>
       def dequeue1: F[B] = self.dequeue1.map(f)
       def cancellableDequeue1: F[(F[B],F[Unit])] =
         self.cancellableDequeue1.map(bu => bu._1.map(f) -> bu._2)
+      def dequeueBatch1(batchSize: Int): F[Chunk[B]] =
+        self.dequeueBatch1(batchSize).map(_.map(f))
+      def cancellableDequeueBatch1(batchSize: Int): F[(F[Chunk[B]],F[Unit])] =
+        self.cancellableDequeueBatch1(batchSize).map(bu => bu._1.map(_.map(f)) -> bu._2)
     }
 }
 
@@ -94,7 +112,7 @@ object Queue {
       * @param queue    Queue, expressed as vector for fast cons/uncons from head/tail
       * @param deq      A list of waiting dequeuers, added to when queue is empty
       */
-    final case class State(queue: Vector[A], deq: Vector[Async.Ref[F,A]])
+    final case class State(queue: Vector[A], deq: Vector[Async.Ref[F,Chunk[A]]])
 
     Signal(0).flatMap { szSignal =>
     F.refOf[State](State(Vector.empty,Vector.empty)).map { qref =>
@@ -115,28 +133,38 @@ object Queue {
             if (c.previous.deq.isEmpty) // we enqueued a value to the queue
               signalSize(c.previous, c.now).as(true)
             else // queue was empty, we had waiting dequeuers
-              c.previous.deq.head.setPure(a).as(true)
+              c.previous.deq.head.setPure(Chunk.singleton(a)).as(true)
           }
 
         def dequeue1: F[A] = cancellableDequeue1.flatMap { _._1 }
 
         def cancellableDequeue1: F[(F[A],F[Unit])] =
-          F.ref[A].flatMap { r =>
-          qref.modify { s =>
-            if (s.queue.isEmpty) s.copy(deq = s.deq :+ r)
-            else s.copy(queue = s.queue.tail)
-          }.map { c =>
-            val deq = signalSize(c.previous, c.now).flatMap { _ =>
-              if (c.previous.queue.nonEmpty) F.pure(c.previous.queue.head)
-              else r.get
-            }
-            val cleanup =
-              if (c.previous.queue.nonEmpty) F.pure(())
-              else qref.modify { s =>
-                s.copy(deq = s.deq.filterNot(_ == r))
-              }.as(())
-            (deq,cleanup)
-          }}
+          cancellableDequeueBatch1(1).flatMap {
+            case (chunks, cancel) => chunks.map(c => (F.pure(c(0)), cancel))
+          }
+
+        def dequeueBatch1(batchSize: Int): F[Chunk[A]] =
+          cancellableDequeueBatch1(batchSize).flatMap { _._1 }
+
+        def cancellableDequeueBatch1(batchSize: Int): F[(F[Chunk[A]],F[Unit])] =
+          F.ref[Chunk[A]].flatMap { r =>
+            qref.modify { s =>
+              if (s.queue.isEmpty) s.copy(deq = s.deq :+ r)
+              else s.copy(queue = s.queue.drop(batchSize))
+            }.map { c =>
+              val deq = signalSize(c.previous, c.now).flatMap { _ =>
+                if (c.previous.queue.nonEmpty) F.pure {
+                    if (batchSize == 1) Chunk.singleton(c.previous.queue.head) else Chunk.indexedSeq(c.previous.queue.take(batchSize))
+                }
+                else r.get
+              }
+              val cleanup =
+                if (c.previous.queue.nonEmpty) F.pure(())
+                else qref.modify { s =>
+                  s.copy(deq = s.deq.filterNot(_ == r))
+                }.as(())
+              (deq,cleanup)
+            }}
 
         def size = szSignal
         def full: immutable.Signal[F, Boolean] = Signal.constant[F,Boolean](false)
@@ -154,8 +182,11 @@ object Queue {
         def offer1(a: A): F[Boolean] =
           permits.tryDecrement.flatMap { b => if (b) q.offer1(a) else F.pure(false) }
         def dequeue1: F[A] = cancellableDequeue1.flatMap { _._1 }
-        def cancellableDequeue1: F[(F[A],F[Unit])] =
-          q.cancellableDequeue1.map { case (deq,cancel) => (deq.flatMap(a => permits.increment.as(a)), cancel) }
+        override def cancellableDequeue1: F[(F[A], F[Unit])] =
+          cancellableDequeueBatch1(1).flatMap { case (chunks, cancel) => chunks.map(c => (F.pure(c(0)), cancel)) }
+        override def dequeueBatch1(batchSize: Int): F[Chunk[A]] = cancellableDequeueBatch1(batchSize).flatMap { _._1 }
+        def cancellableDequeueBatch1(batchSize: Int): F[(F[Chunk[A]],F[Unit])] =
+          q.cancellableDequeueBatch1(batchSize).map { case (deq,cancel) => (deq.flatMap(a => permits.incrementBy(a.size).as(a)), cancel) }
         def size = q.size
         def full: immutable.Signal[F, Boolean] = q.size.map(_ >= maxSize)
         def available: immutable.Signal[F, Int] = q.size.map(maxSize - _)
@@ -172,11 +203,14 @@ object Queue {
         def offer1(a: A): F[Boolean] =
           enqueue1(a).as(true)
         def dequeue1: F[A] = cancellableDequeue1.flatMap { _._1 }
-        def cancellableDequeue1: F[(F[A],F[Unit])] =
-          q.cancellableDequeue1.map { case (deq,cancel) => (deq.flatMap(a => permits.increment.as(a)), cancel) }
+        def dequeueBatch1(batchSize: Int): F[Chunk[A]] = cancellableDequeueBatch1(batchSize).flatMap { _._1 }
+        def cancellableDequeue1: F[(F[A], F[Unit])] = cancellableDequeueBatch1(1).flatMap { case (chunks, cancel) => chunks.map(c => (F.pure(c(0)), cancel))}
+        def cancellableDequeueBatch1(batchSize: Int): F[(F[Chunk[A]],F[Unit])] =
+          q.cancellableDequeueBatch1(batchSize).map { case (deq,cancel) => (deq.flatMap(a => permits.incrementBy(a.size).as(a)), cancel) }
         def size = q.size
         def full: immutable.Signal[F, Boolean] = q.size.map(_ >= maxSize)
         def available: immutable.Signal[F, Int] = q.size.map(maxSize - _)
+
       }
     }}
 
@@ -192,6 +226,9 @@ object Queue {
         def dequeue1: F[A] = cancellableDequeue1.flatMap { _._1 }
         def cancellableDequeue1: F[(F[A],F[Unit])] =
           permits.increment >> q.cancellableDequeue1
+        override def dequeueBatch1(batchSize: Int): F[Chunk[A]] = q.dequeueBatch1(batchSize)
+        def cancellableDequeueBatch1(batchSize: Int): F[(F[Chunk[A]],F[Unit])] =
+          permits.increment >> q.cancellableDequeueBatch1(batchSize)
         def size = q.size
         def full: immutable.Signal[F, Boolean] = Signal.constant(true)
         def available: immutable.Signal[F, Int] = Signal.constant(0)
@@ -222,6 +259,10 @@ object Queue {
         def dequeue1: F[Option[A]] = cancellableDequeue1.flatMap { _._1 }
         def cancellableDequeue1: F[(F[Option[A]],F[Unit])] =
           permits.increment >> q.cancellableDequeue1
+        override def dequeueBatch1(batchSize: Int): F[Chunk[Option[A]]] =
+          q.dequeueBatch1(batchSize)
+        def cancellableDequeueBatch1(batchSize: Int): F[(F[Chunk[Option[A]]],F[Unit])] =
+          permits.increment >> q.cancellableDequeueBatch1(batchSize)
         def size = q.size
         def full: immutable.Signal[F, Boolean] = Signal.constant(true)
         def available: immutable.Signal[F, Int] = Signal.constant(0)


### PR DESCRIPTION
Adds `dequeueAvailable` which dequeues all available values from the queue.

Alters the queue state from containing `Async.Ref[F,A]` to `Either[Async.Ref[F,A], Async.Ref[F,Vector[A]]`, depending on whether the waiter is looking for single, or all queued values.