### PR TITLE
Added unfoldSeq and unfoldSeqEval

### DIFF
--- a/core/jvm/src/test/scala/fs2/StreamSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamSpec.scala
@@ -114,9 +114,20 @@ class StreamSpec extends Fs2Spec {
       }.map(_._1).toList shouldBe List(0, 1, 1, 2, 3, 5, 8, 13)
     }
 
+    "unfoldSeq" in {
+      Stream.unfoldSeq(3) { s =>
+        if(s > 0) Some((Seq.fill(s)(s), s-1)) else None
+      }.toList shouldBe List(3, 3, 3, 2, 2, 1)
+    }
+
     "unfoldEval" in {
       Stream.unfoldEval(10)(s => Task.now(if (s > 0) Some((s, s - 1)) else None))
         .runLog.unsafeRun().toList shouldBe List.range(10, 0, -1)
+    }
+
+    "unfoldSeqEval" in {
+      Stream.unfoldSeqEval(3)(s => Task.now(if(s > 0) Some((Seq.fill(s)(s), s-1)) else None))
+        .runLog.unsafeRun().toList shouldBe List(3, 3, 3, 2, 2, 1)
     }
 
     "translate stack safety" in {

--- a/core/jvm/src/test/scala/fs2/StreamSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamSpec.scala
@@ -120,6 +120,12 @@ class StreamSpec extends Fs2Spec {
       }.toList shouldBe List(3, 3, 3, 2, 2, 1)
     }
 
+    "unfoldChunk" in {
+      Stream.unfoldChunk(4L) { s =>
+        if(s > 0) Some((Chunk.longs(Array[Long](s,s)), s-1)) else None
+      }.toList shouldBe List[Long](4,4,3,3,2,2,1,1)
+    }
+
     "unfoldEval" in {
       Stream.unfoldEval(10)(s => Task.now(if (s > 0) Some((s, s - 1)) else None))
         .runLog.unsafeRun().toList shouldBe List.range(10, 0, -1)
@@ -128,6 +134,11 @@ class StreamSpec extends Fs2Spec {
     "unfoldSeqEval" in {
       Stream.unfoldSeqEval(3)(s => Task.now(if(s > 0) Some((Seq.fill(s)(s), s-1)) else None))
         .runLog.unsafeRun().toList shouldBe List(3, 3, 3, 2, 2, 1)
+    }
+
+    "unfoldChunkEval" in {
+      Stream.unfoldChunkEval(true)(s => Task.now(if(s) Some((Chunk.booleans(Array[Boolean](s)),false)) else None))
+        .runLog.unsafeRun().toList shouldBe List(true)
     }
 
     "translate stack safety" in {

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -508,11 +508,31 @@ object Stream {
     suspend(go(s0))
   }
 
+  /** Produce a (potentially infinite) stream from an unfold of Seqs. */
+  def unfoldSeq[F[_],S,A](s0: S)(f: S => Option[(Seq[A],S)]): Stream[F,A] = {
+    def go(s: S): Stream[F,A] =
+      f(s) match {
+        case Some((a, sn)) => emits(a) ++ go(sn)
+        case None => empty
+      }
+    suspend(go(s0))
+  }
+
   /** Like [[unfold]], but takes an effectful function. */
   def unfoldEval[F[_],S,A](s0: S)(f: S => F[Option[(A,S)]]): Stream[F,A] = {
     def go(s: S): Stream[F,A] =
       eval(f(s)).flatMap {
         case Some((a, sn)) => emit(a) ++ go(sn)
+        case None => empty
+      }
+    suspend(go(s0))
+  }
+
+    /** Like [[unfoldSeq]], but takes an effectful function. */
+  def unfoldSeqEval[F[_],S,A](s0: S)(f: S => F[Option[(Seq[A],S)]]): Stream[F,A] = {
+    def go(s: S): Stream[F,A] =
+      eval(f(s)).flatMap {
+        case Some((a, sn)) => emits(a) ++ go(sn)
         case None => empty
       }
     suspend(go(s0))


### PR DESCRIPTION
Hi,

I was asking on FS2 gitter for a way how to create a stream from a resource that has sth similar to `hasNext` like in iterator or `next` like in `ResultSet` from JDBC but I wanted to emit multiple values at once if there are ready to be published.

The solution could be to use unfold, but it can only publish a single value. 
@edmundnoble suggested I could easily write function that would publish Seq and submit a MR so here it is.

Sorry if I'm doing sth wrong but this is my first PR on github.

