### PR TITLE
Add fs2-reactive-streams to list of projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ If you have a project you'd like to include in this list, either open a PR or le
 * [scodec-stream](https://github.com/scodec/scodec-stream): A library for streaming binary decoding and encoding, built using fs2 and [scodec](https://github.com/scodec/scodec).
 * [streamz](https://github.com/krasserm/streamz): A library that supports the conversion of [Akka Stream](http://doc.akka.io/docs/akka/2.4/scala/stream/index.html) `Source`s, `Flow`s and `Sink`s to and from FS2 `Stream`s, `Pipe`s and `Sink`s, respectively. It also supports the usage of [Apache Camel](http://camel.apache.org/) endpoints in FS2 `Stream`s and Akka Stream `Source`s, `Flow`s and `SubFlow`s.
 * [fs2-zk](https://github.com/Spinoco/fs2-zk): Simple Apache Zookeeper bindings for fs2
+* [fs2-reactive-streams](https://github.com/zainab-ali/fs2-reactive-streams): A reactive streams implementation for fs2.
 
 ### Related projects ###
 


### PR DESCRIPTION
This adds [fs2-reactive-streams](https://github.com/zainab-ali/fs2-reactive-streams) to the list of projects using fs2.