### PR TITLE
Tail recursive Free.map fusion

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/FreeBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/FreeBenchmark.scala
@@ -1,0 +1,30 @@
+package fs2
+package benchmark
+
+import org.openjdk.jmh.annotations.{Benchmark, State, Scope}
+
+import fs2.util.Free
+
+@State(Scope.Thread)
+class FreeBenchmark extends BenchmarkUtils {
+
+  val N = 1000000
+
+  @Benchmark
+  def nestedMaps = {
+    val nestedMapsFree = (0 to N).foldLeft(Free.pure(0): Free[Task, Int]) { (acc, i) => acc.map(_ + i) }
+    nestedMapsFree.run
+  }
+
+  @Benchmark
+  def nestedFlatMaps = {
+    val nestedFlatMapsFree = (0 to N).foldLeft(Free.pure(0): Free[Task, Int]) { (acc, i) => acc.flatMap(j => Free.pure(i + j)) }
+    nestedFlatMapsFree.run
+  }
+
+  @Benchmark
+  def alternatingMapFlatMap = {
+    val nestedMapsFree = (0 to N).foldLeft(Free.pure(0): Free[Task, Int]) { (acc, i) => if (i % 2 == 0) acc.map(_ + i) else acc.flatMap(j => Free.pure(i + j))}
+    nestedMapsFree.run
+  }
+}

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -39,6 +39,7 @@ final class Pull[+F[_],+O,+R] private (private val get: Free[AlgebraF[F,O]#f,Opt
         case Algebra.Eval(fr) => StreamCore.evalScope(fr.attempt).flatMap(f)
         case Algebra.Output(o) => StreamCore.append(o, StreamCore.suspend(f(Right(()))))
       }
+      def map[X](x: X)(f: X => Out) = StreamCore.attemptStream(done(f(x)))
       def bind[X](x: X)(f: X => G[Out]) = StreamCore.attemptStream(f(x))
     })(Sub1.sub1[AlgebraF[F,O]#f], implicitly[RealSupertype[Out,Out]])
   }; if (asStep) s else StreamCore.scope(s) }

--- a/core/shared/src/main/scala/fs2/Scope.scala
+++ b/core/shared/src/main/scala/fs2/Scope.scala
@@ -55,6 +55,7 @@ final class Scope[+F[_],+O] private (private val get: Free[AlgebraF[F]#f,O]) {
           env.tracked.cancelAcquire(token)
           g(Right(()))
       }
+      def map[X](r: X)(g: X => O) = done(g(r))
       def bind[X](r: X)(g: X => FO[O]) = g(r)
     })(Sub1.sub1[AlgebraF[F]#f],implicitly[RealSupertype[O,O]])
   }

--- a/core/shared/src/main/scala/fs2/util/Free.scala
+++ b/core/shared/src/main/scala/fs2/util/Free.scala
@@ -5,11 +5,11 @@ import fs2.internal.Trampoline
 /** A specialized free monad which captures exceptions thrown during evaluation. */
 sealed trait Free[+F[_],+A] {
   import Free._
-  final def flatMap[F2[x]>:F[x],B](f: A => Free[F2,B]): Free[F2,B] = Bind(this, f)
-  final def map[B](f: A => B): Free[F,B] = Bind(this, (a: A) => Free.Pure(f(a)))
+  def flatMap[F2[x]>:F[x],B](f: A => Free[F2,B]): Free[F2,B] = Bind(this, f)
 
-  final def fold[F2[_],G[_],A2>:A](f: Fold[F2,G,A2])(implicit S: Sub1[F,F2], T: RealSupertype[A,A2]): G[A2] =
-    this.step._fold(f)
+  def map[B](f: A => B): Free[F,B] = Map(this, f)
+
+  def fold[F2[_],G[_],A2>:A](f: Fold[F2,G,A2])(implicit S: Sub1[F,F2], T: RealSupertype[A,A2]): G[A2]
 
   final def translate[G[_]](u: F ~> G): Free[G,A] = {
     type FG[x] = Free[G,x]
@@ -18,6 +18,7 @@ sealed trait Free[+F[_],+A] {
       def done(a: A) = Free.pure(a)
       def fail(t: Throwable) = Free.fail(t)
       def eval[X](fx: F[X])(f: Attempt[X] => FG[A]) = Free.attemptEval(u(fx)).flatMap(f)
+      def map[X](x: X)(f: X => A) = Free.pure(f(x))
       def bind[X](x: X)(f: X => FG[A]) = f(x)
     })
   }
@@ -32,30 +33,17 @@ sealed trait Free[+F[_],+A] {
       def done(a: A) = Free.pure(Right(a))
       def fail(t: Throwable) = Free.pure(Left(t))
       def eval[X](fx: F[X])(f: Attempt[X] => G[A]) = Free.attemptEval(fx) flatMap f
+      def map[X](x: X)(f: X => A) = try Free.pure(Right(f(x))) catch { case NonFatal(t) => Free.pure(Left(t)) }
       def bind[X](x: X)(f: X => G[A]) = try f(x) catch { case NonFatal(t) => Free.pure(Left(t)) }
     })
   }
 
