### PR TITLE
Minor performance improvement in Free

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/FreeBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/FreeBenchmark.scala
@@ -1,0 +1,24 @@
+package fs2
+package benchmark
+
+import org.openjdk.jmh.annotations.{Benchmark, State, Scope}
+
+import fs2.util.Free
+
+@State(Scope.Thread)
+class FreeBenchmark extends BenchmarkUtils {
+
+  val N = 1000000
+
+  @Benchmark
+  def nestedMaps = {
+    val nestedMapsFree = (0 to N).foldLeft(Free.pure(0): Free[Task, Int]) { (acc, i) => acc.map(_ + i) }
+    nestedMapsFree.run
+  }
+
+  @Benchmark
+  def nestedFlatMaps = {
+    val nestedFlatMapsFree = (0 to N).foldLeft(Free.pure(0): Free[Task, Int]) { (acc, i) => acc.flatMap(j => Free.pure(i + j)) }
+    nestedFlatMapsFree.run
+  }
+}


### PR DESCRIPTION
This PR improves performance of Free by eagerly applying `Bind(Pure(a), f)` patterns in `Free#step`. We used to do this but it had the unfortunate side effect of evaluating suspends, because suspend is (still) implemented as `pure(()) >> fa`. This PR takes a conservative approach to fixing this issue by introducing a new flag on the `Pure` constructor, indicating whether or not eager evaluation is supported. `Free.pure` sets the flag to true whereas `Free.suspend` sets the flag to false.

The Free benchmarks show 18% - 42% increase:

a0aef44d45e76ebfe6b24aee3fa71664b7bbca0e (head of series/1.0)
```
[info] Benchmark                      Mode  Cnt   Score   Error  Units
[info] FreeBenchmark.nestedFlatMaps  thrpt   10  11.023 ± 1.311  ops/s
[info] FreeBenchmark.nestedMaps      thrpt   10   7.292 ± 1.810  ops/s
```

fa9aa99488b4f4e902fcf528acfb027dd41cd596 (this PR)

```
info] Benchmark                      Mode  Cnt   Score   Error  Units
[info] FreeBenchmark.nestedFlatMaps  thrpt   10  13.660 ± 1.745  ops/s
[info] FreeBenchmark.nestedMaps      thrpt   10  10.412 ± 1.739  ops/s
```

The Stream benchmarks show a wider range of improvements -- the worse case is about equal (`runLog_102400`) and the best case shows a 330% improvement (`awaitPull_256`).

a0aef44d45e76ebfe6b24aee3fa71664b7bbca0e (head of series/1.0)

```
[info] Benchmark                                  Mode  Cnt    Score    Error  Units
[info] StreamBenchmark.awaitPull_256             thrpt   10   57.634 ±  8.218  ops/s
[info] StreamBenchmark.eval_102400               thrpt   10    0.616 ±  0.025  ops/s
[info] StreamBenchmark.leftAssocConcat_102400    thrpt   10    3.261 ±  0.448  ops/s
[info] StreamBenchmark.leftAssocFlatMap_102400   thrpt   10    9.509 ±  0.501  ops/s
[info] StreamBenchmark.rightAssocConcat_102400   thrpt   10    3.171 ±  0.409  ops/s
[info] StreamBenchmark.rightAssocFlatMap_102400  thrpt   10    8.579 ±  0.496  ops/s
[info] StreamBenchmark.runLog_102400             thrpt   10  770.429 ± 28.606  ops/s
```

fa9aa99488b4f4e902fcf528acfb027dd41cd596 (this PR)

```
[info] Benchmark                                  Mode  Cnt    Score    Error  Units
[info] StreamBenchmark.awaitPull_256             thrpt   10  188.070 ± 16.577  ops/s
[info] StreamBenchmark.eval_102400               thrpt   10    1.443 ±  0.317  ops/s
[info] StreamBenchmark.leftAssocConcat_102400    thrpt   10    5.101 ±  0.323  ops/s
[info] StreamBenchmark.leftAssocFlatMap_102400   thrpt   10   12.276 ±  1.137  ops/s
[info] StreamBenchmark.rightAssocConcat_102400   thrpt   10    5.069 ±  0.568  ops/s
[info] StreamBenchmark.rightAssocFlatMap_102400  thrpt   10   12.130 ±  1.069  ops/s
[info] StreamBenchmark.runLog_102400             thrpt   10  767.122 ± 14.423  ops/s
```

I think we should merge this in order to establish a new baseline for performance, and then do the more extensive Free refactorings, like map fusion with type aligned sequences, after this version.