### PR TITLE
Improved performance and readability of GADT encoding

### DIFF
--- a/core/shared/src/main/scala/fs2/Scope.scala
+++ b/core/shared/src/main/scala/fs2/Scope.scala
@@ -1,23 +1,23 @@
 package fs2
 
 import fs2.util.{Attempt,Free,RealSupertype,Sub1,~>}
-import fs2.StreamCore.{Env,R,RF,Token}
+import fs2.StreamCore.{Env,Algebra,AlgebraF,Token}
 
-final class Scope[+F[_],+O] private (private val get: Free[R[F]#f,O]) {
+final class Scope[+F[_],+O] private (private val get: Free[AlgebraF[F]#f,O]) {
 
   def as[O2](o2: O2): Scope[F,O2] = map(_ => o2)
 
   def map[O2](f: O => O2): Scope[F,O2] = new Scope(get map f)
 
   def flatMap[F2[x]>:F[x],O2](f: O => Scope[F2,O2]): Scope[F2,O2] =
-    new Scope(get flatMap[R[F2]#f,O2] (f andThen (_.get)))
+    new Scope(get flatMap[AlgebraF[F2]#f,O2] (f andThen (_.get)))
 
-  def translate[G[_]](f: F ~> G): Scope[G,O] = new Scope(Free.suspend[R[G]#f,O] {
-    get.translate[R[G]#f](new (R[F]#f ~> R[G]#f) {
-      def apply[A](r: RF[F,A]) = r match {
-        case RF.Eval(fa) => RF.Eval(f(fa))
-        case RF.FinishAcquire(token, cleanup) => RF.FinishAcquire(token, cleanup.translate(f))
-        case _ => r.asInstanceOf[RF[G,A]] // Eval and FinishAcquire are only ctors that flatMap `F`
+  def translate[G[_]](f: F ~> G): Scope[G,O] = new Scope(Free.suspend[AlgebraF[G]#f,O] {
+    get.translate[AlgebraF[G]#f](new (AlgebraF[F]#f ~> AlgebraF[G]#f) {
+      def apply[A](r: Algebra[F,A]) = r match {
+        case Algebra.Eval(fa) => Algebra.Eval(f(fa))
+        case Algebra.FinishAcquire(token, cleanup) => Algebra.FinishAcquire(token, cleanup.translate(f))
+        case _ => r.asInstanceOf[Algebra[G,A]] // Eval and FinishAcquire are only ctors that flatMap `F`
       }
     })
   })
@@ -26,34 +26,32 @@ final class Scope[+F[_],+O] private (private val get: Free[R[F]#f,O]) {
 
   def bindEnv[F2[_]](env: Env[F2])(implicit S: Sub1[F,F2]): Free[F2,(List[Token],O)] = Free.suspend {
     type FO[x] = Free[F2,(List[Token],x)]
-    val B = new Free.B[R[F]#f,FO,O] { def f[x] = r => r match {
-      case Right((r,g)) => g(r)
-      case Left((i,g)) => i match {
-        case StreamCore.RF.Eval(fx) => Free.attemptEval(S(fx)) flatMap g
-        case StreamCore.RF.Interrupted => g(Right(env.interrupted()))
-        case StreamCore.RF.Snapshot => g(Right(env.tracked.snapshot))
-        case StreamCore.RF.NewSince(tokens) => g(Right(env.tracked.newSince(tokens)))
-        case StreamCore.RF.Release(tokens) => env.tracked.release(tokens) match {
+    get.fold[AlgebraF[F]#f,FO,O](new Free.Fold[AlgebraF[F]#f,FO,O] {
+      def suspend(g: => FO[O]) = Free.suspend(g)
+      def done(r: O) = Free.pure((Nil,r))
+      def fail(t: Throwable) = Free.fail(t)
+      def eval[X](i: AlgebraF[F]#f[X])(g: Attempt[X] => FO[O]) = i match {
+        case Algebra.Eval(fx) => Free.attemptEval(S(fx)) flatMap g
+        case Algebra.Interrupted => g(Right(env.interrupted()))
+        case Algebra.Snapshot => g(Right(env.tracked.snapshot))
+        case Algebra.NewSince(tokens) => g(Right(env.tracked.newSince(tokens)))
+        case Algebra.Release(tokens) => env.tracked.release(tokens) match {
           case None =>
             g(Left(new RuntimeException("attempting to release resources still in process of being acquired")))
           case Some((rs,leftovers)) =>
             if (leftovers.isEmpty) StreamCore.runCleanup(rs) flatMap { e => g(Right(e)) }
             else StreamCore.runCleanup(rs) flatMap { e => g(Right(e)) map { case (ts,o) => (leftovers ++ ts, o) } }
         }
-        case StreamCore.RF.StartAcquire(token) =>
+        case Algebra.StartAcquire(token) =>
           g(Right(env.tracked.startAcquire(token)))
-        case StreamCore.RF.FinishAcquire(token, c) =>
+        case Algebra.FinishAcquire(token, c) =>
           g(Right(env.tracked.finishAcquire(token, Sub1.substFree(c))))
-        case StreamCore.RF.CancelAcquire(token) =>
+        case Algebra.CancelAcquire(token) =>
           env.tracked.cancelAcquire(token)
           g(Right(()))
       }
-    }}
-    get.fold[R[F]#f,FO,O](
-      Free.suspend,
-      r => Free.pure((Nil,r)),
-      Free.fail,
-      B)(Sub1.sub1[R[F]#f],implicitly[RealSupertype[O,O]])
+      def bind[X](r: X)(g: X => FO[O]) = g(r)
+    })(Sub1.sub1[AlgebraF[F]#f],implicitly[RealSupertype[O,O]])
   }
 
   override def toString = s"Scope($get)"
@@ -65,34 +63,34 @@ object Scope {
   def pure[F[_],O](o: O): Scope[F,O] = new Scope(Free.pure(o))
 
   def attemptEval[F[_],O](o: F[O]): Scope[F,Attempt[O]] =
-    new Scope(Free.attemptEval[R[F]#f,O](StreamCore.RF.Eval(o)))
+    new Scope(Free.attemptEval[AlgebraF[F]#f,O](Algebra.Eval(o)))
 
   def eval[F[_],O](o: F[O]): Scope[F,O] =
     attemptEval(o) flatMap { _.fold(fail, pure) }
 
   def evalFree[F[_],O](o: Free[F,O]): Scope[F,O] =
-    new Scope(o.translate[R[F]#f](new (F ~> R[F]#f) { def apply[x](f: F[x]) = StreamCore.RF.Eval(f) }))
+    new Scope(o.translate[AlgebraF[F]#f](new (F ~> AlgebraF[F]#f) { def apply[x](f: F[x]) = Algebra.Eval(f) }))
 
   def fail[F[_],O](err: Throwable): Scope[F,O] =
     new Scope(Free.fail(err))
 
   def interrupted[F[_]]: Scope[F,Boolean] =
-    new Scope(Free.eval[R[F]#f,Boolean](StreamCore.RF.Interrupted))
+    new Scope(Free.eval[AlgebraF[F]#f,Boolean](Algebra.Interrupted))
 
   def snapshot[F[_]]: Scope[F,Set[Token]] =
-    new Scope(Free.eval[R[F]#f,Set[Token]](StreamCore.RF.Snapshot))
+    new Scope(Free.eval[AlgebraF[F]#f,Set[Token]](Algebra.Snapshot))
 
   def newSince[F[_]](snapshot: Set[Token]): Scope[F,List[Token]] =
-    new Scope(Free.eval[R[F]#f,List[Token]](StreamCore.RF.NewSince(snapshot)))
+    new Scope(Free.eval[AlgebraF[F]#f,List[Token]](Algebra.NewSince(snapshot)))
 
   def release[F[_]](tokens: List[Token]): Scope[F,Attempt[Unit]] =
-    new Scope(Free.eval[R[F]#f,Attempt[Unit]](StreamCore.RF.Release(tokens)))
+    new Scope(Free.eval[AlgebraF[F]#f,Attempt[Unit]](Algebra.Release(tokens)))
 
   def startAcquire[F[_]](token: Token): Scope[F,Boolean] =
-    new Scope(Free.eval[R[F]#f,Boolean](StreamCore.RF.StartAcquire(token)))
+    new Scope(Free.eval[AlgebraF[F]#f,Boolean](Algebra.StartAcquire(token)))
 
   def finishAcquire[F[_]](token: Token, cleanup: Free[F,Attempt[Unit]]): Scope[F,Boolean] =
-    new Scope(Free.eval[R[F]#f,Boolean](StreamCore.RF.FinishAcquire(token, cleanup)))
+    new Scope(Free.eval[AlgebraF[F]#f,Boolean](Algebra.FinishAcquire(token, cleanup)))
 
   def acquire[F[_]](token: Token, cleanup: Free[F,Attempt[Unit]]): Scope[F,Attempt[Unit]] =
     startAcquire(token) flatMap { ok =>
@@ -103,7 +101,7 @@ object Scope {
     }
 
   def cancelAcquire[F[_]](token: Token): Scope[F,Unit] =
-    new Scope(Free.eval[R[F]#f,Unit](StreamCore.RF.CancelAcquire(token)))
+    new Scope(Free.eval[AlgebraF[F]#f,Unit](Algebra.CancelAcquire(token)))
 
   def traverse[F[_],A,B](l: List[A])(f: A => Scope[F,B]): Scope[F,List[B]] =
     l.foldRight(Scope.pure[F,List[B]](List()))((hd,tl) => f(hd) flatMap { b => tl map (b :: _) })

--- a/core/shared/src/main/scala/fs2/util/Free.scala
+++ b/core/shared/src/main/scala/fs2/util/Free.scala
@@ -7,16 +7,17 @@ sealed trait Free[+F[_],+A] {
   def flatMap[F2[x]>:F[x],B](f: A => Free[F2,B]): Free[F2,B] = Bind(this, f)
   def map[B](f: A => B): Free[F,B] = Bind(this, f andThen (Free.Pure(_)))
 
-  def fold[F2[_],G[_],A2>:A](suspend: (=> G[A2]) => G[A2], done: A => G[A2], fail: Throwable => G[A2], bound: B[F2,G,A2])(
-    implicit S: Sub1[F,F2], T: RealSupertype[A,A2])
-    : G[A2]
-    = this.step._fold(suspend, done, fail, bound)
+  def fold[F2[_],G[_],A2>:A](f: Fold[F2,G,A2])(implicit S: Sub1[F,F2], T: RealSupertype[A,A2]): G[A2] =
+    this.step._fold(f)
 
   def translate[G[_]](u: F ~> G): Free[G,A] = {
     type FG[x] = Free[G,x]
-    fold[F,FG,A](Free.suspend, Free.pure, Free.fail, new B[F,FG,A] { def f[x] = r =>
-      r.fold({ case (fr,g) => Free.attemptEval(u(fr)) flatMap g },
-             { case (r,g) => g(r) })
+    fold[F,FG,A](new Fold[F,FG,A] {
+      def suspend(g: => FG[A]) = Free.suspend(g)
+      def done(a: A) = Free.pure(a)
+      def fail(t: Throwable) = Free.fail(t)
+      def eval[X](fx: F[X])(f: Attempt[X] => FG[A]) = Free.attemptEval(u(fx)).flatMap(f)
+      def bind[X](x: X)(f: X => FG[A]) = f(x)
     })
   }
 
@@ -26,28 +27,26 @@ sealed trait Free[+F[_],+A] {
   private
   def attempt_(trampoline: Boolean): Free[F,Attempt[A]] = {
     type G[x] = Free[F,Attempt[x]]
-    fold[F,G,A](if (trampoline) Free.suspend else x => x, a => Free.pure(Right(a)), e => Free.pure(Left(e)),
-      new B[F,G,A] { def f[x] = r =>
-        r.fold({ case (fr,g) => Free.attemptEval(fr) flatMap g },
-               { case (r,g) => try g(r) catch { case NonFatal(t) => Free.pure(Left(t)) } })
-      }
-    )
+    fold[F,G,A](new Fold[F,G,A] {
+      def suspend(g: => G[A]) = if (trampoline) Free.suspend(g) else g
+      def done(a: A) = Free.pure(Right(a))
+      def fail(t: Throwable) = Free.pure(Left(t))
+      def eval[X](fx: F[X])(f: Attempt[X] => G[A]) = Free.attemptEval(fx) flatMap f
+      def bind[X](x: X)(f: X => G[A]) = try f(x) catch { case NonFatal(t) => Free.pure(Left(t)) }
+    })
   }
 
-  protected def _fold[F2[_],G[_],A2>:A](suspend: (=> G[A2]) => G[A2], done: A => G[A2], fail: Throwable => G[A2], bound: B[F2,G,A2])(
-    implicit S: Sub1[F,F2], T: RealSupertype[A,A2]): G[A2]
+  protected def _fold[F2[_],G[_],A2>:A](f: Fold[F2,G,A2])(implicit S: Sub1[F,F2], T: RealSupertype[A,A2]): G[A2]
 
   def runTranslate[G[_],A2>:A](g: F ~> G)(implicit G: Catchable[G]): G[A2] =
     step._runTranslate(g)
 
   protected def _runTranslate[G[_],A2>:A](g: F ~> G)(implicit G: Catchable[G]): G[A2]
 
-  def unroll[G[+_]](implicit G: Functor[G], S: Sub1[F,G])
-  : Unroll[A, G[Free[F,A]]]
-  = this.step._unroll.run
+  def unroll[G[+_]](implicit G: Functor[G], S: Sub1[F,G]): Unroll[A, G[Free[F,A]]] =
+    this.step._unroll.run
 
-  protected def _unroll[G[+_]](implicit G: Functor[G], S: Sub1[F,G])
-  : Trampoline[Unroll[A, G[Free[F,A]]]]
+  protected def _unroll[G[+_]](implicit G: Functor[G], S: Sub1[F,G]): Trampoline[Unroll[A, G[Free[F,A]]]]
 
   def run[F2[x]>:F[x], A2>:A](implicit F2: Catchable[F2]): F2[A2] =
     (this: Free[F2,A2]).runTranslate(UF1.id)
@@ -63,8 +62,12 @@ sealed trait Free[+F[_],+A] {
 
 object Free {
 
-  trait B[F[_],G[_],A] {
-    def f[x]: Either[(F[x], Attempt[x] => G[A]), (x, x => G[A])] => G[A]
+  trait Fold[F[_],G[_],A] {
+    def suspend(g: => G[A]): G[A]
+    def done(a: A): G[A]
+    def fail(t: Throwable): G[A]
+    def eval[X](fx: F[X])(f: Attempt[X] => G[A]): G[A]
+    def bind[X](x: X)(f: X => G[A]): G[A]
   }
 
   def attemptEval[F[_],A](a: F[A]): Free[F,Attempt[A]] = Eval(a)
@@ -86,8 +89,7 @@ object Free {
     def _unroll[G[+_]](implicit G: Functor[G], S: Sub1[Nothing,G])
     : Trampoline[Unroll[Nothing, G[Free[Nothing,Nothing]]]]
     = Trampoline.done { Unroll.Fail(err) }
-    def _fold[F2[_],G[_],A2>:Nothing](suspend: (=> G[A2]) => G[A2], done: Nothing => G[A2], fail: Throwable => G[A2], bound: B[F2,G,A2])(
-      implicit S: Sub1[Nothing,F2], T: RealSupertype[Nothing,A2]): G[A2] = fail(err)
+    def _fold[F2[_],G[_],A2>:Nothing](f: Fold[F2,G,A2])(implicit S: Sub1[Nothing,F2], T: RealSupertype[Nothing,A2]): G[A2] = f.fail(err)
   }
   private[fs2] case class Pure[A](a: A) extends Free[Nothing,A] {
     def _runTranslate[G[_],A2>:A](g: Nothing ~> G)(implicit G: Catchable[G]): G[A2] =
@@ -95,9 +97,7 @@ object Free {
     def _unroll[G[+_]](implicit G: Functor[G], S: Sub1[Nothing,G])
     : Trampoline[Unroll[A, G[Free[Nothing,A]]]]
     = Trampoline.done { Unroll.Pure(a) }
-    def _fold[F2[_],G[_],A2>:A](suspend: (=> G[A2]) => G[A2], done: A => G[A2], fail: Throwable => G[A2], bound: B[F2,G,A2])(
-      implicit S: Sub1[Nothing,F2], T: RealSupertype[A,A2])
-    : G[A2] = done(a)
+    def _fold[F2[_],G[_],A2>:A](f: Fold[F2,G,A2])(implicit S: Sub1[Nothing,F2], T: RealSupertype[A,A2]): G[A2] = f.done(a)
   }
   private[fs2] case class Eval[F[_],A](fa: F[A]) extends Free[F,Attempt[A]] {
     def _runTranslate[G[_],A2>:Attempt[A]](g: F ~> G)(implicit G: Catchable[G]): G[A2] =
@@ -107,11 +107,8 @@ object Free {
     : Trampoline[Unroll[Attempt[A], G[Free[F,Attempt[A]]]]]
     = Trampoline.done { Unroll.Eval(G.map(S(fa))(a => Free.pure(Right(a)))) }
 
-    def _fold[F2[_],G[_],A2>:Attempt[A]](
-      suspend: (=> G[A2]) => G[A2],
-      done: Attempt[A] => G[A2], fail: Throwable => G[A2], bound: B[F2,G,A2])(
-      implicit S: Sub1[F,F2], T: RealSupertype[Attempt[A],A2])
-    : G[A2] = bound.f(Left((S(fa), (a: Attempt[A]) => done(a))))
+    def _fold[F2[_],G[_],A2>:Attempt[A]](f: Fold[F2,G,A2])(implicit S: Sub1[F,F2], T: RealSupertype[Attempt[A],A2]): G[A2] =
+      f.eval(S(fa))(f.done)
   }
   private[fs2] case class Bind[+F[_],R,A](r: Free[F,R], f: R => Free[F,A]) extends Free[F,A] {
     def _runTranslate[G[_],A2>:A](g: F ~> G)(implicit G: Catchable[G]): G[A2] =
@@ -132,19 +129,14 @@ object Free {
            = f.asInstanceOf[Attempt[Any] => Free[F,A]]
         Trampoline.done { Unroll.Eval(G.map(ga) { any => fr(Right(any)) }) }
     }
-    def _fold[F2[_],G[_],A2>:A](
-      suspend: (=> G[A2]) => G[A2],
-      done: A => G[A2], fail: Throwable => G[A2], bound: B[F2,G,A2])(
-      implicit S: Sub1[F,F2], T: RealSupertype[A,A2])
-    : G[A2] = suspend { Sub1.substFree(r) match {
-      case Pure(r) => bound.f[R](Right((r, f andThen (_.fold(suspend, done, fail, bound)))))
-      case Fail(err) => fail(err)
-      // NB: Scala won't let us pattern match on Eval here, but this is safe since `.step`
-      // removes any left-associated flatMaps
-      case eval => bound.f[R](Left(
-        eval.asInstanceOf[Eval[F2,R]].fa ->
-          f.asInstanceOf[Any => Free[F,A]].andThen(_.fold(suspend, done, fail, bound))))
-    }}
+    def _fold[F2[_],G[_],A2>:A](fold: Fold[F2,G,A2])(implicit S: Sub1[F,F2], T: RealSupertype[A,A2]): G[A2] =
+      fold.suspend { Sub1.substFree(r) match {
+        case Pure(r) => fold.bind(r) { r => f(r).fold(fold) }
+        case Fail(err) => fold.fail(err)
+        // NB: Scala won't let us pattern match on Eval here, but this is safe since `.step`
+        // removes any left-associated flatMaps
+        case eval => fold.eval(eval.asInstanceOf[Eval[F2,R]].fa)(f.asInstanceOf[Any => Free[F,A]].andThen(_.fold(fold)))
+      }}
   }
 
   sealed trait Unroll[+A,+B]


### PR DESCRIPTION
Changed the way "bound" cases are encoded in both `Free` and
`StreamCore`. Rather than passing only the bound cases via a trait with
a single universally quantified method, all cases of the fold are passed
in as a trait. This results in significantly less runtime allocations,
as each call to `fold` was allocating a bound instance anyway but now we
can avoid some anonymous function allocations and some Left/Right
allocations.

In a fairly non-scientific test, these changes resulted in a 7%
performance increase for me (aka, I ran the test suite a few times and
measured how long the last run took).

This encoding is more verbose due to having to specify the type
signatures of the various abstract methods representing each case, but
the benefits to both performance and readability outweigh the
inconvenience of the verbosity.