### PR TITLE
Fix scaladoc example for the zipWithScan1

### DIFF
--- a/core/shared/src/main/scala/fs2/pipe.scala
+++ b/core/shared/src/main/scala/fs2/pipe.scala
@@ -495,8 +495,8 @@ object pipe {
    * Zips the input with a running total according to `S`, including the current element. Thus the initial
    * `z` value is the first emitted to the output:
    * {{{
-   * scala> Stream("uno", "dos", "tres", "cuatro").zipWithScan(0)(_ + _.length).toList
-   * res0: List[(String,Int)] = List((uno,0), (dos,3), (tres,6), (cuatro,10))
+   * scala> Stream("uno", "dos", "tres", "cuatro").zipWithScan1(0)(_ + _.length).toList
+   * res0: List[(String, Int)] = List((uno,3), (dos,6), (tres,10), (cuatro,16))
    * }}}
    *
    * @see [[zipWithScan]]


### PR DESCRIPTION
Scaladoc example for the `zipWithScan1` has been copy-pasted from `zipWithScan`.
I ran the command
```scala
Stream("uno", "dos", "tres", "cuatro").zipWithScan1(0)(_ + _.length).toList
```
in the REPL and pasted correct `res0`