### PR TITLE
Add scanF pipe

### DIFF
--- a/core/jvm/src/test/scala/fs2/PipeSpec.scala
+++ b/core/jvm/src/test/scala/fs2/PipeSpec.scala
@@ -311,6 +311,12 @@ class PipeSpec extends Fs2Spec {
       runLog(s.get.scan1(f)) shouldBe v.headOption.fold(Vector.empty[Int])(h => v.drop(1).scanLeft(h)(f))
     }
 
+    "scanF" in forAll { (s: PureStream[Int], n: String) =>
+      val f: (String, Int) => Task[String] = (a: String, b: Int) => Task.now(a + b)
+      val g = (a: String, b: Int) => a + b
+      runLog(s.get.covary[Task].scanF[Task, String](n)(f)) shouldBe runLog(s.get).scanLeft(n)(g)
+    }
+
     "shiftRight" in forAll { (s: PureStream[Int], v: Vector[Int]) =>
       runLog(s.get.shiftRight(v: _*)) shouldBe v ++ runLog(s.get)
     }

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -278,6 +278,8 @@ final class Stream[+F[_],+O] private (private val coreRef: Stream.CoreRef[F,O]) 
   /** Alias for `self through [[pipe.scan1]](f)`. */
   def scan1[O2 >: O](f: (O2, O2) => O2): Stream[F,O2] = self through pipe.scan1(f)
 
+  /** Alias for `self throughv [[pipe.scanF]](z)(f)`. */
+  def scanF[F2[_], O2](z: O2)(f: (O2, O) => F2[O2])(implicit S: Sub1[F, F2]): Stream[F2, O2] =  self throughv pipe.scanF(z)(f)
   /**
    * Used in conjunction with `[[Stream.uncons]]` or `[[Stream.uncons1]]`.
    * When `s.scope` starts, the set of live resources is recorded.


### PR DESCRIPTION
Adds a `scanF` pipe.  

For a `Stream[F, I]`, this has the signature `scan(z: O)(f: (O, I) => F[O]): Stream[F, I]`.

This allows scanning over a stream with a function which returns a Task.