### PR TITLE
Changed io.file.pulls API to return cancellable file handles

### DIFF
--- a/core/shared/src/main/scala/fs2/concurrent.scala
+++ b/core/shared/src/main/scala/fs2/concurrent.scala
@@ -62,7 +62,7 @@ object concurrent {
                      )
             } yield gate
           }
-          Pull.acquireCancellable(startInnerStream) { gate => gate.get }.flatMap { case (release, _) => Pull.eval(earlyReleaseRef.setPure(release)) }
+          Pull.acquireCancellable(startInnerStream) { gate => gate.get }.flatMap { c => Pull.eval(earlyReleaseRef.setPure(c.cancel)) }
         }
       }
 

--- a/io/src/main/scala/fs2/io/file/FileHandle.scala
+++ b/io/src/main/scala/fs2/io/file/FileHandle.scala
@@ -19,11 +19,6 @@ trait FileHandle[F[_]] {
   type Lock
 
   /**
-   * Close the `FileHandle`.
-   */
-  def close(): F[Unit]
-
-  /**
    * Force any updates for the underlying file to storage.
    * @param metaData If true, also attempts to force file metadata updates to storage.
    */
@@ -104,9 +99,6 @@ private[file] object FileHandle {
     new FileHandle[F] {
       type Lock = FileLock
 
-      override def close(): F[Unit] =
-        F.delay(chan.close())
-
       override def force(metaData: Boolean): F[Unit] =
         F.delay(chan.force(metaData))
 
@@ -152,9 +144,6 @@ private[file] object FileHandle {
   private[file] def fromFileChannel[F[_]](chan: FileChannel)(implicit F: Suspendable[F]): FileHandle[F] = {
     new FileHandle[F] {
       type Lock = FileLock
-
-      override def close(): F[Unit] =
-        F.delay(chan.close())
 
       override def force(metaData: Boolean): F[Unit] =
         F.delay(chan.force(metaData))

--- a/io/src/main/scala/fs2/io/file/pulls.scala
+++ b/io/src/main/scala/fs2/io/file/pulls.scala
@@ -7,7 +7,6 @@ import java.nio.file._
 import java.util.concurrent.ExecutorService
 
 import fs2.util.{Async,Suspendable}
-import fs2.util.syntax._
 
 /** Provides various `Pull`s for working with files. */
 object pulls {
@@ -49,7 +48,7 @@ object pulls {
    *
    * The `Pull` closes the acquired `java.nio.channels.FileChannel` when it is done.
    */
-  def fromPath[F[_]](path: Path, flags: Seq[OpenOption])(implicit F: Suspendable[F]): Pull[F, Nothing, FileHandle[F]] =
+  def fromPath[F[_]](path: Path, flags: Seq[OpenOption])(implicit F: Suspendable[F]): Pull[F, Nothing, Pull.Cancellable[F, FileHandle[F]]] =
     fromFileChannel(F.delay(FileChannel.open(path, flags: _*)))
 
   /**
@@ -57,7 +56,7 @@ object pulls {
    *
    * The `Pull` closes the acquired `java.nio.channels.AsynchronousFileChannel` when it is done.
    */
-  def fromPathAsync[F[_]](path: Path, flags: Seq[OpenOption], executorService: Option[ExecutorService] = None)(implicit F: Async[F]): Pull[F, Nothing, FileHandle[F]] = {
+  def fromPathAsync[F[_]](path: Path, flags: Seq[OpenOption], executorService: Option[ExecutorService] = None)(implicit F: Async[F]): Pull[F, Nothing, Pull.Cancellable[F, FileHandle[F]]] = {
     import collection.JavaConverters._
     fromAsynchronousFileChannel(F.delay(AsynchronousFileChannel.open(path, flags.toSet.asJava, executorService.orNull)))
   }
@@ -67,14 +66,14 @@ object pulls {
    *
    * The `Pull` closes the provided `java.nio.channels.FileChannel` when it is done.
    */
-  def fromFileChannel[F[_]: Suspendable](channel: F[FileChannel]): Pull[F, Nothing, FileHandle[F]] =
-    Pull.acquire(channel.map(FileHandle.fromFileChannel[F]))(_.close())
+  def fromFileChannel[F[_]](channel: F[FileChannel])(implicit F: Suspendable[F]): Pull[F, Nothing, Pull.Cancellable[F, FileHandle[F]]] =
+    Pull.acquireCancellable(channel)(ch => F.delay(ch.close())).map(_.map(FileHandle.fromFileChannel[F]))
 
   /**
    * Given a `java.nio.channels.AsynchronousFileChannel`, will create a `Pull` which allows asynchronous operations against the underlying file.
    *
    * The `Pull` closes the provided `java.nio.channels.AsynchronousFileChannel` when it is done.
    */
-  def fromAsynchronousFileChannel[F[_]: Async](channel: F[AsynchronousFileChannel]): Pull[F, Nothing, FileHandle[F]] =
-    Pull.acquire(channel.map(FileHandle.fromAsynchronousFileChannel[F]))(_.close())
+  def fromAsynchronousFileChannel[F[_]](channel: F[AsynchronousFileChannel])(implicit F: Async[F]): Pull[F, Nothing, Pull.Cancellable[F, FileHandle[F]]] =
+    Pull.acquireCancellable(channel)(ch => F.delay(ch.close())).map(_.map(FileHandle.fromAsynchronousFileChannel[F]))
 }


### PR DESCRIPTION
Fixes #772.

If we're good with this overall approach, TCP/UDP sockets should get a similar treatment. Specifically, we should *not* expose a `close` method on `FileHandle`/`Socket`/etc. and instead, return a `Cancellable[F,Resource]` from pulls.