### PR TITLE
Fix issue with use of "root" `uncons` / `uncons1` and clarify docs

### DIFF
--- a/core/jvm/src/test/scala/fs2/ResourceSafetySpec.scala
+++ b/core/jvm/src/test/scala/fs2/ResourceSafetySpec.scala
@@ -70,6 +70,12 @@ class ResourceSafetySpec extends Fs2Spec with EventuallySupport {
       withClue(s.tag) { 0L shouldBe c.get }
     }
 
+    "early termination of uncons" in {
+      var n = 0
+      Stream(1,2,3).onFinalize(Task.delay(n = 1)).uncons.run.unsafeRun
+      n shouldBe 1
+    }
+
     "bracket release should not be called until necessary" in {
       val buffer = collection.mutable.ListBuffer[Symbol]()
       runLog {


### PR DESCRIPTION
I was looking into clarifying the docs on `uncons` and `uncons1` to say that they should be used in conjunction with `Stream.scope` (see #797) and noticed what I'd say is a problem - if you use `uncons` but don't have a surrounding `scope` call or `Pull` (which uses `scope`), you can have a finalizer not run. This test used to fail:

```Scala
    "early termination of uncons" in {
      var n = 0
      Stream(1,2,3).onFinalize(Task.delay(n = 1)).uncons.run.unsafeRun
      n shouldBe 1
    }
```

That test is now fixed, by adding a call to `scope` in `runFold`, but the note about using `scope` in conjunction with `uncons` still applies if you want prompt finalization.

Sorry @jedesah but my docs kind of clobber some of your work in #797. I felt like the docs were trying to cover too many things (like the fact that if you reference an effectful stream twice, its effects are repeated... which is not really specific to `uncons` at all, just a general property of effectful streams).

This could be backported to 0.9 series also? Not sure how important that is, this would only show up if you were using `uncons` at the "root" of your stream, which I think would be super rare.