### PR TITLE
Stack safety and constant factor improvements of Catenable

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/CatenableBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/CatenableBenchmark.scala
@@ -19,9 +19,14 @@ class CatenableBenchmark extends BenchmarkUtils {
   @Benchmark def mapLargeCatenable = largeCatenable.map(_ + 1)
   @Benchmark def mapLargeVector = largeVector.map(_ + 1)
 
-  @Benchmark def consSmallCatenable = 0 :: smallCatenable
+  @Benchmark def foldLeftSmallCatenable = smallCatenable.foldLeft(0)(_ + _)
+  @Benchmark def foldLeftSmallVector = smallVector.foldLeft(0)(_ + _)
+  @Benchmark def foldLeftLargeCatenable = largeCatenable.foldLeft(0)(_ + _)
+  @Benchmark def foldLeftLargeVector = largeVector.foldLeft(0)(_ + _)
+
+  @Benchmark def consSmallCatenable = 0 +: smallCatenable
   @Benchmark def consSmallVector = 0 +: smallVector
-  @Benchmark def consLargeCatenable = 0 :: largeCatenable
+  @Benchmark def consLargeCatenable = 0 +: largeCatenable
   @Benchmark def consLargeVector = 0 +: largeVector
 
   @Benchmark def createTinyCatenable = Catenable(1)

--- a/benchmark/src/main/scala/fs2/benchmark/CatenableBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/CatenableBenchmark.scala
@@ -1,0 +1,31 @@
+package fs2
+package benchmark
+
+import org.openjdk.jmh.annotations.{Benchmark, State, Scope}
+
+import fs2.util.Catenable
+
+@State(Scope.Thread)
+class CatenableBenchmark extends BenchmarkUtils {
+
+  val smallCatenable = Catenable(1, 2, 3, 4, 5)
+  val smallVector = Vector(1, 2, 3, 4, 5)
+
+  val largeCatenable = Catenable.fromSeq(0 to 1000000)
+  val largeVector = (0 to 1000000).toVector
+
+  @Benchmark def mapSmallCatenable = smallCatenable.map(_ + 1)
+  @Benchmark def mapSmallVector = smallVector.map(_ + 1)
+  @Benchmark def mapLargeCatenable = largeCatenable.map(_ + 1)
+  @Benchmark def mapLargeVector = largeVector.map(_ + 1)
+
+  @Benchmark def consSmallCatenable = 0 :: smallCatenable
+  @Benchmark def consSmallVector = 0 +: smallVector
+  @Benchmark def consLargeCatenable = 0 :: largeCatenable
+  @Benchmark def consLargeVector = 0 +: largeVector
+
+  @Benchmark def createTinyCatenable = Catenable(1)
+  @Benchmark def createTinyVector = Vector(1)
+  @Benchmark def createSmallCatenable = Catenable(1, 2, 3, 4, 5)
+  @Benchmark def createSmallVector = Vector(1, 2, 3, 4, 5)
+}

--- a/core/shared/src/main/scala/fs2/util/Catenable.scala
+++ b/core/shared/src/main/scala/fs2/util/Catenable.scala
@@ -5,70 +5,134 @@ import Catenable._
 /**
  * Trivial catenable sequence. Supports O(1) append, and (amortized)
  * O(1) `uncons`, such that walking the sequence via N successive `uncons`
- * steps takes O(N). Like a difference list, conversion to a `Stream[A]`
+ * steps takes O(N). Like a difference list, conversion to a `Seq[A]`
  * takes linear time, regardless of how the sequence is built up.
  */
 sealed abstract class Catenable[+A] {
 
   /** Returns the head and tail of this catenable if non empty, none otherwise. Amortized O(1). */
-  def uncons: Option[(A, Catenable[A])] = {
-    @annotation.tailrec
-    def go(c: Catenable[A], rights: List[Catenable[A]]): Option[(A,Catenable[A])] = c match {
-      case Empty => rights match {
-        case Nil => None
-        case c :: rights => go(c, rights)
+  final def uncons: Option[(A, Catenable[A])] = {
+    var c: Catenable[A] = this
+    var rights: List[Catenable[A]] = Nil
+    var result: Option[(A, Catenable[A])] = null
+    while (result eq null) {
+      c match {
+        case Empty =>
+          rights match {
+            case Nil => result = None
+            case h :: t => c = h; rights = t
+          }
+        case Single(a) =>
+          val next = if (rights.isEmpty) empty else rights.reverse.reduceLeft((x, y) => Append(y,x))
+          result = Some(a -> next)
+        case Append(l, r) => c = l; rights = r :: rights
       }
-      case Single(a) => Some(a -> (if (rights.isEmpty) empty else rights.reduceRight(Append(_,_))))
-      case Append(l,r) => go(l, r :: rights)
     }
-    go(this, List())
+    result
   }
 
-  def isEmpty: Boolean = this match {
-    case Empty => true
-    case _ => false // okay since `append` smart constructor guarantees each branch non-empty
-  }
+  /** Returns true if there are no elements in this collection. */
+  def isEmpty: Boolean
 
   /** Concatenates this with `c` in O(1) runtime. */
-  def ++[A2>:A](c: Catenable[A2])(implicit T: RealSupertype[A,A2]): Catenable[A2] =
+  final def ++[A2>:A](c: Catenable[A2])(implicit T: RealSupertype[A,A2]): Catenable[A2] =
     append(this, c)
 
-  /** Alias for [[push]]. */
-  def ::[A2>:A](a: A2)(implicit T: RealSupertype[A,A2]): Catenable[A2] =
-    this.push(a)
-
   /** Returns a new catenable consisting of `a` followed by this. O(1) runtime. */
-  def push[A2>:A](a: A2)(implicit T: RealSupertype[A,A2]): Catenable[A2] =
+  final def cons[A2>:A](a: A2)(implicit T: RealSupertype[A,A2]): Catenable[A2] =
     append(single(a), this)
 
-  def toStream: Stream[A] = uncons match {
-    case None => Stream.empty
-    case Some((hd, tl)) => hd #:: tl.toStream
+  /** Alias for [[cons]]. */
+  final def +:[A2>:A](a: A2)(implicit T: RealSupertype[A,A2]): Catenable[A2] =
+    cons(a)
+
+  /** Returns a new catenable consisting of this followed by `a`. O(1) runtime. */
+  final def snoc[A2>:A](a: A2)(implicit T: RealSupertype[A,A2]): Catenable[A2] =
+    append(this, single(a))
+
+  /** Alias for [[snoc]]. */
+  final def :+[A2>:A](a: A2)(implicit T: RealSupertype[A,A2]): Catenable[A2] =
+    snoc(a)
+
+  /** Applies the supplied function to each element and returns a new catenable. */
+  final def map[B](f: A => B): Catenable[B] =
+    foldLeft(empty: Catenable[B])((acc, a) => acc :+ f(a))
+
+  /** Folds over the elements from left to right using the supplied initial value and function. */
+  final def foldLeft[B](z: B)(f: (B, A) => B): B = {
+    var result = z
+    foreach(a => result = f(result, a))
+    result
   }
 
-  def map[B](f: A => B): Catenable[B] = Catenable.fromSeq(toStream.map(f))
+  /** Applies the supplied function to each element, left to right. */
+  final def foreach(f: A => Unit): Unit = {
+    var c: Catenable[A] = this
+    var rights: List[Catenable[A]] = Nil
+    while (c ne null) {
+      c match {
+        case Empty =>
+          rights match {
+            case Nil => c = null
+            case h :: t => c = h; rights = t
+          }
+        case Single(a) =>
+          f(a)
+          c = if (rights.isEmpty) Empty else rights.reverse.reduceLeft((x, y) => Append(y,x))
+          rights = Nil
+        case Append(l, r) => c = l; rights = r :: rights
+      }
+    }
+  }
+
+  /** Converts to a list. */
+  final def toList: List[A] = {
+    val builder = List.newBuilder[A]
+    foreach { a => builder += a; () }
+    builder.result
+  }
+
+  override def toString = "Catenable(..)"
 }
 
 object Catenable {
-  private case object Empty extends Catenable[Nothing]
-  private final case class Single[A](a: A) extends Catenable[A]
-  private final case class Append[A](left: Catenable[A], right: Catenable[A]) extends Catenable[A]
-
-  val empty: Catenable[Nothing] = Empty
-
-  def single[A](a: A): Catenable[A] = Single(a)
-
-  def append[A](c: Catenable[A], c2: Catenable[A]): Catenable[A] = c match {
-    case Empty => c2
-    case _ => c2 match {
-      case Empty => c
-      case _ => Append(c,c2)
-    }
+  private final case object Empty extends Catenable[Nothing] {
+    def isEmpty: Boolean = true
+  }
+  private final case class Single[A](a: A) extends Catenable[A] {
+    def isEmpty: Boolean = false
+  }
+  private final case class Append[A](left: Catenable[A], right: Catenable[A]) extends Catenable[A] {
+    def isEmpty: Boolean = false // b/c `append` constructor doesn't allow either branch to be empty
   }
 
+  /** Empty catenable. */
+  val empty: Catenable[Nothing] = Empty
+
+  /** Creates a catenable of 1 element. */
+  def single[A](a: A): Catenable[A] = Single(a)
+
+  /** Appends two catenables. */
+  def append[A](c: Catenable[A], c2: Catenable[A]): Catenable[A] =
+    if (c.isEmpty) c2
+    else if (c2.isEmpty) c
+    else Append(c, c2)
+
+  /** Creates a catenable from the specified sequence. */
   def fromSeq[A](s: Seq[A]): Catenable[A] =
     if (s.isEmpty) empty
-    else s.view.map(single).reduceRight(Append(_,_))
+    else s.view.reverse.map(single).reduceLeft((x, y) => Append(y, x))
 
-  def apply[A](as: A*): Catenable[A] = fromSeq(as)
+  /** Creates a catenable from the specified elements. */
+  def apply[A](as: A*): Catenable[A] = {
+    // Assumption: `as` is small enough that calling size doesn't outweigh benefit of calling empty/single
+    as.size match {
+      case 0 => empty
+      case 1 => single(as.head)
+      case n if n <= 1024 =>
+        // nb: avoid cost of reversing input if colection is small
+        as.view.map(single).reduceRight(Append(_, _))
+      case n => as.view.reverse.map(single).reduceLeft((x, y) => Append(y, x))
+    }
+  }
 }


### PR DESCRIPTION
This PR drastically improves constant factor performance of `Catenable` in certain usage patterns. API is changed a little bit:
 - `push` was renamed `cons`
 - `::` was renamed to `+:`
 - `:+`/`snoc` was added
 - `toStream` replaced with `toList`
 - `foldLeft` and `foreach` added
 - fixed stack safety bug in `uncons` and `fromSeq` -- `reduceRight` is *not* stack safe so the input is now reversed

Of particular note is the fact that singleton catenable construction was only about 1.5x as fast as creating a singleton vector, and small catenable construction was a bit slower than small vector creation.

Please excuse the while loops, but this is performance sensitive code so :shrug:.

8e20c6f1305ada0f50ed441f706228d1b5133f93 (before the changes in this PR)

```
[info] Benchmark                                 Mode  Cnt          Score         Error  Units
[info] CatenableBenchmark.consLargeCatenable    thrpt   10  123886314.876 ± 1230223.043  ops/s
[info] CatenableBenchmark.consLargeVector       thrpt   10   10566409.027 ±  710173.165  ops/s
[info] CatenableBenchmark.consSmallCatenable    thrpt   10  120474774.758 ± 3335136.723  ops/s
[info] CatenableBenchmark.consSmallVector       thrpt   10   16325204.308 ±  299289.520  ops/s
[info] CatenableBenchmark.createSmallCatenable  thrpt   10    8947210.997 ±  325165.771  ops/s
[info] CatenableBenchmark.createSmallVector     thrpt   10   11255936.788 ±  203349.167  ops/s
[info] CatenableBenchmark.createTinyCatenable   thrpt   10   22871648.117 ±  613434.137  ops/s
[info] CatenableBenchmark.createTinyVector      thrpt   10   15123925.504 ±  484690.580  ops/s
[info] CatenableBenchmark.mapLargeCatenable     thrpt   10          2.580 ±       0.740  ops/s
[info] CatenableBenchmark.mapLargeVector        thrpt   10         87.447 ±       6.032  ops/s
[info] CatenableBenchmark.mapSmallCatenable     thrpt   10    1500240.055 ±   32720.321  ops/s
[info] CatenableBenchmark.mapSmallVector        thrpt   10   13814716.675 ±  319184.790  ops/s
```

796700be3a8e683985f0cf04e1f014e7bb9a5a1f (this PR)

```
[info] Benchmark                                   Mode  Cnt          Score         Error  Units
[info] CatenableBenchmark.consLargeCatenable      thrpt   10  150443328.810 ± 4262697.027  ops/s
[info] CatenableBenchmark.consLargeVector         thrpt   10   12215271.536 ±  780910.325  ops/s
[info] CatenableBenchmark.consSmallCatenable      thrpt   10  146698308.995 ± 8798103.672  ops/s
[info] CatenableBenchmark.consSmallVector         thrpt   10   19154715.531 ±  854095.070  ops/s
[info] CatenableBenchmark.createSmallCatenable    thrpt   10   10458084.536 ±  111327.117  ops/s
[info] CatenableBenchmark.createSmallVector       thrpt   10   12795767.588 ±   50284.190  ops/s
[info] CatenableBenchmark.createTinyCatenable     thrpt   10  128573263.762 ± 1670802.767  ops/s
[info] CatenableBenchmark.createTinyVector        thrpt   10   17131861.034 ±  315356.904  ops/s
[info] CatenableBenchmark.foldLeftLargeCatenable  thrpt   10         80.424 ±       0.877  ops/s
[info] CatenableBenchmark.foldLeftLargeVector     thrpt   10         77.336 ±       2.238  ops/s
[info] CatenableBenchmark.foldLeftSmallCatenable  thrpt   10   10220962.669 ±   96901.748  ops/s
[info] CatenableBenchmark.foldLeftSmallVector     thrpt   10   18855179.003 ±  175591.352  ops/s
[info] CatenableBenchmark.mapLargeCatenable       thrpt   10         16.990 ±       4.297  ops/s
[info] CatenableBenchmark.mapLargeVector          thrpt   10         67.306 ±       2.419  ops/s
[info] CatenableBenchmark.mapSmallCatenable       thrpt   10    8988928.329 ±  252565.606  ops/s
[info] CatenableBenchmark.mapSmallVector          thrpt   10   15259942.354 ± 1126953.820  ops/s
```