### PR TITLE
Task Ref now increments nonce with every set

### DIFF
--- a/core/jvm/src/test/scala/fs2/TaskSpec.scala
+++ b/core/jvm/src/test/scala/fs2/TaskSpec.scala
@@ -1,0 +1,36 @@
+package fs2
+
+/**
+  * Created by adamchlupacek on 22/10/16.
+  */
+class TaskSpec extends Fs2Spec{
+
+
+  "Task" - {
+
+    "Ref" - {
+
+      "Set increments nonce" in {
+
+        Task.ref[Int].flatMap{ref =>
+          ref.setPure(1).flatMap{_ =>
+            ref.access.flatMap{case ((_, set)) =>
+              ref.setPure(2).flatMap{_ =>
+                set(Right(3))
+              }
+
+            }
+          }
+
+        }.unsafeRun() shouldBe false
+
+
+      }
+
+
+    }
+
+
+  }
+
+}

--- a/core/jvm/src/test/scala/fs2/TaskSpec.scala
+++ b/core/jvm/src/test/scala/fs2/TaskSpec.scala
@@ -5,11 +5,8 @@ package fs2
   */
 class TaskSpec extends Fs2Spec{
 
-
   "Task" - {
-
     "Ref" - {
-
       "Set increments nonce" in {
 
         Task.ref[Int].flatMap{ref =>
@@ -23,14 +20,7 @@ class TaskSpec extends Fs2Spec{
           }
 
         }.unsafeRun() shouldBe false
-
-
       }
-
-
     }
-
-
   }
-
 }

--- a/core/jvm/src/test/scala/fs2/TaskSpec.scala
+++ b/core/jvm/src/test/scala/fs2/TaskSpec.scala
@@ -6,7 +6,12 @@ class TaskSpec extends Fs2Spec{
 
   "Task" - {
     "Ref" - {
-      "Set increments nonce" in {
+
+      /**
+        * Tests whether set after access causes said access's
+        * set to default to no-op as the value in ref has changed
+        */
+      "Interleaving set and access " in {
 
         Task.ref[Int].flatMap{ref =>
           ref.setPure(1).flatMap{_ =>

--- a/core/jvm/src/test/scala/fs2/TaskSpec.scala
+++ b/core/jvm/src/test/scala/fs2/TaskSpec.scala
@@ -1,8 +1,5 @@
 package fs2
 
-/**
-  * Created by adamchlupacek on 22/10/16.
-  */
 class TaskSpec extends Fs2Spec{
 
   "Task" - {
@@ -15,10 +12,8 @@ class TaskSpec extends Fs2Spec{
               ref.setPure(2).flatMap{_ =>
                 set(Right(3))
               }
-
             }
           }
-
         }.unsafeRun() shouldBe false
       }
     }

--- a/core/jvm/src/test/scala/fs2/TaskSpec.scala
+++ b/core/jvm/src/test/scala/fs2/TaskSpec.scala
@@ -1,5 +1,7 @@
 package fs2
 
+import scala.concurrent.duration._
+
 class TaskSpec extends Fs2Spec{
 
   "Task" - {
@@ -10,7 +12,7 @@ class TaskSpec extends Fs2Spec{
           ref.setPure(1).flatMap{_ =>
             ref.access.flatMap{case ((_, set)) =>
               ref.setPure(2).flatMap{_ =>
-                set(Right(3))
+                set(Right(3)).schedule(100.millis)
               }
             }
           }

--- a/core/shared/src/main/scala/fs2/Task.scala
+++ b/core/shared/src/main/scala/fs2/Task.scala
@@ -290,8 +290,8 @@ object Task extends TaskPlatform with TaskInstances {
         else { val r = result; val id = nonce; S { cb(r.map((_,id))) } }
 
       case Msg.Set(r) =>
+        nonce += 1L
         if (result eq null) {
-          nonce += 1L
           val id = nonce
           waiting.values.foreach(cb => S { cb(r.map((_,id))) })
           waiting = LinkedMap.empty


### PR DESCRIPTION
As per comments in `fs2.Task.ref` the nonce should be updated with every successful set or modify, up till now for set the nonce was updated only in case of the first set, this PR addresses this issue. 

Added a test that demonstrates the case in which this would be an issue. This would also affect modify of the ref in case there was a concurrent set on it.