### PR TITLE
Updated laws with clarifications

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -11,10 +11,10 @@ import fs2.util.{Applicative,Async,Attempt,Catchable,Free,Lub1,RealSupertype,Sub
  *
  * `append` forms a monoid in conjunction with `empty`:
  *   - `empty append s == s` and `s append empty == s`.
- *   -`(s1 append s2) append s3 == s1 append (s2 append s3)`
+ *   - `(s1 append s2) append s3 == s1 append (s2 append s3)`
  *
  * And `push` is consistent with using `append` to prepend a single chunk:
- *   -`push(c)(s) == chunk(c) append s`
+ *   - `push(c)(s) == chunk(c) append s`
  *
  * `fail` propagates until being caught by `onError`:
  *   - `fail(e) onError h == h(e)`
@@ -22,15 +22,37 @@ import fs2.util.{Applicative,Async,Attempt,Catchable,Free,Lub1,RealSupertype,Sub
  *   - `fail(e) flatMap f == fail(e)`
  *
  * `Stream` forms a monad with `emit` and `flatMap`:
- *   - `emit >=> f == f`
- *   - `f >=> emit == f`
- *   - `(f >=> g) >=> h == f >=> (g >=> h)`
+ *   - `emit >=> f == f` (left identity)
+ *   - `f >=> emit === f` (right identity - note weaker equality notion here)
+ *   - `(f >=> g) >=> h == f >=> (g >=> h)` (associativity)
  *  where `emit(a)` is defined as `chunk(Chunk.singleton(a)) and
  *  `f >=> g` is defined as `a => a flatMap f flatMap g`
  *
  * The monad is the list-style sequencing monad:
  *   - `(a append b) flatMap f == (a flatMap f) append (b flatMap f)`
  *   - `empty flatMap f == empty`
+ *
+ * '''Technical notes'''
+ *
+ * ''Note:'' since the chunk structure of the stream is observable, and
+ * `s flatMap (emit)` produces a stream of singleton chunks,
+ * the right identity law uses a weaker notion of equality, `===` which
+ * normalizes both sides with respect to chunk structure:
+ *
+ *   `(s1 === s2) = normalize(s1) == normalize(s2)`
+ *   where `==` is full equality
+ *   (`a == b` iff `f(a)` is identical to `f(b)` for all `f`)
+ *
+ * `normalize(s)` can be defined as `s.repeatPull(_.echo1)`, which just
+ * produces a singly-chunked stream from any input stream `s`.
+ *
+ * ''Note:'' For efficiency `[[Stream.map]]` function operates on an entire
+ * chunk at a time and preserves chunk structure, which differs from
+ * the `map` derived from the monad (`s map f == s flatMap (f andThen emit)`)
+ * which would produce singleton chunks. In particular, if `f` throws errors, the
+ * chunked version will fail on the first ''chunk'' with an error, while
+ * the unchunked version will fail on the first ''element'' with an error.
+ * Exceptions in pure code like this are strongly discouraged.
  */
 final class Stream[+F[_],+O] private (private val coreRef: Stream.CoreRef[F,O]) { self =>
 


### PR DESCRIPTION
This is partially in response to #760. The right identity monad law uses a weaker notion of equality, since `s flatMap emit` produces singleton chunks. _I think the other laws are still good with 'full equality' but would appreciate if others would think about whether this is true and raise any counterexamples._

Also added a note about how `map` can differ from the monad-derived map, in particular for exceptions in pure code.