### PR TITLE
convert bytes to 0-255 Int for InputStream#read()

### DIFF
--- a/io/src/main/scala/fs2/io/JavaInputOutputStream.scala
+++ b/io/src/main/scala/fs2/io/JavaInputOutputStream.scala
@@ -144,9 +144,9 @@ private[io] object JavaInputOutputStream {
 
       def go(acc:Array[Byte]):F[Int] = {
         F.flatMap(readOnce(acc,0,1,queue,dnState)) { read =>
-          if (read < 0) F.pure(read)
+          if (read < 0) F.pure(-1)
           else if (read == 0) go(acc)
-          else F.pure(acc(0).toInt)
+          else F.pure(acc(0) & 0xFF)
         }
       }
 

--- a/io/src/test/scala/fs2/io/JavaInputOutputStreamSpec.scala
+++ b/io/src/test/scala/fs2/io/JavaInputOutputStreamSpec.scala
@@ -75,6 +75,14 @@ class JavaInputOutputStreamSpec extends Fs2Spec {
       result shouldBe Vector(true)
     }
 
+    "converts to 0..255 int values except EOF mark" in {
+      val s: Stream[Task, Byte] = Stream.range(0, 256, 1).map(_.toByte)
+      val result = s.through(toInputStream).map { is =>
+        Vector.fill(257)(is.read())
+      }.runLog.map(_.flatten).unsafeRun()
+      result shouldBe (Stream.range(0, 256, 1) ++ Stream(-1)).toVector
+    }
+
   }
 
 


### PR DESCRIPTION
This fixed `fs2.io.toInputStream` so that [InputStream#read()](https://docs.oracle.com/javase/7/docs/api/java/io/InputStream.html#read()) only returns values of 0 to 255 and -1 for signalling the end.