### PR TITLE
ScalaDoc updates and minor API adjustments

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,8 @@ lazy val commonSettings = Seq(
     import fs2._
     import fs2.util._
   """,
-  doctestWithDependencies := false
+  doctestWithDependencies := false,
+  doctestTestFramework := DoctestTestFramework.ScalaTest
 ) ++ testSettings ++ scaladocSettings ++ publishingSettings ++ releaseSettings
 
 lazy val testSettings = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -149,7 +149,7 @@ lazy val core = crossProject.in(file("core")).
   jsSettings(commonJsSettings: _*)
 
 lazy val coreJVM = core.jvm
-lazy val coreJS = core.js
+lazy val coreJS = core.js.disablePlugins(DoctestPlugin)
 
 lazy val io = project.in(file("io")).
   settings(commonSettings).

--- a/core/jvm/src/test/scala/fs2/PipeSpec.scala
+++ b/core/jvm/src/test/scala/fs2/PipeSpec.scala
@@ -34,6 +34,14 @@ class PipeSpec extends Fs2Spec {
       counter shouldBe (s.get.toList.size * 2 + 1)
     }
 
+    "changes" in {
+      Stream.empty.covary[Pure].changes.toList shouldBe Nil
+      Stream(1, 2, 3, 4).changes.toList shouldBe List(1, 2, 3, 4)
+      Stream(1, 1, 2, 2, 3, 3, 4, 3).changes.toList shouldBe List(1, 2, 3, 4, 3)
+      Stream("1", "2", "33", "44", "5", "66").changesBy(_.length).toList shouldBe
+        List("1", "33", "5", "66")
+    }
+    
     "chunkLimit" in forAll { (s: PureStream[Int], n0: SmallPositive) =>
       val sizeV = s.get.chunkLimit(n0.get).toVector.map(_.size)
       assert(sizeV.forall(_ <= n0.get) && sizeV.sum == s.get.toVector.size)
@@ -89,14 +97,6 @@ class PipeSpec extends Fs2Spec {
       val v = runLog(s.get)
       val i = Gen.oneOf(v).sample.getOrElse(0)
       runLog(s.get.delete(_ == i)) shouldBe v.diff(Vector(i))
-    }
-
-    "distinctConsecutive" in {
-      Stream.empty.covary[Pure].distinctConsecutive.toList shouldBe Nil
-      Stream(1, 2, 3, 4).distinctConsecutive.toList shouldBe List(1, 2, 3, 4)
-      Stream(1, 1, 2, 2, 3, 3, 4, 3).distinctConsecutive.toList shouldBe List(1, 2, 3, 4, 3)
-      Stream("1", "2", "33", "44", "5", "66").distinctConsecutiveBy(_.length).toList shouldBe
-        List("1", "33", "5", "66")
     }
 
     "drop" in forAll { (s: PureStream[Int], negate: Boolean, n0: SmallNonnegative) =>

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -53,6 +53,12 @@ final class Stream[+F[_],+O] private (private val coreRef: Stream.CoreRef[F,O]) 
   /** Alias for `self through [[pipe.bufferBy]]`. */
   def bufferBy(f: O => Boolean): Stream[F,O] = self through pipe.bufferBy(f)
 
+  /** Alias for `self through [[pipe.changes]]`. */
+  def changes: Stream[F,O] = self through pipe.changes
+
+  /** Alias for `self through [[pipe.changesBy]]`. */
+  def changesBy[O2](f: O => O2): Stream[F,O] = self through pipe.changesBy(f)
+
   /** Alias for `self through [[pipe.chunkLimit]]`. */
   def chunkLimit(n: Int): Stream[F,NonEmptyChunk[O]] = self through pipe.chunkLimit(n)
 
@@ -82,13 +88,6 @@ final class Stream[+F[_],+O] private (private val coreRef: Stream.CoreRef[F,O]) 
 
   /** Alias for `self through [[pipe.delete]]`. */
   def delete(f: O => Boolean): Stream[F,O] = self through pipe.delete(f)
-
-  /** Alias for `self through [[pipe.distinctConsecutive]]`. */
-  def distinctConsecutive: Stream[F,O] = self through pipe.distinctConsecutive
-
-  /** Alias for `self through [[pipe.distinctConsecutiveBy]]`. */
-  def distinctConsecutiveBy[O2](f: O => O2): Stream[F,O] =
-    self through pipe.distinctConsecutiveBy(f)
 
   def drain: Stream[F, Nothing] = flatMap { _ => Stream.empty }
 
@@ -448,7 +447,7 @@ object Stream {
    * Note: The last emitted range may be truncated at `stopExclusive`. For
    * instance, `ranges(0,5,4)` results in `(0,4), (4,5)`.
    *
-   * @throws IllegalArgumentException if `size` <= 0
+   * @throws scala.IllegalArgumentException if `size` <= 0
    */
   def ranges[F[_]](start: Int, stopExclusive: Int, size: Int): Stream[F,(Int,Int)] = {
     require(size > 0, "size must be > 0, was: " + size)

--- a/core/shared/src/main/scala/fs2/async/mutable/Queue.scala
+++ b/core/shared/src/main/scala/fs2/async/mutable/Queue.scala
@@ -69,8 +69,8 @@ trait Queue[F[_], A] { self =>
   def full: immutable.Signal[F, Boolean]
 
   /**
-   * Returns an alternate view of this `Queue` where its elements are of type [[B]],
-   * given back and forth function from `A` to `B`.
+   * Returns an alternate view of this `Queue` where its elements are of type `B`,
+   * given two functions, `A => B` and `B => A`.
    */
   def imap[B](f: A => B)(g: B => A)(implicit F: Functor[F]): Queue[F, B] =
     new Queue[F, B] {

--- a/core/shared/src/main/scala/fs2/async/mutable/Topic.scala
+++ b/core/shared/src/main/scala/fs2/async/mutable/Topic.scala
@@ -7,70 +7,66 @@ import fs2.util.Async
 import fs2.util.syntax._
 
 /**
-  * Asynchronous Topic.
-  *
-  * Topic allows you to distribute `A` published by arbitrary number of publishers to arbitrary number of subscribers.
-  *
-  * Topic has built-in back-pressure support implemented as maximum bound (`maxQueued`) that a subscriber is allowed to enqueue.
-  * Once that bound is hit, publishing may semantically block until the lagging subscriber consumes some of its queued elements.
-  *
-  * Additionally the subscriber has possibility to terminate whenever size of enqueued elements is over certain size
-  * by using `subscribeSize`.
-  */
+ * Asynchronous Topic.
+ *
+ * Topic allows you to distribute `A` published by arbitrary number of publishers to arbitrary number of subscribers.
+ *
+ * Topic has built-in back-pressure support implemented as maximum bound (`maxQueued`) that a subscriber is allowed to enqueue.
+ * Once that bound is hit, publishing may semantically block until the lagging subscriber consumes some of its queued elements.
+ *
+ * Additionally the subscriber has possibility to terminate whenever size of enqueued elements is over certain size
+ * by using `subscribeSize`.
+ */
 trait Topic[F[_], A] { self =>
 
   /**
-    * Published any elements from source of `A` to this topic.
-    * If any of the subscribers reach its `maxQueued` limit, then this will hold to publish next element
-    * before that subscriber consumes it's elements or terminates.
-    */
+   * Publishes elements from source of `A` to this topic.
+   * [[Sink]] equivalent of `publish1`.
+   */
   def publish: Sink[F, A]
 
   /**
-    * Publish one `A` to topic.
-    *
-    * This will wait until `A` is published to all subscribers.
-    * If one of the subscribers is over the `maxQueued` limit, this will wait to complete until that subscriber processes
-    * some of its elements to get room for this new. published `A`
-    *
-    */
+   * Publishes one `A` to topic.
+   *
+   * This waits until `a` is published to all subscribers.
+   * If any of the subscribers is over the `maxQueued` limit, this will wait to complete until that subscriber processes
+   * enough of its elements such that `a` is enqueued.
+   */
   def publish1(a: A): F[Unit]
 
   /**
-    * Subscribes to receive any published `A` to this topic.
-    *
-    * Always returns last `A` published first, and then any next `A` published.
-    *
-    * If the subscriber is over `maxQueued` bound of messages awaiting to be processed,
-    * then publishers will hold into publishing to the queue.
-    *
-    */
+   * Subscribes for `A` values that are published to this topic.
+   *
+   * Pulling on the returned stream opens a "subscription", which allows up to
+   * `maxQueued` elements to be enqueued as a result of publication.
+   *
+   * The first element in the stream is always the last published `A` at the time
+   * the stream is first pulled from, followed by each published `A` value from that
+   * point forward.
+   *
+   * If at any point, the queue backing the subscription has `maxQueued` elements in it,
+   * any further publications semantically block until elements are dequeued from the
+   * subscription queue.
+   *
+   * @param maxQueued maximum number of elements to enqueue to the subscription
+   * queue before blocking publishers
+   */
   def subscribe(maxQueued: Int): Stream[F, A]
 
   /**
-    * Subscribes to receive published `A` to this topic.
-    *
-    * Always returns last `A` published first, and then any next `A` available
-    *
-    * Additionally this emits current size of the queue of `A` for this subscriber allowing
-    * you to terminate (or adjust) the subscription if subscriber is way behind the elements available.
-    *
-    * Note that queue size is approximate and may not be exactly the size when `A` was taken.
-    *
-    * If the subscriber is over `maxQueued` bound of messages awaiting to be processed,
-    * then publishers will hold into publishing to the queue.
-    *
-    */
+   * Like [[subscribe]] but emits an approximate number of queued elements for this subscription
+   * with each emitted `A` value.
+   */
   def subscribeSize(maxQueued: Int): Stream[F, (A, Int)]
 
   /**
-    * Signal of current active subscribers
-    */
+   * Signal of current active subscribers.
+   */
   def subscribers: fs2.async.immutable.Signal[F, Int]
 
   /**
-   * Returns an alternate view of this `Topic` where its elements are of type [[B]],
-   * given back and forth function from `A` to `B`.
+   * Returns an alternate view of this `Topic` where its elements are of type `B`,
+   * given two functions, `A => B` and `B => A`.
    */
   def imap[B](f: A => B)(g: B => A): Topic[F, B] =
     new Topic[F, B] {

--- a/core/shared/src/main/scala/fs2/pipe.scala
+++ b/core/shared/src/main/scala/fs2/pipe.scala
@@ -8,7 +8,7 @@ object pipe {
   // nb: methods are in alphabetical order
 
   /** Behaves like the identity function, but requests `n` elements at a time from the input. */
-  def buffer[F[_],I](n: Int): Stream[F,I] => Stream[F,I] =
+  def buffer[F[_],I](n: Int): Pipe[F,I,I] =
     _.repeatPull { _.awaitN(n, true).flatMap { case (chunks, h) =>
       chunks.foldLeft(Pull.pure(()): Pull[F,I,Unit]) { (acc, c) => acc >> Pull.output(c) } as h
     }}
@@ -45,42 +45,11 @@ object pipe {
     _.pull { h => go(Vector.empty, false)(h) }
   }
 
-  /** Outputs first value, and then any changed value from the last value. `eqf` is used for equality. **/
-  def changes[F[_],I](eqf:(I,I) => Boolean): Stream[F,I] => Stream[F,I] =
-    zipWithPrevious andThen collect {
-      case (None,next) => next
-      case (Some(last), next) if !eqf(last,next) => next
-    }
-
-  /** Outputs chunks with a limited maximum size, splitting as necessary. */
-  def chunkLimit[F[_],I](n: Int): Stream[F,I] => Stream[F,NonEmptyChunk[I]] =
-    _ repeatPull { _.awaitLimit(n) flatMap { case (chunk, h) => Pull.output1(chunk) as h } }
-
-  /** Outputs a list of chunks, the total size of all chunks is limited and split as necessary. */
-  def chunkN[F[_],I](n: Int, allowFewer: Boolean = true): Stream[F,I] => Stream[F,List[NonEmptyChunk[I]]] =
-    _ repeatPull { _.awaitN(n, allowFewer) flatMap { case (chunks, h) => Pull.output1(chunks) as h }}
-
-  /** Output all chunks from the input `Handle`. */
-  def chunks[F[_],I]: Stream[F,I] => Stream[F,NonEmptyChunk[I]] =
-    _ repeatPull { _.await.flatMap { case (chunk, h) => Pull.output1(chunk) as h }}
-
-  /** Map/filter simultaneously. Calls `collect` on each `Chunk` in the stream. */
-  def collect[F[_],I,I2](pf: PartialFunction[I, I2]): Stream[F,I] => Stream[F,I2] =
-    mapChunks(_.collect(pf))
-
-  /** Emits the first element of the Stream for which the partial function is defined. */
-  def collectFirst[F[_],I,I2](pf: PartialFunction[I, I2]): Stream[F,I] => Stream[F,I2] =
-    _ pull { h => h.find(pf.isDefinedAt) flatMap { case (i, h) => Pull.output1(pf(i)) }}
-
-  /** Skip the first element that matches the predicate. */
-  def delete[F[_],I](p: I => Boolean): Stream[F,I] => Stream[F,I] =
-    _ pull { h => h.takeWhile((i:I) => !p(i)).flatMap(_.drop(1)).flatMap(_.echo) }
-
   /**
    * Emits only elements that are distinct from their immediate predecessors,
    * using natural equality for comparison.
    */
-  def distinctConsecutive[F[_],I]: Stream[F,I] => Stream[F,I] =
+  def changes[F[_],I]: Pipe[F,I,I] =
     filterWithPrevious((i1, i2) => i1 != i2)
 
   /**
@@ -90,13 +59,37 @@ object pipe {
    * Note that `f` is called for each element in the stream multiple times
    * and hence should be fast (e.g., an accessor). It is not intended to be
    * used for computationally intensive conversions. For such conversions,
-   * consider something like: `src.map(i => (i, f(i))).distinctConsecutiveBy(_._2).map(_._1)`
+   * consider something like: `src.map(i => (i, f(i))).changesBy(_._2).map(_._1)`
    */
-  def distinctConsecutiveBy[F[_],I,I2](f: I => I2): Stream[F,I] => Stream[F,I] =
+  def changesBy[F[_],I,I2](f: I => I2): Pipe[F,I,I] =
     filterWithPrevious((i1, i2) => f(i1) != f(i2))
 
-  /** Drop `n` elements of the input, then echo the rest. */
-  def drop[F[_],I](n: Long): Stream[F,I] => Stream[F,I] =
+  /** Outputs chunks with a limited maximum size, splitting as necessary. */
+  def chunkLimit[F[_],I](n: Int): Pipe[F,I,NonEmptyChunk[I]] =
+    _ repeatPull { _.awaitLimit(n) flatMap { case (chunk, h) => Pull.output1(chunk) as h } }
+
+  /** Outputs a list of chunks, the total size of all chunks is limited and split as necessary. */
+  def chunkN[F[_],I](n: Int, allowFewer: Boolean = true): Pipe[F,I,List[NonEmptyChunk[I]]] =
+    _ repeatPull { _.awaitN(n, allowFewer) flatMap { case (chunks, h) => Pull.output1(chunks) as h }}
+
+  /** Outputs all chunks from the input `Handle`. */
+  def chunks[F[_],I]: Pipe[F,I,NonEmptyChunk[I]] =
+    _ repeatPull { _.await.flatMap { case (chunk, h) => Pull.output1(chunk) as h }}
+
+  /** Map/filter simultaneously. Calls `collect` on each `Chunk` in the stream. */
+  def collect[F[_],I,I2](pf: PartialFunction[I, I2]): Pipe[F,I,I2] =
+    mapChunks(_.collect(pf))
+
+  /** Emits the first element of the Stream for which the partial function is defined. */
+  def collectFirst[F[_],I,I2](pf: PartialFunction[I, I2]): Pipe[F,I,I2] =
+    _ pull { h => h.find(pf.isDefinedAt) flatMap { case (i, h) => Pull.output1(pf(i)) }}
+
+  /** Skips the first element that matches the predicate. */
+  def delete[F[_],I](p: I => Boolean): Pipe[F,I,I] =
+    _ pull { h => h.takeWhile((i:I) => !p(i)).flatMap(_.drop(1)).flatMap(_.echo) }
+
+  /** Drops `n` elements of the input, then echoes the rest. */
+  def drop[F[_],I](n: Long): Pipe[F,I,I] =
     _ pull { h => h.drop(n).flatMap(_.echo) }
 
   /** Drops the last element. */
@@ -121,7 +114,7 @@ object pipe {
   }
 
   /** Emits all but the last `n` elements of the input. */
-  def dropRight[F[_],I](n: Int): Stream[F,I] => Stream[F,I] = {
+  def dropRight[F[_],I](n: Int): Pipe[F,I,I] = {
     if (n <= 0) identity
     else {
       def go(acc: Vector[I]): Handle[F,I] => Pull[F,I,Unit] = {
@@ -135,23 +128,23 @@ object pipe {
     }
   }
 
-  /** Drop the elements of the input until the predicate `p` fails, then echo the rest. */
-  def dropWhile[F[_], I](p: I => Boolean): Stream[F,I] => Stream[F,I] =
+  /** Drops the elements of the input until the predicate `p` fails, then echoes the rest. */
+  def dropWhile[F[_], I](p: I => Boolean): Pipe[F,I,I] =
     _ pull { h => h.dropWhile(p).flatMap(_.echo) }
 
   /** Emits `true` as soon as a matching element is received, else `false` if no input matches */
-  def exists[F[_], I](p: I => Boolean): Stream[F, I] => Stream[F, Boolean] =
+  def exists[F[_], I](p: I => Boolean): Pipe[F,I,Boolean] =
     _ pull { h => h.forall(!p(_)) flatMap { i => Pull.output1(!i) }}
 
-  /** Emit only inputs which match the supplied predicate. */
-  def filter[F[_], I](f: I => Boolean): Stream[F,I] => Stream[F,I] =
+  /** Emits only inputs which match the supplied predicate. */
+  def filter[F[_], I](f: I => Boolean): Pipe[F,I,I] =
     mapChunks(_ filter f)
 
   /**
    * Like `filter`, but the predicate `f` depends on the previously emitted and
    * current elements.
    */
-  def filterWithPrevious[F[_],I](f: (I, I) => Boolean): Stream[F,I] => Stream[F,I] = {
+  def filterWithPrevious[F[_],I](f: (I, I) => Boolean): Pipe[F,I,I] = {
     def go(last: I): Handle[F,I] => Pull[F,I,Unit] =
       _.receive { (c, h) =>
         // Check if we can emit this chunk unmodified
@@ -172,32 +165,32 @@ object pipe {
   }
 
   /** Emits the first input (if any) which matches the supplied predicate, to the output of the returned `Pull` */
-  def find[F[_],I](f: I => Boolean): Stream[F,I] => Stream[F,I] =
+  def find[F[_],I](f: I => Boolean): Pipe[F,I,I] =
     _ pull { h => h.find(f).flatMap { case (o, h) => Pull.output1(o) }}
 
   /**
    * Folds all inputs using an initial value `z` and supplied binary operator,
    * and emits a single element stream.
    */
-  def fold[F[_],I,O](z: O)(f: (O, I) => O): Stream[F,I] => Stream[F,O] =
+  def fold[F[_],I,O](z: O)(f: (O, I) => O): Pipe[F,I,O] =
     _ pull { h => h.fold(z)(f).flatMap(Pull.output1) }
 
   /**
    * Folds all inputs using the supplied binary operator, and emits a single-element
    * stream, or the empty stream if the input is empty.
    */
-  def fold1[F[_],I](f: (I, I) => I): Stream[F,I] => Stream[F,I] =
+  def fold1[F[_],I](f: (I, I) => I): Pipe[F,I,I] =
     _ pull { h => h.fold1(f).flatMap(Pull.output1) }
 
   /**
    * Emits a single `true` value if all input matches the predicate.
    * Halts with `false` as soon as a non-matching element is received.
    */
-  def forall[F[_], I](p: I => Boolean): Stream[F,I] => Stream[F,Boolean] =
+  def forall[F[_], I](p: I => Boolean): Pipe[F,I,Boolean] =
     _ pull { h => h.forall(p) flatMap Pull.output1 }
 
   /** Emits the specified separator between every pair of elements in the source stream. */
-  def intersperse[F[_],I](separator: I): Stream[F,I] => Stream[F,I] =
+  def intersperse[F[_],I](separator: I): Pipe[F,I,I] =
     _ pull { h => h.echo1 flatMap Pull.loop { (h: Handle[F,I]) =>
       h.receive { case (chunk, h) =>
         val interspersed = {
@@ -209,30 +202,28 @@ object pipe {
       }
     }}
 
-  /** Write all inputs to the output of the returned `Pull`. */
-  def id[F[_],I]: Stream[F,I] => Stream[F,I] =
-    s => s
+  /** Identity pipe - every input is output unchanged. */
+  def id[F[_],I]: Pipe[F,I,I] = s => s
 
-  /** Return the last element of the input `Handle`, if non-empty. */
-  def last[F[_],I]: Stream[F,I] => Stream[F,Option[I]] =
+  /** Returns the last element of the input `Handle`, if non-empty. */
+  def last[F[_],I]: Pipe[F,I,Option[I]] =
     _ pull { h => h.last.flatMap { o => Pull.output1(o) }}
 
-  /** Return the last element of the input `Handle` if non-empty, otherwise li. */
-  def lastOr[F[_],I](li: => I): Stream[F,I] => Stream[F,I] =
+  /** Returns the last element of the input `Handle` if non-empty, otherwise li. */
+  def lastOr[F[_],I](li: => I): Pipe[F,I,I] =
     _ pull { h => h.last.flatMap {
       case Some(o) => Pull.output1(o)
       case None => Pull.output1(li)
     }}
 
   /**
-   * Write all inputs to the output of the returned `Pull`, transforming elements using `f`.
+   * Applies the specified pure function to each input and emits the result.
    * Works in a chunky fashion and creates a `Chunk.indexedSeq` for each mapped chunk.
    */
-  def lift[F[_],I,O](f: I => O): Stream[F,I] => Stream[F,O] =
-    _ map f
+  def lift[F[_],I,O](f: I => O): Pipe[F,I,O] = _ map f
 
-  /** Output a transformed version of all chunks from the input `Handle`. */
-  def mapChunks[F[_],I,O](f: Chunk[I] => Chunk[O]): Stream[F,I] => Stream[F,O] =
+  /** Outputs a transformed version of all chunks from the input `Handle`. */
+  def mapChunks[F[_],I,O](f: Chunk[I] => Chunk[O]): Pipe[F,I,O] =
     _ repeatPull { _.await.flatMap { case (chunk, h) => Pull.output(f(chunk)) as h }}
 
   /**
@@ -244,7 +235,7 @@ object pipe {
     * res0: Vector[(Int, Char)] = Vector((5,H), (10,W))
     * }}}
     */
-  def mapAccumulate[F[_],S,I,O](init: S)(f: (S,I) => (S,O)): Stream[F,I] => Stream[F,(S,O)] =
+  def mapAccumulate[F[_],S,I,O](init: S)(f: (S,I) => (S,O)): Pipe[F,I,(S,O)] =
     _.pull { _.receive { case (chunk, h) =>
       val f2 = (s: S, i: I) => {
         val (newS, newO) = f(s, i)
@@ -263,7 +254,7 @@ object pipe {
    * Behaves like `id`, but starts fetching the next chunk before emitting the current,
    * enabling processing on either side of the `prefetch` to run in parallel.
    */
-  def prefetch[F[_]:Async,I]: Stream[F,I] => Stream[F,I] =
+  def prefetch[F[_]:Async,I]: Pipe[F,I,I] =
     _ repeatPull { _.receive {
       case (hd, tl) => tl.prefetch flatMap { p => Pull.output(hd) >> p }}}
 
@@ -273,11 +264,11 @@ object pipe {
    * may be less than `n` elements. Otherwise, if the final chunk is less than `n`
    * elements, it is dropped.
    */
-  def rechunkN[F[_],I](n: Int, allowFewer: Boolean = true): Stream[F,I] => Stream[F,I] =
+  def rechunkN[F[_],I](n: Int, allowFewer: Boolean = true): Pipe[F,I,I] =
     in => chunkN(n, allowFewer)(in).flatMap { chunks => Stream.chunk(Chunk.concat(chunks)) }
 
-  /** Rethrow any `Left(err)`. Preserves chunkiness. */
-  def rethrow[F[_],I]: Stream[F,Attempt[I]] => Stream[F,I] =
+  /** Rethrows any `Left(err)`. Preserves chunkiness. */
+  def rethrow[F[_],I]: Pipe[F,Attempt[I],I] =
     _.chunks.flatMap { es =>
       val errs = es collect { case Left(e) => e }
       val ok = es collect { case Right(i) => i }
@@ -288,7 +279,7 @@ object pipe {
     }
 
   /** Alias for `[[pipe.fold1]]` */
-  def reduce[F[_],I](f: (I, I) => I): Stream[F,I] => Stream[F,I] = fold1(f)
+  def reduce[F[_],I](f: (I, I) => I): Pipe[F,I,I] = fold1(f)
 
   /**
    * Left fold which outputs all intermediate results. Example:
@@ -302,7 +293,7 @@ object pipe {
    *
    * Works in a chunky fashion, and creates a `Chunk.indexedSeq` for each converted chunk.
    */
-  def scan[F[_],I,O](z: O)(f: (O, I) => O): Stream[F,I] => Stream[F,O] = {
+  def scan[F[_],I,O](z: O)(f: (O, I) => O): Pipe[F,I,O] = {
     _ pull (_scan0(z)(f))
   }
 
@@ -322,11 +313,11 @@ object pipe {
   /**
    * Like `[[pipe.scan]]`, but uses the first element of the stream as the seed.
    */
-  def scan1[F[_],I](f: (I, I) => I): Stream[F,I] => Stream[F,I] =
+  def scan1[F[_],I](f: (I, I) => I): Pipe[F,I,I] =
     _ pull { _.receive1 { (o, h) => _scan0(o)(f)(h) }}
 
-  /** Emit the given values, then echo the rest of the input. */
-  def shiftRight[F[_],I](head: I*): Stream[F,I] => Stream[F,I] =
+  /** Emits the given values, then echoes the rest of the input. */
+  def shiftRight[F[_],I](head: I*): Pipe[F,I,I] =
     _ pull { h => h.push(Chunk.indexedSeq(Vector(head: _*))).echo }
 
   /**
@@ -336,11 +327,11 @@ object pipe {
    *
    * @example {{{
    * scala> Stream(1, 2, 3, 4).sliding(2).toList
-   * res0: List[Chunk[Int]] = List(Chunk(1, 2), Chunk(2, 3), Chunk(3, 4))
+   * res0: List[Vector[Int]] = List(Vector(1, 2), Vector(2, 3), Vector(3, 4))
    * }}}
-   * @throws IllegalArgumentException if `n` <= 0
+   * @throws scala.IllegalArgumentException if `n` <= 0
    */
-  def sliding[F[_],I](n: Int): Stream[F,I] => Stream[F,Vector[I]] = {
+  def sliding[F[_],I](n: Int): Pipe[F,I,Vector[I]] = {
     require(n > 0, "n must be > 0")
     def go(window: Vector[I]): Handle[F,I] => Pull[F,Vector[I],Unit] = h => {
       h.receive {
@@ -358,7 +349,7 @@ object pipe {
   }
 
   /**
-   * Break the input into chunks where the delimiter matches the predicate.
+   * Breaks the input into chunks where the delimiter matches the predicate.
    * The delimiter does not appear in the output. Two adjacent delimiters in the
    * input result in an empty chunk in the output.
    */
@@ -382,42 +373,42 @@ object pipe {
   }
 
   /** Writes the sum of all input elements, or zero if the input is empty. */
-  def sum[F[_],I](implicit ev: Numeric[I]): Stream[F,I] => Stream[F,I] =
+  def sum[F[_],I](implicit ev: Numeric[I]): Pipe[F,I,I] =
     fold(ev.zero)(ev.plus)
 
   /** Emits all elements of the input except the first one. */
-  def tail[F[_],I]: Stream[F,I] => Stream[F,I] =
+  def tail[F[_],I]: Pipe[F,I,I] =
     drop(1)
 
-  /** Emit the first `n` elements of the input `Handle` and return the new `Handle`. */
-  def take[F[_],I](n: Long): Stream[F,I] => Stream[F,I] =
+  /** Emits the first `n` elements of the input `Handle` and returns the new `Handle`. */
+  def take[F[_],I](n: Long): Pipe[F,I,I] =
     _.pull(_.take(n))
 
   /** Emits the last `n` elements of the input. */
-  def takeRight[F[_],I](n: Long): Stream[F,I] => Stream[F,I] =
+  def takeRight[F[_],I](n: Long): Pipe[F,I,I] =
     _ pull { h => h.takeRight(n).flatMap(is => Pull.output(Chunk.indexedSeq(is))) }
 
   /** Like `takeWhile`, but emits the first value which tests false. */
-  def takeThrough[F[_],I](f: I => Boolean): Stream[F,I] => Stream[F,I] =
+  def takeThrough[F[_],I](f: I => Boolean): Pipe[F,I,I] =
     _.pull(_.takeThrough(f))
 
-  /** Emit the longest prefix of the input for which all elements test true according to `f`. */
-  def takeWhile[F[_],I](f: I => Boolean): Stream[F,I] => Stream[F,I] =
+  /** Emits the longest prefix of the input for which all elements test true according to `f`. */
+  def takeWhile[F[_],I](f: I => Boolean): Pipe[F,I,I] =
     _.pull(_.takeWhile(f))
 
-  /** Convert the input to a stream of solely 1-element chunks. */
-  def unchunk[F[_],I]: Stream[F,I] => Stream[F,I] =
+  /** Converts the input to a stream of 1-element chunks. */
+  def unchunk[F[_],I]: Pipe[F,I,I] =
     _ repeatPull { _.receive1 { case (i, h) => Pull.output1(i) as h }}
 
   /**
-   * Halt the input stream at the first `None`.
+   * Halts the input stream at the first `None`.
    *
    * @example {{{
-   * scala> unNoneTerminate(Stream(Some(1), Some(2), None, Some(3), None)).toVector
-   * res0: Vector[Int] = Vector(1, 2)
+   * scala> Stream[Pure, Option[Int]](Some(1), Some(2), None, Some(3), None).unNoneTerminate.toList
+   * res0: List[Int] = List(1, 2)
    * }}}
    */
-  def unNoneTerminate[F[_],I]: Stream[F,Option[I]] => Stream[F,I] =
+  def unNoneTerminate[F[_],I]: Pipe[F,Option[I],I] =
     _ repeatPull { _.receive {
       case (hd, tl) =>
         val out = Chunk.indexedSeq(hd.toVector.takeWhile { _.isDefined }.collect { case Some(i) => i })
@@ -434,21 +425,21 @@ object pipe {
    * res0: Vector[Vector[Int]] = Vector(Vector(1, 2), Vector(3, 4), Vector(5))
    * }}}
    */
-  def vectorChunkN[F[_],I](n: Int, allowFewer: Boolean = true): Stream[F,I] => Stream[F,Vector[I]] =
+  def vectorChunkN[F[_],I](n: Int, allowFewer: Boolean = true): Pipe[F,I,Vector[I]] =
     chunkN(n, allowFewer) andThen (_.map(i => i.foldLeft(Vector.empty[I])((v, c) => v ++ c.iterator)))
 
-  /** Zip the elements of the input `Handle` with its indices, and return the new `Handle` */
-  def zipWithIndex[F[_],I]: Stream[F,I] => Stream[F,(I,Int)] = {
+  /** Zips the elements of the input `Handle` with its indices, and returns the new `Handle` */
+  def zipWithIndex[F[_],I]: Pipe[F,I,(I,Int)] = {
     mapAccumulate[F, Int, I, I](-1) {
       case (i, x) => (i + 1, x)
     } andThen(_.map(_.swap))
   }
 
   /**
-    * Zip the elements of the input `Handle` with its next element wrapped into `Some`, and return the new `Handle`.
-    * The last element is zipped with `None`.
-    */
-  def zipWithNext[F[_], I]: Stream[F, I] => Stream[F, (I, Option[I])] = {
+   * Zips the elements of the input `Handle` with its next element wrapped into `Some`, and returns the new `Handle`.
+   * The last element is zipped with `None`.
+   */
+  def zipWithNext[F[_], I]: Pipe[F,I,(I,Option[I])] = {
     def go(last: I): Handle[F, I] => Pull[F, (I, Option[I]), Handle[F, I]] =
       _.receiveOption {
         case None => Pull.output1((last, None)) as Handle.empty
@@ -462,21 +453,21 @@ object pipe {
   }
 
   /**
-    * Zip the elements of the input `Handle` with its previous element wrapped into `Some`, and return the new `Handle`.
-    * The first element is zipped with `None`.
-    */
-  def zipWithPrevious[F[_], I]: Stream[F, I] => Stream[F, (Option[I], I)] = {
+   * Zips the elements of the input `Handle` with its previous element wrapped into `Some`, and returns the new `Handle`.
+   * The first element is zipped with `None`.
+   */
+  def zipWithPrevious[F[_], I]: Pipe[F,I,(Option[I],I)] = {
     mapAccumulate[F, Option[I], I, (Option[I], I)](None) {
       case (prev, next) => (Some(next), (prev, next))
     } andThen(_.map { case (_, prevNext) => prevNext })
   }
 
   /**
-    * Zip the elements of the input `Handle` with its previous and next elements wrapped into `Some`, and return the new `Handle`.
-    * The first element is zipped with `None` as the previous element,
-    * the last element is zipped with `None` as the next element.
-    */
-  def zipWithPreviousAndNext[F[_], I]: Stream[F, I] => Stream[F, (Option[I], I, Option[I])] = {
+   * Zips the elements of the input `Handle` with its previous and next elements wrapped into `Some`, and returns the new `Handle`.
+   * The first element is zipped with `None` as the previous element,
+   * the last element is zipped with `None` as the next element.
+   */
+  def zipWithPreviousAndNext[F[_], I]: Pipe[F,I,(Option[I],I,Option[I])] = {
     (zipWithPrevious[F, I] andThen zipWithNext[F, (Option[I], I)]) andThen {
       _.map {
         case ((prev, that), None) => (prev, that, None)
@@ -495,7 +486,7 @@ object pipe {
    *
    * @see [[zipWithScan1]]
    */
-  def zipWithScan[F[_],I,S](z: S)(f: (S, I) => S): Stream[F,I] => Stream[F,(I,S)] =
+  def zipWithScan[F[_],I,S](z: S)(f: (S, I) => S): Pipe[F,I,(I,S)] =
     _.mapAccumulate(z) { (s,i) => val s2 = f(s,i); (s2, (i,s)) }.map(_._2)
 
   /**
@@ -508,15 +499,17 @@ object pipe {
    *
    * @see [[zipWithScan]]
    */
-  def zipWithScan1[F[_],I,S](z: S)(f: (S, I) => S): Stream[F,I] => Stream[F,(I,S)] =
+  def zipWithScan1[F[_],I,S](z: S)(f: (S, I) => S): Pipe[F,I,(I,S)] =
     _.mapAccumulate(z) { (s,i) => val s2 = f(s,i); (s2, (i,s2)) }.map(_._2)
 
   // stepping a stream
 
-  def covary[F[_],I,O](s: Stream[Pure,I] => Stream[Pure,O]): Pipe[F,I,O] =
+  /** Converts a pure pipe to an arbitrary effect. */
+  def covary[F[_],I,O](s: Pipe[Pure,I,O]): Pipe[F,I,O] =
     s.asInstanceOf[Pipe[F,I,O]]
 
-  def stepper[I,O](s: Stream[Pure,I] => Stream[Pure,O]): Stepper[I,O] = {
+  /** Creates a [[Stepper]], which allows incrementally stepping a pure pipe. */
+  def stepper[I,O](s: Pipe[Pure,I,O]): Stepper[I,O] = {
     type Read[+R] = Option[Chunk[I]] => R
     def readFunctor: Functor[Read] = new Functor[Read] {
       def map[A,B](fa: Read[A])(g: A => B): Read[B]
@@ -548,6 +541,11 @@ object pipe {
     go(stepf(new Handle[Read,O](List(), outputs)))
   }
 
+  /**
+   * Allows stepping of a pure pipe. Each invocation of [[step]] results in
+   * a value of the [[Stepper.Step]] algebra, indicating that the pipe is either done, it
+   * failed with an exception, it emitted a chunk of output, or it is awaiting input.
+   */
   sealed trait Stepper[-A,+B] {
     @annotation.tailrec
     final def step: Stepper.Step[A,B] = this match {
@@ -559,10 +557,15 @@ object pipe {
   object Stepper {
     private[fs2] final case class Suspend[A,B](force: () => Stepper[A,B]) extends Stepper[A,B]
 
+    /** Algebra describing the result of stepping a pure pipe. */
     sealed trait Step[-A,+B] extends Stepper[A,B]
+    /** Pipe indicated it is done. */
     final case object Done extends Step[Any,Nothing]
+    /** Pipe failed with the specified exception. */
     final case class Fail(err: Throwable) extends Step[Any,Nothing]
+    /** Pipe emitted a chunk of elements. */
     final case class Emits[A,B](chunk: Chunk[B], next: Stepper[A,B]) extends Step[A,B]
+    /** Pipe is awaiting input. */
     final case class Await[A,B](receive: Option[Chunk[A]] => Stepper[A,B]) extends Step[A,B]
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.github.tkawachi" % "sbt-doctest" % "0.3.5")
+addSbtPlugin("com.github.tkawachi" % "sbt-doctest" % "0.4.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.7.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
@@ -6,5 +6,5 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.7")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.4.2")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.11")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.10")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.12")
 


### PR DESCRIPTION
 - Enabled sbt-doctest
 - Minor ScalaDoc consistency changes
 - Removed `pipe.changes` and renamed `distinctConsecutive` and
`distinctConsecutiveBy` to `changes` and `changesBy`
 - Removed `Signal#changes` in favor of calling `discrete.changes.map(_
=> ())`. Rationale is that a common use case is `s.discrete.changes` (without the map to unit) and that's confusing compared to `s.changes`.

Will merge tomorrow if there are no objections by then.