### PR TITLE
Fixed #782

### DIFF
--- a/core/shared/src/main/scala/fs2/ScopedFuture.scala
+++ b/core/shared/src/main/scala/fs2/ScopedFuture.scala
@@ -47,8 +47,8 @@ sealed trait ScopedFuture[F[_],A] { self =>
       (a, cancelA) = t0
       t1 <- b.cancellableGet
       (b, cancelB) = t1
-      _ <- ref.set(a.map(Left(_)))
-      _ <- ref.set(b.map(Right(_)))
+      _ <- ref.setAsync(a.map(Left(_)))
+      _ <- ref.setAsync(b.map(Right(_)))
     } yield {
       (ref.get.flatMap {
         case Left((a,onForce)) => cancelB.as((Left(a),onForce))
@@ -104,7 +104,7 @@ object ScopedFuture {
         F.ref[((A,Scope[F,Unit]),Int)].flatMap { ref =>
           val cancels: F[Vector[(F[Unit],Int)]] = (es zip (0 until es.size)).traverse { case (a,i) =>
             a.cancellableGet.flatMap { case (a, cancelA) =>
-              ref.set(a.map((_,i))).as((cancelA,i))
+              ref.setAsync(a.map((_,i))).as((cancelA,i))
             }
           }
           cancels.flatMap { cancels =>

--- a/core/shared/src/main/scala/fs2/StreamCore.scala
+++ b/core/shared/src/main/scala/fs2/StreamCore.scala
@@ -109,7 +109,7 @@ private[fs2] sealed trait StreamCore[F[_],O] { self =>
     lazy val rootCleanup: Free[F,Attempt[Unit]] = Free.suspend { resources.closeAll(noopWaiters) match {
       case Left(waiting) =>
         Free.eval(Vector.fill(waiting)(F.ref[Unit]).sequence) flatMap { gates =>
-          resources.closeAll(gates.toStream.map(gate => () => F.unsafeRunAsync(gate.setPure(()))(_ => IO.pure(())))) match {
+          resources.closeAll(gates.toStream.map(gate => () => F.unsafeRunAsync(gate.setAsyncPure(()))(_ => IO.pure(())))) match {
             case Left(_) => Free.eval(gates.traverse(_.get)) flatMap { _ =>
               resources.closeAll(noopWaiters) match {
                 case Left(_) => println("likely FS2 bug - resources still being acquired after Resources.closeAll call")
@@ -130,7 +130,7 @@ private[fs2] sealed trait StreamCore[F[_],O] { self =>
         if (ok) Scope.pure(())
         else Scope.evalFree(rootCleanup).flatMap(_.fold(Scope.fail, Scope.pure))
       }}
-    val s: F[Unit] = ref.set { step.bindEnv(StreamCore.Env(resources, () => resources.isClosed)).run.map {
+    val s: F[Unit] = ref.setAsync { step.bindEnv(StreamCore.Env(resources, () => resources.isClosed)).run.map {
       case (ts, StreamCore.StepResult.Done) => (ts, None)
       case (ts, StreamCore.StepResult.Failed(t)) => (ts, Some(Left(t)))
       case (ts, StreamCore.StepResult.Emits(out, s)) => (ts, Some(Right((out, s))))

--- a/core/shared/src/main/scala/fs2/Task.scala
+++ b/core/shared/src/main/scala/fs2/Task.scala
@@ -214,7 +214,7 @@ object Task extends TaskPlatform {
    }}}
   */
   def start[A](t: Task[A])(implicit ec: ExecutionContext): Task[Task[A]] =
-    Concurrent[Task].ref[A].flatMap { ref => ref.set(t) map (_ => ref.get) }
+    Concurrent[Task].ref[A].flatMap { ref => ref.setAsync(t) map (_ => ref.get) }
 
   /**
     * Like [[async]], but run the callback in the same thread in the same

--- a/core/shared/src/main/scala/fs2/async/mutable/Queue.scala
+++ b/core/shared/src/main/scala/fs2/async/mutable/Queue.scala
@@ -136,7 +136,7 @@ object Queue {
             if (c.previous.deq.isEmpty) // we enqueued a value to the queue
               signalSize(c.previous, c.now).as(true)
             else // queue was empty, we had waiting dequeuers
-              c.previous.deq.head.setPure(NonEmptyChunk.singleton(a)).as(true)
+              c.previous.deq.head.setAsyncPure(NonEmptyChunk.singleton(a)).as(true)
           }
 
         def dequeue1: F[A] = cancellableDequeue1.flatMap { _._1 }

--- a/core/shared/src/main/scala/fs2/async/mutable/Semaphore.scala
+++ b/core/shared/src/main/scala/fs2/async/mutable/Semaphore.scala
@@ -70,7 +70,7 @@ object Semaphore {
     type S = Either[Vector[(Long,Concurrent.Ref[F,Unit])], Long]
     F.refOf[S](Right(n)).map { ref => new Semaphore[F] {
       private def open(gate: Concurrent.Ref[F,Unit]): F[Unit] =
-        gate.setPure(())
+        gate.setAsyncPure(())
 
       def count = ref.get.map(count_)
       def decrementBy(n: Long) = { ensureNonneg(n)

--- a/core/shared/src/main/scala/fs2/async/mutable/Signal.scala
+++ b/core/shared/src/main/scala/fs2/async/mutable/Signal.scala
@@ -77,7 +77,7 @@ object Signal {
           if (c.previous._3.isEmpty) F.pure(c.map(_._1) -> b)
           else {
             val now = c.now._1 -> c.now._2
-            c.previous._3.toVector.traverse { case(_, ref) => ref.setPure(now) } >> F.pure(c.map(_._1) -> b)
+            c.previous._3.toVector.traverse { case(_, ref) => ref.setAsyncPure(now) } >> F.pure(c.map(_._1) -> b)
           }
         }
       }

--- a/core/shared/src/main/scala/fs2/async/mutable/Topic.scala
+++ b/core/shared/src/main/scala/fs2/async/mutable/Topic.scala
@@ -105,7 +105,7 @@ object Topic {
           def unSubscribe: F[Unit] = for {
             _ <- state.modify { case (a,subs) => a -> subs.filterNot(_.id == id) }
             _ <- subSignal.modify(_ - 1)
-            _ <- done.setPure(true)
+            _ <- done.setAsyncPure(true)
           } yield ()
           def subscribe: Stream[F, A] = eval(firstA.get) ++ q.dequeue
           def publish(a: A): F[Unit] = {
@@ -125,7 +125,7 @@ object Topic {
         }
         c <- state.modify { case(a,s) => a -> (s :+ sub) }
         _ <- subSignal.modify(_ + 1)
-        _ <- firstA.setPure(c.now._1)
+        _ <- firstA.setAsyncPure(c.now._1)
       } yield sub
 
       new Topic[F,A] {

--- a/io/src/test/scala/fs2/io/tcp/SocketSpec.scala
+++ b/io/src/test/scala/fs2/io/tcp/SocketSpec.scala
@@ -39,7 +39,7 @@ class SocketSpec extends Fs2Spec {
           val ps =
             serverWithLocalAddress[IO](new InetSocketAddress(InetAddress.getByName(null), 0))
             .flatMap {
-              case Left(local) => Stream.eval_(localBindAddress.set(IO.pure(local)))
+              case Left(local) => Stream.eval_(localBindAddress.setAsyncPure(local))
               case Right(s) =>
                 Stream.emit(s.flatMap { (socket: Socket[IO]) =>
                   socket.reads(1024).to(socket.writes()).onFinalize(socket.endOfOutput)


### PR DESCRIPTION
Review by @pchlupacek 

Note that I did not thread-shift invocation of the callback in order to be consistent with `TrySet`. I tried thread-shifting both `TrySet` callback invocation and `Set` callback invocation, but that caused the `publish synchronous` test to fail in `TopicSpec`. Maybe you can investigate?