-  protected def _fold[F2[_],G[_],A2>:A](f: Fold[F2,G,A2])(implicit S: Sub1[F,F2], T: RealSupertype[A,A2]): G[A2]
-
-  final def runTranslate[G[_],A2>:A](g: F ~> G)(implicit G: Catchable[G]): G[A2] =
-    step._runTranslate(g)
-
-  protected def _runTranslate[G[_],A2>:A](g: F ~> G)(implicit G: Catchable[G]): G[A2]
-
   final def unroll[G[+_]](implicit G: Functor[G], S: Sub1[F,G]): Unroll[A, G[Free[F,A]]] =
-    this.step._unroll.run
+    unroll_.run
 
-  protected def _unroll[G[+_]](implicit G: Functor[G], S: Sub1[F,G]): Trampoline[Unroll[A, G[Free[F,A]]]]
+  protected def unroll_[G[+_]](implicit G: Functor[G], S: Sub1[F,G]): Trampoline[Unroll[A, G[Free[F,A]]]]
 
-  final def run[F2[x]>:F[x], A2>:A](implicit F2: Catchable[F2]): F2[A2] =
-    (this: Free[F2,A2]).runTranslate(UF1.id)
-
-  @annotation.tailrec
-  private[fs2] final def step: Free[F,A] = this match {
-    case Bind(Bind(x, f), g) => (x flatMap (a => f(a) flatMap g)).step
-    case _ => this
-  }
+  def run[F2[x]>:F[x], A2>:A](implicit F2: Catchable[F2]): F2[A2]
 
   override def toString = "Free(..)"
 }
@@ -67,6 +55,7 @@ object Free {
     def done(a: A): G[A]
     def fail(t: Throwable): G[A]
     def eval[X](fx: F[X])(f: Attempt[X] => G[A]): G[A]
+    def map[X](x: X)(f: X => A): G[A]
     def bind[X](x: X)(f: X => G[A]): G[A]
   }
 
