### PR TITLE
Build runLog result with a VectorBuilder

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/StreamBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/StreamBenchmark.scala
@@ -36,6 +36,12 @@ class StreamBenchmark extends BenchmarkUtils {
     Stream.repeatEval(Task.delay(())).take(N).runLast.unsafeRun().get
   }
 
+  @GenerateN(0, 2, 3, 6, 12, 25, 50, 100, 200, 400, 800, 1600, 3200, 6400, 12800, 25600, 51200, 102400)
+  @Benchmark
+  def runLog(N: Int): Vector[Int] = {
+    Stream.emits(0 until N).covary[Task].runLog.unsafeRun()
+  }
+
   @GenerateN(1, 2, 4, 8, 16, 32, 64, 128, 256)
   @Benchmark
   def awaitPull(N: Int): Int = {

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1,5 +1,6 @@
 package fs2
 
+import scala.collection.immutable.VectorBuilder
 import fs2.util.{Applicative,Async,Attempt,Catchable,Free,Lub1,RealSupertype,Sub1,~>}
 
 /**
@@ -227,7 +228,7 @@ final class Stream[+F[_],+O] private (private val coreRef: Stream.CoreRef[F,O]) 
     get.runFold(z)(f)
 
   def runLogFree: Free[F,Vector[O]] =
-    runFoldFree(Vector.empty[O])(_ :+ _)
+    Free.suspend(runFoldFree(new VectorBuilder[O])(_ += _).map(_.result))
 
   /** Alias for `self through [[pipe.prefetch]](f).` */
   def prefetch[F2[_]](implicit S:Sub1[F,F2], F2:Async[F2]): Stream[F2,O] =


### PR DESCRIPTION
runLog builds its result by repeatedly appending to a `Vector`.  For large streams, better performance is possible using a `VectorBuilder`, at some cost to smaller streams.  The crossover point is not clear from [initial benchmarks], but might be evaluated with a smarter choice of GenerateN.

[initial benchmarks]: https://gist.github.com/rossabaker/3e141683db87728824b254f3a281201b