### PR TITLE
Fix a bug in test code

### DIFF
--- a/core/shared/src/test/scala/fs2/TextSpec.scala
+++ b/core/shared/src/test/scala/fs2/TextSpec.scala
@@ -52,7 +52,7 @@ class TextSpec extends Fs2Spec {
 
       "n byte sequences" in forAll { (s: String) =>
         val n = Gen.choose(1,9).sample.getOrElse(1)
-        Stream.chunk(utf8Bytes(s)).pure.chunkLimit(1).flatMap(Stream.chunk).through(utf8Decode).toList.mkString shouldBe s
+        Stream.chunk(utf8Bytes(s)).pure.chunkLimit(n).flatMap(Stream.chunk).through(utf8Decode).toList.mkString shouldBe s
       }
 
       // The next tests were taken from:


### PR DESCRIPTION
Looks like a porting bug

https://github.com/functional-streams-for-scala/fs2/commit
/97ad8d6f0b9e98f7fc14b7304b0f5c6b69d4e693#diff-542dd3ea6873dc327e3c7395d4fa9400R52

https://github.com/scalaz/scalaz-stream/blob/series/0.8/src/test/scala/scalaz/stream/Utf8DecodeSpec.scala#L57-L60