@@ -84,58 +73,86 @@ object Free {
     pure(()) flatMap { _ => fa }
 
   private final case class Fail(err: Throwable) extends Free[Nothing,Nothing] {
-    def _runTranslate[G[_],A2>:Nothing](g: Nothing ~> G)(implicit G: Catchable[G]): G[A2] =
-      G.fail(err)
-    def _unroll[G[+_]](implicit G: Functor[G], S: Sub1[Nothing,G])
-    : Trampoline[Unroll[Nothing, G[Free[Nothing,Nothing]]]]
-    = Trampoline.done { Unroll.Fail(err) }
-    def _fold[F2[_],G[_],A2>:Nothing](f: Fold[F2,G,A2])(implicit S: Sub1[Nothing,F2], T: RealSupertype[Nothing,A2]): G[A2] = f.fail(err)
+    def run[F2[x]>:Nothing, A2>:Nothing](implicit F2: Catchable[F2]): F2[A2] =
+      F2.fail(err)
+    def unroll_[G[+_]](implicit G: Functor[G], S: Sub1[Nothing,G]): Trampoline[Unroll[Nothing, G[Free[Nothing,Nothing]]]] =
+      Trampoline.done { Unroll.Fail(err) }
+    def fold[F2[_],G[_],A2>:Nothing](f: Fold[F2,G,A2])(implicit S: Sub1[Nothing,F2], T: RealSupertype[Nothing,A2]): G[A2] =
+      f.fail(err)
   }
   private final case class Pure[A](a: A) extends Free[Nothing,A] {
-    def _runTranslate[G[_],A2>:A](g: Nothing ~> G)(implicit G: Catchable[G]): G[A2] =
-      G.pure(a)
-    def _unroll[G[+_]](implicit G: Functor[G], S: Sub1[Nothing,G])
-    : Trampoline[Unroll[A, G[Free[Nothing,A]]]]
-    = Trampoline.done { Unroll.Pure(a) }
-    def _fold[F2[_],G[_],A2>:A](f: Fold[F2,G,A2])(implicit S: Sub1[Nothing,F2], T: RealSupertype[A,A2]): G[A2] = f.done(a)
+    def run[F2[x]>:Nothing, A2>:A](implicit F2: Catchable[F2]): F2[A2] =
+      F2.pure(a)
+    def unroll_[G[+_]](implicit G: Functor[G], S: Sub1[Nothing,G]): Trampoline[Unroll[A, G[Free[Nothing,A]]]] =
+      Trampoline.done { Unroll.Pure(a) }
+    def fold[F2[_],G[_],A2>:A](f: Fold[F2,G,A2])(implicit S: Sub1[Nothing,F2], T: RealSupertype[A,A2]): G[A2] =
+      f.done(a)
   }
   private final case class Eval[F[_],A](fa: F[A]) extends Free[F,Attempt[A]] {
-    def _runTranslate[G[_],A2>:Attempt[A]](g: F ~> G)(implicit G: Catchable[G]): G[A2] =
-      G.attempt { g(fa) }.asInstanceOf[G[A2]]
-
-    def _unroll[G[+_]](implicit G: Functor[G], S: Sub1[F,G])
-    : Trampoline[Unroll[Attempt[A], G[Free[F,Attempt[A]]]]]
-    = Trampoline.done { Unroll.Eval(G.map(S(fa))(a => Free.pure(Right(a)))) }
-
-    def _fold[F2[_],G[_],A2>:Attempt[A]](f: Fold[F2,G,A2])(implicit S: Sub1[F,F2], T: RealSupertype[Attempt[A],A2]): G[A2] =
+    def run[F2[x]>:F[x], A2>:Attempt[A]](implicit F2: Catchable[F2]): F2[A2] =
+      F2.attempt(fa).asInstanceOf[F2[A2]]
+    def unroll_[G[+_]](implicit G: Functor[G], S: Sub1[F,G]): Trampoline[Unroll[Attempt[A], G[Free[F,Attempt[A]]]]] =
+      Trampoline.done { Unroll.Eval(G.map(S(fa))(a => Free.pure(Right(a)))) }
+    def fold[F2[_],G[_],A2>:Attempt[A]](f: Fold[F2,G,A2])(implicit S: Sub1[F,F2], T: RealSupertype[Attempt[A],A2]): G[A2] =
       f.eval(S(fa))(f.done)
   }
-  private final case class Bind[+F[_],R,A](r: Free[F,R], f: R => Free[F,A]) extends Free[F,A] {
-    def _runTranslate[G[_],A2>:A](g: F ~> G)(implicit G: Catchable[G]): G[A2] =
-      G.flatMap(r._runTranslate(g))(r => f(r).runTranslate(g))
-    def _unroll[G[+_]](implicit G: Functor[G], S: Sub1[F,G])
-    : Trampoline[Unroll[A, G[Free[F,A]]]]
-    = Sub1.substFree(r) match {
+  private final case class Map[+F[_],R,A](r: Free[F,R], f: R => A) extends Free[F,A] {
+    override def map[B](g: A => B): Free[F,B] =
+      Map(r, f andThen g)
+    override def flatMap[F2[x]>:F[x],B](g: A => Free[F2,B]): Free[F2,B] =
+      Bind(r, f andThen g)
+    def run[F2[x]>:F[x], A2>:A](implicit F2: Catchable[F2]): F2[A2] =
+      F2.map(r.run(F2))(r => f(r))
+    def unroll_[G[+_]](implicit G: Functor[G], S: Sub1[F,G]): Trampoline[Unroll[A, G[Free[F,A]]]] = Sub1.substFree(r) match {
       case Pure(r) =>
-        try Trampoline.suspend { f(r).step._unroll }
+        try Trampoline.done { Unroll.Pure(f(r)) }
+        catch { case NonFatal(err) => Trampoline.done { Unroll.Fail(err) } }
+      case Fail(err) => Trampoline.done { Unroll.Fail(err) }
+      case eval =>
+        val ga: G[Any] = eval.asInstanceOf[Eval[G,Any]].fa
+        val fr: Attempt[Any] => A = f.asInstanceOf[Attempt[Any] => A]
+        Trampoline.done { Unroll.Eval(G.map(ga)(a => pure(fr(Right(a))))) }
+    }
+    def fold[F2[_],G[_],A2>:A](fold: Fold[F2,G,A2])(implicit S: Sub1[F,F2], T: RealSupertype[A,A2]): G[A2] =
+      fold.suspend { Sub1.substFree(r) match {
+        case Pure(r) => fold.map(r)(f)
+        case Fail(err) => fold.fail(err)
+        case eval =>
+          val fa: F2[Any] = eval.asInstanceOf[Eval[F2,Any]].fa
+          val fr: Attempt[Any] => A = f.asInstanceOf[Attempt[Any] => A]
+          fold.eval(fa)(fr andThen fold.done)
+      }}
+  }
+  private final case class Bind[+F[_],R,A](r: Free[F,R], f: R => Free[F,A]) extends Free[F,A] {
+    override def map[B](g: A => B): Free[F,B] =
+      Bind(r, (r: R) => f(r).map(g))
+    override def flatMap[F2[x]>:F[x],B](g: A => Free[F2,B]): Free[F2,B] =
+      Bind(r, (r: R) => f(r).flatMap(g))
+    def run[F2[x]>:F[x], A2>:A](implicit F2: Catchable[F2]): F2[A2] =
+      F2.flatMap(r.run(F2))(r => f(r).run(F2))
+    def unroll_[G[+_]](implicit G: Functor[G], S: Sub1[F,G]): Trampoline[Unroll[A, G[Free[F,A]]]] = Sub1.substFree(r) match {
+      case Pure(r) =>
+        try Trampoline.suspend { f(r).unroll_ }
         catch { case NonFatal(err) => Trampoline.done { Unroll.Fail(err) } }
       case Fail(err) => Trampoline.done { Unroll.Fail(err) }
       case eval =>
         // NB: not bothering to convince Scala this is legit but since
-        // `.step` returns a right-associated flatMap, and `Eval[F,A]` has type
+        // `flatMap` and `map` build right-associated, and `Eval[F,A]` has type
         // Free[Attempt[A]], this is safe
         val ga: G[Any] = eval.asInstanceOf[Eval[G,Any]].fa
-        val fr: Attempt[Any] => Free[F,A]
-           = f.asInstanceOf[Attempt[Any] => Free[F,A]]
+        val fr: Attempt[Any] => Free[F,A] = f.asInstanceOf[Attempt[Any] => Free[F,A]]
         Trampoline.done { Unroll.Eval(G.map(ga) { any => fr(Right(any)) }) }
     }
-    def _fold[F2[_],G[_],A2>:A](fold: Fold[F2,G,A2])(implicit S: Sub1[F,F2], T: RealSupertype[A,A2]): G[A2] =
+    def fold[F2[_],G[_],A2>:A](fold: Fold[F2,G,A2])(implicit S: Sub1[F,F2], T: RealSupertype[A,A2]): G[A2] =
       fold.suspend { Sub1.substFree(r) match {
         case Pure(r) => fold.bind(r) { r => f(r).fold(fold) }
         case Fail(err) => fold.fail(err)
-        // NB: Scala won't let us pattern match on Eval here, but this is safe since `.step`
-        // removes any left-associated flatMaps
-        case eval => fold.eval(eval.asInstanceOf[Eval[F2,R]].fa)(a => f.asInstanceOf[Any => Free[F,A]](a).fold(fold))
+        // NB: Scala won't let us pattern match on Eval here, but this is safe since `flatMap` and `map`
+        // prevent left-associated flatMaps
+        case eval =>
+          val fa: F2[Any] = eval.asInstanceOf[Eval[F2,Any]].fa
+          val fr: Attempt[Any] => Free[F,A] = f.asInstanceOf[Attempt[Any] => Free[F,A]]
+          fold.eval(fa)(a => fr(a).fold(fold))
       }}
   }
 


### PR DESCRIPTION
A continuation of @mpilquist's earlier branch, but with stack-safe map fusion.  Also a rediscovery of scalac's bug with `tailrec` and existential types.