### PR TITLE
Minor performance improvements in Free

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/FreeBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/FreeBenchmark.scala
@@ -21,4 +21,10 @@ class FreeBenchmark extends BenchmarkUtils {
     val nestedFlatMapsFree = (0 to N).foldLeft(Free.pure(0): Free[Task, Int]) { (acc, i) => acc.flatMap(j => Free.pure(i + j)) }
     nestedFlatMapsFree.run
   }
+
+  @Benchmark
+  def alternatingMapFlatMap = {
+    val nestedMapsFree = (0 to N).foldLeft(Free.pure(0): Free[Task, Int]) { (acc, i) => if (i % 2 == 0) acc.map(_ + i) else acc.flatMap(j => Free.pure(i + j))}
+    nestedMapsFree.run
+  }
 }

--- a/benchmark/src/main/scala/fs2/benchmark/FreeBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/FreeBenchmark.scala
@@ -1,0 +1,24 @@
+package fs2
+package benchmark
+
+import org.openjdk.jmh.annotations.{Benchmark, State, Scope}
+
+import fs2.util.Free
+
+@State(Scope.Thread)
+class FreeBenchmark extends BenchmarkUtils {
+
+  val N = 1000000
+
+  @Benchmark
+  def nestedMaps = {
+    val nestedMapsFree = (0 to N).foldLeft(Free.pure(0): Free[Task, Int]) { (acc, i) => acc.map(_ + i) }
+    nestedMapsFree.run
+  }
+
+  @Benchmark
+  def nestedFlatMaps = {
+    val nestedFlatMapsFree = (0 to N).foldLeft(Free.pure(0): Free[Task, Int]) { (acc, i) => acc.flatMap(j => Free.pure(i + j)) }
+    nestedFlatMapsFree.run
+  }
+}

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -39,6 +39,7 @@ final class Pull[+F[_],+O,+R] private (private val get: Free[AlgebraF[F,O]#f,Opt
         case Algebra.Eval(fr) => StreamCore.evalScope(fr.attempt).flatMap(f)
         case Algebra.Output(o) => StreamCore.append(o, StreamCore.suspend(f(Right(()))))
       }
+      def map[X](x: X)(f: X => Out) = StreamCore.attemptStream(done(f(x)))
       def bind[X](x: X)(f: X => G[Out]) = StreamCore.attemptStream(f(x))
     })(Sub1.sub1[AlgebraF[F,O]#f], implicitly[RealSupertype[Out,Out]])
   }; if (asStep) s else StreamCore.scope(s) }

--- a/core/shared/src/main/scala/fs2/Scope.scala
+++ b/core/shared/src/main/scala/fs2/Scope.scala
@@ -55,6 +55,7 @@ final class Scope[+F[_],+O] private (private val get: Free[AlgebraF[F]#f,O]) {
           env.tracked.cancelAcquire(token)
           g(Right(()))
       }
+      def map[X](r: X)(g: X => O) = done(g(r))
       def bind[X](r: X)(g: X => FO[O]) = g(r)
     })(Sub1.sub1[AlgebraF[F]#f],implicitly[RealSupertype[O,O]])
   }


### PR DESCRIPTION
This PR implements a few minor performance improvements, including:
 - Removing `Free#step` in favor of doing associativity fixups directly in `flatMap`
 - Added `Free.Map` constructor and implemented map fusion, along with cooperative associativity fixups between `flatMap` and `map`
 - Replacing `runTranslate` with `run` (negligible improvement but simplifies code)

The removal of `step` didn't make much improvements in the benchmark (as long as the benchmark covers both the building of the `Free` as well as the running of it). This includes using polymorphic subtype method dispatch to fixup associativity.

Map fusion resulted in a 3x performance improvement for the consecutive map test.

a0aef44d45e76ebfe6b24aee3fa71664b7bbca0e (head of series/1.0 at time of opening)
```
[info] Benchmark                      Mode  Cnt   Score   Error  Units
[info] FreeBenchmark.nestedFlatMaps  thrpt   10  11.023 ± 1.311  ops/s
[info] FreeBenchmark.nestedMaps      thrpt   10   7.292 ± 1.810  ops/s
```

9d69b8fe480efaa6620ceedfa166f9b1427de7f6 (with step removed and without Map constructor)
```
[info] Benchmark                      Mode  Cnt   Score   Error  Units
[info] FreeBenchmark.nestedFlatMaps  thrpt   10  11.254 ± 1.081  ops/s
[info] FreeBenchmark.nestedMaps      thrpt   10   7.266 ± 3.232  ops/s
```

8ebd5a0f93591962e27452b8f17fff96d81ffe1d (The final commit in this PR at time of opening)
```
[info] Benchmark                             Mode  Cnt   Score   Error  Units
[info] FreeBenchmark.alternatingMapFlatMap  thrpt   10  11.207 ± 4.787  ops/s
[info] FreeBenchmark.nestedFlatMaps         thrpt   10  12.372 ± 3.718  ops/s
[info] FreeBenchmark.nestedMaps             thrpt   10  21.336 ± 2.183  ops/s
```