### PR TITLE
clarifies nowrap argument for inflate / decompression

### DIFF
--- a/core/jvm/src/main/scala/fs2/compress.scala
+++ b/core/jvm/src/main/scala/fs2/compress.scala
@@ -57,7 +57,7 @@ object compress {
   /**
     * Returns a `Pipe` that inflates (decompresses) its input elements using
     * a `java.util.zip.Inflater` with the parameter `nowrap`.
-    * @param nowrap if true then support GZIP compatible compression
+    * @param nowrap if true then support GZIP compatible decompression
     * @param bufferSize size of the internal buffer that is used by the
     *                   decompressor. Default size is 32 KB.
     */


### PR DESCRIPTION
Reading the scaladoc, it is a bit irritating reading the word *compression* in the *inflate* aka *decompression* function. I suppose, this was introduced by copy-pasting.

---

> This is CONSISTENCY!
>
> -- Leonidas