### PR TITLE
Fixed Chunk.concat to not smash custom chunks

### DIFF
--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -1,6 +1,6 @@
 package fs2
 
-import scala.reflect.ClassTag
+import scala.reflect.{classTag, ClassTag}
 
 /**
  * A strict, in-memory sequence of `A` values.
@@ -41,6 +41,13 @@ trait Chunk[+A] { self =>
 
   /** Returns a new chunk made up of the elements of this chunk for which the specified predicate returns true. */
   def filter(f: A => Boolean): Chunk[A]
+
+  /** Returns Some(this) if A =:= B. This function is pessimistic, in that it will assume None unless proven safe */
+  def conform[B: ClassTag]: Option[Chunk[B]]
+
+  /** Returns a new chunk consisting of the elements from the current chunk followed by the elements of the given chunks, in order */
+  def concatAll[B >: A](chunks: Seq[Chunk[B]]): Chunk[B] =
+    Chunk.indexedSeq(chunks.foldLeft(this.toVector: Vector[B]) { _ ++ _.toVector })
 
   /**
    * Reduces this chunk to a value of type `B` by applying `f` to each element, left to right,
@@ -169,6 +176,108 @@ trait Chunk[+A] { self =>
   override def hashCode: Int = iterator.toStream.hashCode
 }
 
+trait MonomorphicChunk[+A] extends Chunk[A] {
+  protected val tag: ClassTag[_]    // can't use type A because of invariance
+
+  final def conform[B](implicit ev: ClassTag[B]): Option[Chunk[B]] =
+    if (ev == tag) Some(this.asInstanceOf[Chunk[B]]) else None
+}
+
+trait PolymorphicChunk[+A] extends Chunk[A] {
+
+  final def conform[B: ClassTag] = None
+
+  /**
+   * An implementation of concatAll which special-cases the primitive chunks
+   * defined *here* and attempts to recover specialization downstream.  Alternative
+   * specialized chunk implementations will, necessarily, be omitted from this
+   * "downstream respecialization" process.
+   */
+  final override def concatAll[B >: A](chunks: Seq[Chunk[B]]): Chunk[B] = {
+    def itr = this.iterator ++ chunks.iterator
+
+    /** Concatenates the specified sequence of boolean chunks in to a single chunk. */
+    def concatBooleans(chunks: Seq[Chunk[Boolean]]): Chunk[Boolean] = {
+      if (chunks.isEmpty) Chunk.empty
+      else {
+        val size = chunks.foldLeft(0)(_ + _.size)
+        val arr = Array.ofDim[Boolean](size)
+        var offset = 0
+        chunks.foreach { c =>
+          if (!c.isEmpty) {
+            c.copyToArray(arr, offset)
+            offset += c.size
+          }
+        }
+        Chunk.booleans(arr)
+      }
+    }
+
+    /** Concatenates the specified sequence of byte chunks in to a single chunk. */
+    def concatBytes(chunks: Seq[Chunk[Byte]]): Chunk[Byte] = {
+      if (chunks.isEmpty) Chunk.empty
+      else {
+        val size = chunks.foldLeft(0)(_ + _.size)
+        val arr = Array.ofDim[Byte](size)
+        var offset = 0
+        chunks.foreach { c =>
+          if (!c.isEmpty) {
+            c.copyToArray(arr, offset)
+            offset += c.size
+          }
+        }
+        Chunk.bytes(arr)
+      }
+    }
+
+    /** Concatenates the specified sequence of double chunks in to a single chunk. */
+    def concatDoubles(chunks: Seq[Chunk[Double]]): Chunk[Double] = {
+      if (chunks.isEmpty) Chunk.empty
+      else {
+        val size = chunks.foldLeft(0)(_ + _.size)
+        val arr = Array.ofDim[Double](size)
+        var offset = 0
+        chunks.foreach { c =>
+          if (!c.isEmpty) {
+            c.copyToArray(arr, offset)
+            offset += c.size
+          }
+        }
+        Chunk.doubles(arr)
+      }
+    }
+
+    /** Concatenates the specified sequence of long chunks in to a single chunk. */
+    def concatLongs(chunks: Seq[Chunk[Long]]): Chunk[Long] = {
+      if (chunks.isEmpty) Chunk.empty
+      else {
+        val size = chunks.foldLeft(0)(_ + _.size)
+        val arr = Array.ofDim[Long](size)
+        var offset = 0
+        chunks.foreach { c =>
+          if (!c.isEmpty) {
+            c.copyToArray(arr, offset)
+            offset += c.size
+          }
+        }
+        Chunk.longs(arr)
+      }
+    }
+
+    // djs: you know, I have serious doubts that this is ACTUALLY improving performance...
+    if (itr forall { _.isInstanceOf[Boolean] })
+      concatBooleans((this +: chunks).asInstanceOf[Seq[Chunk[Boolean]]]).asInstanceOf[Chunk[B]]
+    else if (itr forall { _.isInstanceOf[Byte] })
+      concatBytes((this +: chunks).asInstanceOf[Seq[Chunk[Byte]]]).asInstanceOf[Chunk[B]]
+    else if (itr forall { _.isInstanceOf[Double] })
+      concatDoubles((this +: chunks).asInstanceOf[Seq[Chunk[Double]]]).asInstanceOf[Chunk[B]]
+    else if (itr forall { _.isInstanceOf[Long] })
+      concatLongs((this +: chunks).asInstanceOf[Seq[Chunk[Long]]]).asInstanceOf[Chunk[B]]
+    else
+      super.concatAll(chunks)
+  }
+}
+
 object Chunk {
 
   /** Empty chunk. */
@@ -181,11 +290,13 @@ object Chunk {
     def take(n: Int) = empty
     def foldLeft[B](z: B)(f: (B,Nothing) => B): B = z
     def foldRight[B](z: B)(f: (Nothing,B) => B): B = z
+    def conform[B: ClassTag] = Some(this.asInstanceOf[Chunk[B]])
+    override def concatAll[B](chunks: Seq[Chunk[B]]): Chunk[B] = Chunk.concat(chunks)
     override def map[B](f: Nothing => B) = empty
   }
 
   /** Creates a chunk of one element. */
-  def singleton[A](a: A): NonEmptyChunk[A] = NonEmptyChunk.fromChunkUnsafe(new Chunk[A] { self =>
+  def singleton[A](a: A): NonEmptyChunk[A] = NonEmptyChunk.fromChunkUnsafe(new PolymorphicChunk[A] { self =>
     def size = 1
     def apply(i: Int) = if (i == 0) a else throw new IllegalArgumentException(s"Chunk.singleton($i)")
     def copyToArray[B >: A](xs: Array[B], start: Int): Unit = xs(start) = a
@@ -199,7 +310,7 @@ object Chunk {
   })
 
   /** Creates a chunk from an indexed sequence, using the existing index-based access provided by the indexed sequence. */
-  def indexedSeq[A](a: collection.IndexedSeq[A]): Chunk[A] = new Chunk[A] {
+  def indexedSeq[A](a: collection.IndexedSeq[A]): Chunk[A] = new PolymorphicChunk[A] {
     def size = a.size
     override def isEmpty = a.isEmpty
     override def uncons = if (a.isEmpty) None else Some(a.head -> indexedSeq(a drop 1))
@@ -215,7 +326,7 @@ object Chunk {
   }
 
   /** Creates a chunk from a sequence, using a lazy copy of the sequence to support indexed based access. */
-  def seq[A](a: Seq[A]): Chunk[A] = new Chunk[A] {
+  def seq[A](a: Seq[A]): Chunk[A] = new PolymorphicChunk[A] {
     lazy val vec = a.toIndexedSeq
     def size = a.size
     override def isEmpty = a.isEmpty
@@ -277,99 +388,10 @@ object Chunk {
 
   /** Concatenates the specified sequence of chunks in to a single chunk. */
   def concat[A](chunks: Seq[Chunk[A]]): Chunk[A] = {
-    if (chunks.isEmpty) {
+    if (chunks.isEmpty)
       Chunk.empty
-    } else if (chunks.forall(c =>
-      c.isInstanceOf[Chunk.Booleans] ||
-      (c.isInstanceOf[NonEmptyChunk.Wrapped[_]] && c.asInstanceOf[NonEmptyChunk.Wrapped[_]].underlying.isInstanceOf[Chunk.Booleans]) ||
-      c.iterator.forall(_.isInstanceOf[Boolean]))) {
-      concatBooleans(chunks.asInstanceOf[Seq[Chunk[Boolean]]]).asInstanceOf[Chunk[A]]
-    } else if (chunks.forall(c =>
-      c.isInstanceOf[Chunk.Bytes] ||
-      (c.isInstanceOf[NonEmptyChunk.Wrapped[_]] && c.asInstanceOf[NonEmptyChunk.Wrapped[_]].underlying.isInstanceOf[Chunk.Bytes]) ||
-      c.iterator.forall(_.isInstanceOf[Byte]))) {
-      concatBytes(chunks.asInstanceOf[Seq[Chunk[Byte]]]).asInstanceOf[Chunk[A]]
-    } else if (chunks.forall(c =>
-       c.isInstanceOf[Chunk.Doubles] ||
-      (c.isInstanceOf[NonEmptyChunk.Wrapped[_]] && c.asInstanceOf[NonEmptyChunk.Wrapped[_]].underlying.isInstanceOf[Chunk.Doubles]) ||
-      c.iterator.forall(_.isInstanceOf[Double]))) {
-      concatDoubles(chunks.asInstanceOf[Seq[Chunk[Double]]]).asInstanceOf[Chunk[A]]
-    } else if (chunks.forall(c =>
-      c.isInstanceOf[Chunk.Longs] ||
-      (c.isInstanceOf[NonEmptyChunk.Wrapped[_]] && c.asInstanceOf[NonEmptyChunk.Wrapped[_]].underlying.isInstanceOf[Chunk.Longs]) ||
-      c.iterator.forall(_.isInstanceOf[Long]))) {
-      concatLongs(chunks.asInstanceOf[Seq[Chunk[Long]]]).asInstanceOf[Chunk[A]]
-    } else {
-      Chunk.indexedSeq(chunks.foldLeft(Vector.empty[A])(_ ++ _.toVector))
-    }
-  }
-
-  /** Concatenates the specified sequence of boolean chunks in to a single chunk. */
-  def concatBooleans(chunks: Seq[Chunk[Boolean]]): Chunk[Boolean] = {
-    if (chunks.isEmpty) Chunk.empty
-    else {
-      val size = chunks.foldLeft(0)(_ + _.size)
-      val arr = Array.ofDim[Boolean](size)
-      var offset = 0
-      chunks.foreach { c =>
-        if (!c.isEmpty) {
-          c.copyToArray(arr, offset)
-          offset += c.size
-        }
-      }
-      Chunk.booleans(arr)
-    }
-  }
-
-  /** Concatenates the specified sequence of byte chunks in to a single chunk. */
-  def concatBytes(chunks: Seq[Chunk[Byte]]): Chunk[Byte] = {
-    if (chunks.isEmpty) Chunk.empty
-    else {
-      val size = chunks.foldLeft(0)(_ + _.size)
-      val arr = Array.ofDim[Byte](size)
-      var offset = 0
-      chunks.foreach { c =>
-        if (!c.isEmpty) {
-          c.copyToArray(arr, offset)
-          offset += c.size
-        }
-      }
-      Chunk.bytes(arr)
-    }
-  }
-
-  /** Concatenates the specified sequence of double chunks in to a single chunk. */
-  def concatDoubles(chunks: Seq[Chunk[Double]]): Chunk[Double] = {
-    if (chunks.isEmpty) Chunk.empty
-    else {
-      val size = chunks.foldLeft(0)(_ + _.size)
-      val arr = Array.ofDim[Double](size)
-      var offset = 0
-      chunks.foreach { c =>
-        if (!c.isEmpty) {
-          c.copyToArray(arr, offset)
-          offset += c.size
-        }
-      }
-      Chunk.doubles(arr)
-    }
-  }
-
-  /** Concatenates the specified sequence of long chunks in to a single chunk. */
-  def concatLongs(chunks: Seq[Chunk[Long]]): Chunk[Long] = {
-    if (chunks.isEmpty) Chunk.empty
-    else {
-      val size = chunks.foldLeft(0)(_ + _.size)
-      val arr = Array.ofDim[Long](size)
-      var offset = 0
-      chunks.foreach { c =>
-        if (!c.isEmpty) {
-          c.copyToArray(arr, offset)
-          offset += c.size
-        }
-      }
-      Chunk.longs(arr)
-    }
+    else
+      chunks.head concatAll chunks.tail
   }
 
   // justification of the performance of this class: http://stackoverflow.com/a/6823454
@@ -449,8 +471,8 @@ object Chunk {
   // matching, e.g. `h.receive { case (bits: Booleans) #: h => /* do stuff unboxed */ } `
 
   /** Specialized chunk supporting unboxed operations on booleans. */
-  final class Booleans private[Chunk](val values: Array[Boolean], val offset: Int, sz: Int) extends Chunk[Boolean] {
-  self =>
+  final class Booleans private[Chunk](val values: Array[Boolean], val offset: Int, sz: Int) extends MonomorphicChunk[Boolean] { self =>
+    protected val tag = classTag[Boolean]
     val size = sz min (values.length - offset)
     def at(i: Int): Boolean = values(offset + i)
     def apply(i: Int) = values(offset + i)
@@ -488,6 +510,33 @@ object Chunk {
       (0 until size).foldLeft(z)((z,i) => f(z, at(i)))
     def foldRight[B](z: B)(f: (Boolean,B) => B): B =
       ((size-1) to 0 by -1).foldLeft(z)((tl,hd) => f(at(hd), tl))
+
+    override def concatAll[B >: Boolean](chunks: Seq[Chunk[B]]): Chunk[B] = {
+      val conformed = chunks flatMap { _.conform[Boolean] }
+
+      if (chunks.isEmpty) {
+        this
+      } else if ((chunks lengthCompare conformed.size) == 0) {
+        val size = conformed.foldLeft(this.size)(_ + _.size)
+        val arr = Array.ofDim[Boolean](size)
+        var offset = 0
+
+        if (!isEmpty) {
+          copyToArray(arr, offset)
+          offset += this.size
+        }
+
+        conformed.foreach { c =>
+          if (!c.isEmpty) {
+            c.copyToArray(arr, offset)
+            offset += c.size
+          }
+        }
+        Chunk.booleans(arr)
+      } else {
+        super.concatAll(chunks)
+      }
+    }
 
     // here be dragons; modify with EXTREME care
     override def map[B](f: Boolean => B): Chunk[B] = {
@@ -558,8 +607,8 @@ object Chunk {
   }
 
   /** Specialized chunk supporting unboxed operations on bytes. */
-  final class Bytes private[Chunk](val values: Array[Byte], val offset: Int, sz: Int) extends Chunk[Byte] {
-  self =>
+  final class Bytes private[Chunk](val values: Array[Byte], val offset: Int, sz: Int) extends MonomorphicChunk[Byte] { self =>
+    protected val tag = classTag[Byte]
     val size = sz min (values.length - offset)
     def at(i: Int): Byte = values(offset + i)
     def apply(i: Int) = values(offset + i)
@@ -597,6 +646,34 @@ object Chunk {
       (0 until size).foldLeft(z)((z,i) => f(z, at(i)))
     def foldRight[B](z: B)(f: (Byte,B) => B): B =
       ((size-1) to 0 by -1).foldLeft(z)((tl,hd) => f(at(hd), tl))
+
+    override def concatAll[B >: Byte](chunks: Seq[Chunk[B]]): Chunk[B] = {
+      val conformed = chunks flatMap { _.conform[Byte] }
+
+      if (chunks.isEmpty) {
+        this
+      } else if ((chunks lengthCompare conformed.size) == 0) {
+        val size = conformed.foldLeft(this.size)(_ + _.size)
+        val arr = Array.ofDim[Byte](size)
+        var offset = 0
+
+        if (!isEmpty) {
+          copyToArray(arr, offset)
+          offset += this.size
+        }
+
+        conformed.foreach { c =>
+          if (!c.isEmpty) {
+            c.copyToArray(arr, offset)
+            offset += c.size
+          }
+        }
+        Chunk.bytes(arr)
+      } else {
+        super.concatAll(chunks)
+      }
+    }
+
     override def toString: String = s"Bytes(offset=$offset, sz=$sz, values=${values.toSeq})"
 
     // here be dragons; modify with EXTREME care
@@ -668,8 +745,8 @@ object Chunk {
   }
 
   /** Specialized chunk supporting unboxed operations on longs. */
-  final class Longs private[Chunk](val values: Array[Long], val offset: Int, sz: Int) extends Chunk[Long] {
-  self =>
+  final class Longs private[Chunk](val values: Array[Long], val offset: Int, sz: Int) extends MonomorphicChunk[Long] { self =>
+    protected val tag = classTag[Long]
     val size = sz min (values.length - offset)
     def at(i: Int): Long = values(offset + i)
     def apply(i: Int) = values(offset + i)
@@ -707,6 +784,33 @@ object Chunk {
       (0 until size).foldLeft(z)((z,i) => f(z, at(i)))
     def foldRight[B](z: B)(f: (Long,B) => B): B =
       ((size-1) to 0 by -1).foldLeft(z)((tl,hd) => f(at(hd), tl))
+
+    override def concatAll[B >: Long](chunks: Seq[Chunk[B]]): Chunk[B] = {
+      val conformed = chunks flatMap { _.conform[Long] }
+
+      if (chunks.isEmpty) {
+        this
+      } else if ((chunks lengthCompare conformed.size) == 0) {
+        val size = conformed.foldLeft(this.size)(_ + _.size)
+        val arr = Array.ofDim[Long](size)
+        var offset = 0
+
+        if (!isEmpty) {
+          copyToArray(arr, offset)
+          offset += this.size
+        }
+
+        conformed.foreach { c =>
+          if (!c.isEmpty) {
+            c.copyToArray(arr, offset)
+            offset += c.size
+          }
+        }
+        Chunk.longs(arr)
+      } else {
+        super.concatAll(chunks)
+      }
+    }
 
     // here be dragons; modify with EXTREME care
     override def map[B](f: Long => B): Chunk[B] = {
@@ -777,8 +881,8 @@ object Chunk {
   }
 
   /** Specialized chunk supporting unboxed operations on doubles. */
-  final class Doubles private[Chunk](val values: Array[Double], val offset: Int, sz: Int) extends Chunk[Double] {
-  self =>
+  final class Doubles private[Chunk](val values: Array[Double], val offset: Int, sz: Int) extends MonomorphicChunk[Double] { self =>
+    protected val tag = classTag[Double]
     val size = sz min (values.length - offset)
     def at(i: Int): Double = values(offset + i)
     def apply(i: Int) = values(offset + i)
@@ -816,6 +920,33 @@ object Chunk {
       (0 until size).foldLeft(z)((z,i) => f(z, at(i)))
     def foldRight[B](z: B)(f: (Double,B) => B): B =
       ((size-1) to 0 by -1).foldLeft(z)((tl,hd) => f(at(hd), tl))
+
+    override def concatAll[B >: Double](chunks: Seq[Chunk[B]]): Chunk[B] = {
+      val conformed = chunks flatMap { _.conform[Double] }
+
+      if (chunks.isEmpty) {
+        this
+      } else if ((chunks lengthCompare conformed.size) == 0) {
+        val size = conformed.foldLeft(this.size)(_ + _.size)
+        val arr = Array.ofDim[Double](size)
+        var offset = 0
+
+        if (!isEmpty) {
+          copyToArray(arr, offset)
+          offset += this.size
+        }
+
+        conformed.foreach { c =>
+          if (!c.isEmpty) {
+            c.copyToArray(arr, offset)
+            offset += c.size
+          }
+        }
+        Chunk.doubles(arr)
+      } else {
+        super.concatAll(chunks)
+      }
+    }
 
     // here be dragons; modify with EXTREME care
     override def map[B](f: Double => B): Chunk[B] = {
@@ -889,7 +1020,7 @@ object Chunk {
 /**
  * A chunk which has at least one element.
  */
-sealed trait NonEmptyChunk[+A] extends Chunk[A] {
+sealed trait NonEmptyChunk[+A] extends PolymorphicChunk[A] {
 
   /** Like [[uncons]] but returns the head and tail directly instead of being wrapped in an `Option`. */
   def unconsNonEmpty: (A, Chunk[A])
@@ -954,7 +1085,7 @@ object NonEmptyChunk {
     case _ => new Wrapped(c)
   }
 
-  private[fs2] final class Wrapped[A](val underlying: Chunk[A]) extends NonEmptyChunk[A] {
+  private final class Wrapped[A](val underlying: Chunk[A]) extends NonEmptyChunk[A] {
     def unconsNonEmpty: (A, Chunk[A]) = underlying.uncons.get
     def apply(i: Int): A = underlying(i)
     def copyToArray[B >: A](xs: Array[B], start: Int): Unit = underlying.copyToArray(xs, start)

--- a/core/shared/src/test/scala/fs2/ChunkSpec.scala
+++ b/core/shared/src/test/scala/fs2/ChunkSpec.scala
@@ -22,6 +22,7 @@ class ChunkSpec extends Fs2Spec {
       Chunk.indexedSeq(c).iterator.toList shouldBe c.iterator.toList
     }
 
+
     implicit val arbBooleanChunk: Arbitrary[Chunk[Boolean]] = Arbitrary {
       for {
         n <- Gen.choose(0, 100)
@@ -167,13 +168,13 @@ class ChunkSpec extends Fs2Spec {
     "toarray.long" in forAll { c: Chunk[Long] => checkToArray(c) }
     "toarray.unspecialized" in forAll { c: Chunk[Int] => checkToArray(c) }
 
+
     def checkConcat[A, T: ClassTag](cs: Seq[Chunk[A]]) = {
       val result = Chunk.concat(cs)
       result.toVector shouldBe cs.foldLeft(Vector.empty[A])(_ ++ _.toVector)
       if (!result.isEmpty) result shouldBe a[T]
       result
     }
-
     "concat.boolean" in forAll { cs: List[Chunk[Boolean]] => checkConcat[Boolean, Chunk.Booleans](cs) }
     "concat.bytes" in forAll { cs: List[Chunk[Byte]] => checkConcat[Byte, Chunk.Bytes](cs) }
     "concat.doubles" in forAll { cs: List[Chunk[Double]] => checkConcat[Double, Chunk.Doubles](cs) }


### PR DESCRIPTION
Critical motivating example: `ByteVectorChunk`.  Without the ability to write this kind of `Chunk`, fs2 cannot be easily used for high-performance IO, simply because it will lack the ability to operate on direct `ByteBuffer` instances (via scodec's `ByteVector`).  This is a pretty big deal for frameworks like http4s.

Now, `Chunk` is not sealed (good!), but `Chunk.concat` has a fairly significant amount of hard-coded assumptions about the type of specialization which is possible.  Specifically, it's assuming that the `Chunk.*` implementations are the _only_ specialized chunks that will ever be useful, with all other unforeseen `Chunk` subtypes falling more into the camp of `Chunk.indexedSeq`.  This assumption stems from the fact that it has a hard-coded set of cases that it checks (very inefficiently, btw!) and it will forcibly despecialize (using element-by-element iteration) any chunks which do not conform to its assumptions.  If we look at the example of `ByteVectorChunk`, the specialization would *sort of* be retained, but you would lose the `ByteVector` and every individual `Byte` would be boxed and read onto the heap (twice, actually), resulting in an instance of `Chunk.Bytes`.  Now, `Chunk.Bytes` is good, but it's not `ByteVectorChunk`.  We need to preserve `ByteVectorChunk` through `Chunk.concat`, or the concept is basically dead on arrival.

Enter: subtype polymorphism!  I've rearranged the branching to be *open* and extensible via subtyping and inheritance.  (note to self: crow to someone who cares about a useful application of inheritance and subtyping)  There are now two new functions on `Chunk`:

```scala
  /** Returns Some(this) if A =:= B. This function is pessimistic, in that it will assume None unless proven safe */
  def conform[B: ClassTag]: Option[Chunk[B]]

  /** Returns a new chunk consisting of the elements from the current chunk followed by the elements of the given chunks, in order */
  def concatAll[B >: A](chunks: Seq[Chunk[B]]): Chunk[B] =
    Chunk.indexedSeq(chunks.foldLeft(this.toVector: Vector[B]) { _ ++ _.toVector })
```

The `conform` function is basically a safe cast, which is necessary to detect and work around covariance when the sequence of chunks is secretly heterogeneous (hopefully rare).  It is basically always safe to return `None` from this function, though there may be circumstances (such as `ByteVectorChunk` where safe and efficient checking is possible).  `concatAll` is really where the meat is.

Intuitively, `Chunk.concat(chunks) = chunks.head concatAll chunks.tail`.  Modulo bounds checking of course.  Basically, this delegates the decision about whether-or-not and *how* to respecialize to the runtime type of the first chunk in the sequence.  If that runtime type is using the default implementation of `concatAll` (which will be fine for any non-specialized chunks), everything is essentially kept despecialized.  Note that if you have a `Chunk` implementation which *wants* to attempt to respecialize the hard-coded primitive chunk types, you can mix in `PolymorphicChunk`.  Otherwise, if you're something like `ByteVectorChunk`, you just implement the `concatAll` function in such a way that your secret hidden specialized features are preserved as much as possible.

Now, as mentioned, I preserved the optimistic respecialization of chunks that *contain* primitives but aren't actually primitive, but I'm not entirely sure it's a good idea.  You would need to have one heck of a downstream pipeline to really make it worthwhile, considering that it results in traversing the entire sequence, *element-by-element*, twice.  We should probably profile it.

This reimplementation did result in some code duplication (since I wanted to avoid creating junk `Seq` instances when I have no way of knowing the asymptotic complexity of the underlying implementation), and there are a *couple* cases that it is going to miss.  For example, `NonEmptyChunk` is a hot flaming mess and I'm really annoyed at its existence.  Respecialization is slightly weaker in cases involving `NonEmptyChunk` than it was previously.  We can improve a bit on the situation in this PR.  Aside from that though, every case that *was* respecialized is *still* respecialized, and the mechanism is now extensible.

---

Dedicated to @rossabaker 