### PR TITLE
fix Stream#repeat

### DIFF
--- a/core/jvm/src/test/scala/fs2/StreamSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamSpec.scala
@@ -123,5 +123,9 @@ class StreamSpec extends Fs2Spec {
       import fs2.util.{~>}
       Stream.repeatEval(Task.delay(0)).translate(new (Task ~> Task) { def apply[X](x: Task[X]) = Task.suspend(x) }).take(1000000).run.unsafeRun()
     }
+
+    "repeaat empty" in {
+      Stream.empty.pure.repeat.toList shouldBe List()
+    }
   }
 }

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -219,7 +219,10 @@ final class Stream[+F[_],+O] private (private val coreRef: Stream.CoreRef[F,O]) 
   def pure(implicit S: Sub1[F,Pure]): Stream[Pure,O] = covary[Pure]
 
   /** Repeat this stream an infinite number of times. `s.repeat == s ++ s ++ s ++ ...` */
-  def repeat: Stream[F,O] = self ++ repeat
+  def repeat: Stream[F,O] = for {
+    a <- self.uncons1
+    b <- a.map { case (h, t) => t.cons1(h) ++ repeat }.getOrElse(Stream.empty)
+  } yield b
 
   def runFree: Free[F,Unit] =
     runFoldFree(())((_,_) => ())


### PR DESCRIPTION
Stream#repeat should return empty Stream when self is empty, or at least it should stop safety.