### PR TITLE
Switch to simpler encoding of `Free`, make `ViewL` a value class

### DIFF
--- a/core/jvm/src/test/scala/fs2/Pipe2Spec.scala
+++ b/core/jvm/src/test/scala/fs2/Pipe2Spec.scala
@@ -124,7 +124,6 @@ class Pipe2Spec extends Fs2Spec {
     }
 
     "merge (left/right failure)" in {
-      pending
       forAll { (s1: PureStream[Int], f: Failure) =>
         an[Err.type] should be thrownBy {
           runLog((s1.get.covary[IO] merge f.get))

--- a/core/jvm/src/test/scala/fs2/StreamSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamSpec.scala
@@ -54,7 +54,7 @@ class StreamSpec extends Fs2Spec with Inside {
     }
 
     "onError (1)" in {
-      pending // fails when exception thrown from pure code - e.g., s.map(_ => throw Err)
+      // pending // fails when exception thrown from pure code - e.g., s.map(_ => throw Err)
       forAll { (s: PureStream[Int], f: Failure) =>
         val s2 = s.get ++ f.get
         runLog(s2.onError(_ => Stream.empty)) shouldBe runLog(s.get)

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -23,9 +23,6 @@ abstract class Chunk[+O] extends Segment[O,Unit] { self =>
   final def head: O = apply(0)
   final def last: O = apply(size - 1)
 
-  final override def map[O2](f: O => O2): Chunk[O2] =
-    super.map(f).toChunk
-
   def indexWhere(p: O => Boolean): Option[Int] = {
     var i = 0
     var result = -1

--- a/core/shared/src/main/scala/fs2/async/mutable/Queue.scala
+++ b/core/shared/src/main/scala/fs2/async/mutable/Queue.scala
@@ -101,9 +101,9 @@ abstract class Queue[F[_], A] { self =>
       def cancellableDequeue1: F[(F[B],F[Unit])] =
         self.cancellableDequeue1.map(bu => bu._1.map(f) -> bu._2)
       def dequeueBatch1(batchSize: Int): F[Chunk[B]] =
-        self.dequeueBatch1(batchSize).map(_.map(f))
+        self.dequeueBatch1(batchSize).map(_.map(f).toChunk)
       def cancellableDequeueBatch1(batchSize: Int): F[(F[Chunk[B]],F[Unit])] =
-        self.cancellableDequeueBatch1(batchSize).map(bu => bu._1.map(_.map(f)) -> bu._2)
+        self.cancellableDequeueBatch1(batchSize).map(bu => bu._1.map(_.map(f).toChunk) -> bu._2)
     }
 }
 

--- a/core/shared/src/main/scala/fs2/internal/Free.scala
+++ b/core/shared/src/main/scala/fs2/internal/Free.scala
@@ -61,53 +61,75 @@ object Free {
     case class Done[F[_], R](r: R) extends ViewL[F,R]
     case class Failed[F[_],R](error: Throwable) extends ViewL[F,R]
 
+    class Handler[F[_],R](val get: Option[Throwable => Free[F,R]]) extends AnyVal {
+      def push(onErrInner: Throwable => Free[F,R]): Handler[F,R] = get match {
+        case None => new Handler(Some(onErrInner))
+        case Some(onErr) => new Handler(Some((e: Throwable) => OnError(Try(onErrInner(e)), onErr)))
+      }
+      def attachHandler(f: Free[F,R]): Free[F,R] = get match {
+        case None => f
+        case Some(h) => OnError(f, h)
+      }
+      def apply(err: Throwable): Free[F,R] = get match {
+        case None => Fail(err)
+        case Some(h) => try h(err) catch { case e: Throwable => Fail(e) }
+      }
+      def flatMap[R2](f: R => Free[F,R2]): Handler[F,R2] = get match {
+        case None => new Handler(None)
+        case Some(h) => new Handler(Some((e: Throwable) => h(e) flatMap f)) // todo: trampoline?
+      }
+    }
+    object Handler { def empty[F[_],R]: Handler[F,R] = new Handler(None) }
+
+    // Pure(x)
+    // Bind(Eval(e), f)
+    // OnError(Bind(Eval(e), f), h)
+
     def apply[F[_], R](free: Free[F, R]): ViewL[F, R] = {
       type FreeF[x] = Free[F,x]
       type X = Any
       @annotation.tailrec
-      def go(free: Free[F, X], k: Option[X => Free[F,R]],
-                               onErr: Option[Throwable => Free[F,R]]): ViewL[F, R] = free match {
+      def go(free: Free[F, X], k: Option[X => Free[F,R]]
+                             , onErr: Handler[F,R]
+                             , onPureErr: Handler[F,R]): ViewL[F, R] = free match {
         case Pure(x) => k match {
           case None => ViewL.Done(x.asInstanceOf[R])
-          case Some(f) => go(Try(f(x)).asInstanceOf[Free[F,X]], None, None)
+          case Some(f) => go(Try(f(x)).asInstanceOf[Free[F,X]], None, Handler.empty, Handler.empty)
         }
         case Eval(fx) => k match {
-          case None => ViewL.Bound(fx, (x: X) => Free.Pure(x.asInstanceOf[R]), onErr)
-          case Some(f) => ViewL.Bound(fx, f, onErr)
+          case None => ViewL.Bound(fx, (x: X) => Free.Pure(x.asInstanceOf[R]), onErr.get)
+          case Some(f) => ViewL.Bound(fx, f, onErr.get)
         }
-        case Fail(err) => onErr match {
-          case None => ViewL.Failed(err)
-          case Some(onErr) => go(Try(onErr(err)).asInstanceOf[Free[F,X]], None, None)
-        }
-        case OnError(fx, onErrInner) => k match {
-          case None => onErr match {
-            case None => go(fx, None, Some((e: Throwable) => Try(onErrInner(e)).asInstanceOf[Free[F,R]]))
-            case Some(onErr) => go(fx, None,
-              Some((e: Throwable) => OnError(Try(onErrInner(e)).asInstanceOf[Free[F,R]], onErr)))
-          }
-          case Some(k2) => onErr match {
-            case None => go(fx, k, Some((e: Throwable) => Try(onErrInner(e)) flatMap k2))
-            case Some(onErr) => go(fx, k,
-              Some((e: Throwable) => OnError(Try(onErrInner(e)) flatMap k2, onErr)))
-          }
+        case Fail(err) =>
+          go(onPureErr(err).asInstanceOf[Free[F,X]], None, Handler.empty, Handler.empty)
+        case OnError(fx, h) => k match {
+          case None => go(fx, None, onErr.push(h.asInstanceOf[Throwable => Free[F,R]]),
+                                    onPureErr.push(h.asInstanceOf[Throwable => Free[F,R]]))
+          // (a onError h) flatMap k2
+          case Some(k2) =>
+            val h2 = h.asInstanceOf[Throwable => Free[F,R]]
+            go(fx, k, onErr.push(h2).flatMap(k2), onPureErr.push(h2).flatMap(k2))
         }
         case b: Free.Bind[F, _, X] =>
           val fw: Free[F, Any] = b.fx.asInstanceOf[Free[F, Any]]
           val f: Any => Free[F, X] = b.f.asInstanceOf[Any => Free[F, X]]
           k match {
-            case None => onErr match {
-              case None => go(fw, Some(f.asInstanceOf[X => Free[F,R]]), onErr)
-              case Some(h) => go(fw,
-                Some((x: X) => Free.Pure(()) flatMap { _ => Try(f.asInstanceOf[X => Free[F,R]](x)) onError h }),
-                onErr)
-            }
-            case Some(g) => onErr match {
-              case None => go(fw, Some(w => Try(f(w)).flatMap(g)), onErr)
-              case Some(h) => go(fw, Some(w => Try(f(w)).flatMap(g).onError(h)), onErr)
-            }
+            case None => go(fw,
+              Some((x: X) => onErr.attachHandler(Try(f.asInstanceOf[X => Free[F,R]](x)))),
+                Handler.empty,
+                onPureErr)
+            case Some(g) =>
+              // keep onErr on the error handling stack in case there's an error in pure code
+              go(fw, Some(w => onErr.attachHandler(Try(f(w)).flatMap(g))), Handler.empty, onErr)
           }
       }
-      go(free.asInstanceOf[Free[F,X]], None, None)
+      // inline use of `Try`, avoid constructing intermediate `Fail` objects
+      // basic idea - onErr and onPureErr get pushed in event of OnError ctor
+      // in event of a Bind, we attach the current onErr to the continuation and set onErr to empty,
+      // but still keep onPureErr
+      // idea being - if we are successful, the `Bound.f` continuation will reattach error handlers
+      // so don't want to dup work
+      go(free.asInstanceOf[Free[F,X]], None, Handler.empty, Handler.empty)
     }
   }
 

--- a/core/shared/src/main/scala/fs2/internal/Free.scala
+++ b/core/shared/src/main/scala/fs2/internal/Free.scala
@@ -1,162 +1,99 @@
 package fs2.internal
 
 import Free.ViewL
-import Free.ViewL._
 import Free._
 
 import cats.{ ~>, MonadError }
 
 sealed abstract class Free[F[_], +R] {
 
-  def flatMap[R2](f: R => Free[F, R2]): Free[F, R2] = Bind(this, f)
-  def map[R2](f: R => R2): Free[F,R2] = Bind(this, (r: R) => Free.Pure(f(r)))
-  def onError[R2>:R](h: Throwable => Free[F,R2]): Free[F,R2] = OnError(this, h)
+  def flatMap[R2](f: R => Free[F, R2]): Free[F, R2] =
+    Bind[F,R,R2](this, e => e match {
+      case Right(r) => try f(r) catch { case NonFatal(e) => Free.Fail(e) }
+      case Left(e) => Free.Fail(e)
+    })
+
+  def map[R2](f: R => R2): Free[F,R2] =
+    Bind(this, (r: Either[Throwable,R]) => r match {
+      case Right(r) => try Free.Pure(f(r)) catch { case NonFatal(e) => Free.Fail(e) }
+      case Left(e) => Free.Fail(e)
+    })
+
+  def onError[R2>:R](h: Throwable => Free[F,R2]): Free[F,R2] =
+    Bind[F,R2,R2](this, e => e match {
+      case Right(a) => Free.Pure(a)
+      case Left(e) => try h(e) catch { case NonFatal(e) => Free.Fail(e) } })
+
   lazy val viewL: ViewL[F,R] = ViewL(this) // todo - review this
-  def translate[G[_]](f: F ~> G): Free[G, R] = this.viewL match {
-    case Done(r) => Pure(r)
-    case b: Bound[F,_,R] => b.translate(f) match {
-      case Done(r) => Pure(r)
-      case Failed(err) => Fail(err)
-      case b: Bound[G,_,R] => b.toFree
-    }
-    case Failed(err) => Fail(err)
+
+  def translate[G[_]](f: F ~> G): Free[G, R] = this.viewL.get match {
+    case Pure(r) => Pure(r)
+    case Bind(fx, k) => Bind(fx translate f, k andThen (_ translate f))
+    case Fail(e) => Fail(e)
+    case Eval(fx) => Eval(f(fx))
   }
 }
 
 object Free {
+  // Pure(r), Fail(e), Eval(fr), Bind(Eval(fx), k),
+  class ViewL[F[_],+R](val get: Free[F,R]) extends AnyVal
+
   case class Pure[F[_], R](r: R) extends Free[F, R] {
     override def translate[G[_]](f: F ~> G): Free[G, R] = this.asInstanceOf[Free[G,R]]
   }
   case class Eval[F[_], R](fr: F[R]) extends Free[F, R] {
     override def translate[G[_]](f: F ~> G): Free[G, R] = Eval(f(fr))
   }
-  case class Bind[F[_], X, R](fx: Free[F, X], f: X => Free[F, R]) extends Free[F, R]
-  case class OnError[F[_],R](fr: Free[F,R], onError: Throwable => Free[F,R]) extends Free[F,R]
+  case class Bind[F[_], X, R](fx: Free[F, X], f: Either[Throwable,X] => Free[F, R]) extends Free[F, R]
   case class Fail[F[_], R](error: Throwable) extends Free[F,R] {
     override def translate[G[_]](f: F ~> G): Free[G, R] = this.asInstanceOf[Free[G,R]]
   }
 
-  def Try[F[_],R](f: => Free[F,R]): Free[F,R] =
-    try f catch { case NonFatal(t) => Fail(t) }
+  private val pureContinuation_ = (e: Either[Throwable,Any]) => e match {
+    case Right(r) => Pure[Any,Any](r)
+    case Left(e) => Fail[Any,Any](e)
+  }
 
-  sealed abstract class ViewL[F[_], +R]
+  def pureContinuation[F[_],R]: Either[Throwable,R] => Free[F,R] =
+    pureContinuation_.asInstanceOf[Either[Throwable,R] => Free[F,R]]
 
   object ViewL {
-    class Bound[F[_], X, R] private (val fx: F[X], k: Continuation[F,X,R]) extends ViewL[F, R] {
-      def hasErrorHandler = k.hasErrorHandler
-      def handleError(e: Throwable): Free[F,R] = k(Fail(e))
-      def tryBind: X => Free[F,R] = x => k(Pure(x))
-      def toFree: Free[F,R] = k(Eval(fx))
-      def translate[G[_]](f: F ~> G): ViewL[G,R] =
-        try Bound(f(fx), k.translate(f))
-        catch { case NonFatal(e) => k(Fail(e)).translate(f).viewL }
-    }
-    object Bound {
-      def apply[F[_],X,R](fx: F[X], k: Continuation[F,X,R]): Bound[F,X,R] =
-        new Bound(fx, k)
-    }
-    case class Done[F[_], R](r: R) extends ViewL[F,R]
-    case class Failed[F[_],R](error: Throwable) extends ViewL[F,R]
-
-    abstract class Continuation[F[_],A,R] {
-      def apply(f: Free[F,A]): Free[F,R]
-      def compose[A0](k: Continuation[F,A0,A]): Continuation[F,A0,R] = Continuation.composed(k, this)
-      def hasErrorHandler: Boolean
-      def translate[G[_]](nt: F ~> G): Continuation[G,A,R]
-      def depth = 0
-    }
-    object Continuation {
-      case class OnError[F[_],A](h: Throwable => Free[F,A]) extends Continuation[F,A,A] {
-        def apply(f: Free[F,A]): Free[F,A] = f match {
-          case Free.Fail(e) => try h(e) catch { case NonFatal(e) => Fail(e) }
-          case Free.Pure(x) => f
-          case _ => f onError h
-        }
-        override def compose[A0](k: Continuation[F,A0,A]) = k match {
-          case OnError(hi) =>
-            OnError[F,A0]((e: Throwable) => hi(e) onError h.asInstanceOf[Throwable => Free[F,A0]])
-              .asInstanceOf[Continuation[F,A0,A]]
-          case _ => composed(k, this)
-        }
-        def hasErrorHandler = true
-        def translate[G[_]](nt: F ~> G): Continuation[G,A,A] =
-          OnError((e: Throwable) => h(e).translate(nt))
-      }
-      def composed[F[_],A,B,C](f: Continuation[F,A,B], g: Continuation[F,B,C]): Continuation[F,A,C]
-        = new Continuation[F,A,C] {
-          val hasErrorHandler = f.hasErrorHandler || g.hasErrorHandler
-          override val depth = (f.depth max g.depth) + 1
-          def apply(a: Free[F,A]) =
-            if (depth < 25) g(f(a))
-            else Free.Pure(()) flatMap { _ => g(f(a)) }
-          def translate[G[_]](nt: F ~> G): Continuation[G,A,C] =
-            composed(f.translate(nt), g.translate(nt))
-        }
-
-      case class FlatMap[F[_],A,B](f: A => Free[F,B]) extends Continuation[F,A,B] {
-        def apply(a: Free[F,A]): Free[F,B] = a match {
-          case Free.Fail(_) => a.asInstanceOf[Free[F,B]]
-          case Free.Pure(a) => try f(a) catch { case NonFatal(e) => Fail(e) }
-          case _ => a flatMap f
-        }
-        override def compose[A0](k: Continuation[F,A0,A]): Continuation[F,A0,B] = k match {
-          case FlatMap(g) => FlatMap((a0: A0) => g(a0) flatMap f)
-          case _ => Continuation.composed(k, this)
-        }
-        def translate[G[_]](nt: F ~> G): Continuation[G,A,B] =
-          FlatMap((a: A) => f(a).translate(nt))
-        def hasErrorHandler = false
-      }
-      case class Done[F[_],A](proof: A =:= A) extends Continuation[F,A,A] {
-        def apply(a: Free[F,A]): Free[F,A] = a
-        def hasErrorHandler = false
-        override def compose[A0](k: Continuation[F,A0,A]) = k
-        def translate[G[_]](nt: F ~> G): Continuation[G,A,A] = this.asInstanceOf[Continuation[G,A,A]]
-      }
-      def done[F[_],A](implicit eq: A =:= A) = Done(eq)
-      def flatMap[F[_],A,B](f: A => Free[F,B]) = FlatMap(f)
-      def onError[F[_],A](h: Throwable => Free[F,A]) = OnError(h)
-    }
-
-    // Pure(x)
-    // Eval(e)
-    // Bind(Eval(e), f)
-    // OnError(Bind(Eval(e), f), h)
-    // Bind(OnError(Eval(e), h), f)
-
     def apply[F[_], R](free: Free[F, R]): ViewL[F, R] = {
       type FreeF[x] = Free[F,x]
       type X = Any
       @annotation.tailrec
-      def go(free: Free[F, X], k: Continuation[F,X,R]): ViewL[F, R] = free match {
-        case Pure(x) => k match {
-          case d: Continuation.Done[F,Any] => ViewL.Done(x.asInstanceOf[R])
-          case k => go(k(free), Continuation.done[F,X].asInstanceOf[Continuation[F,X,R]])
-        }
-        case Eval(fx) => ViewL.Bound(fx, k)
-        case Fail(err) => k match {
-          case d: Continuation.Done[F,Any] => ViewL.Failed(err)
-          case k => go(k(free), Continuation.done[F,X].asInstanceOf[Continuation[F,X,R]])
-        }
-        case OnError(fx, h) => go(fx, Continuation.composed(Continuation.onError(h), k))
+      def go(free: Free[F, X]): ViewL[F, R] = free match {
+        case Pure(x) => new ViewL(free.asInstanceOf[Free[F,R]])
+        case Eval(fx) => new ViewL(Bind(free.asInstanceOf[Free[F,R]], pureContinuation[F,R]))
+        case Fail(err) => new ViewL(free.asInstanceOf[Free[F,R]])
         case b: Free.Bind[F, _, X] =>
           val fw: Free[F, Any] = b.fx.asInstanceOf[Free[F, Any]]
-          val f: Any => Free[F, X] = b.f.asInstanceOf[Any => Free[F, X]]
-          go(fw, Continuation.composed(Continuation.flatMap(f), k))
+          val f: Either[Throwable,Any] => Free[F, X] = b.f.asInstanceOf[Either[Throwable,Any] => Free[F, X]]
+          fw match {
+            case Pure(x) => go(f(Right(x)))
+            case Fail(e) => go(f(Left(e)))
+            case Eval(_) => new ViewL(b.asInstanceOf[Free[F,R]])
+            case Bind(w, g) => go(Bind(w, kcompose(g, f)))
+          }
       }
-      go(free.asInstanceOf[Free[F,X]], Continuation.done[F,X].asInstanceOf[Continuation[F,X,R]])
+      go(free.asInstanceOf[Free[F,X]])
     }
   }
 
+  // todo suspend
+  private def kcompose[F[_],A,B,C](
+    a: Either[Throwable,A] => Free[F,B],
+    b: Either[Throwable,B] => Free[F,C]): Either[Throwable,A] => Free[F,C] =
+    e => Bind(a(e), b)
+
   implicit class FreeRunOps[F[_],R](val self: Free[F,R]) extends AnyVal {
     def run(implicit F: MonadError[F, Throwable]): F[R] = {
-      self.viewL match {
-        case Done(r) => F.pure(r)
-        case Failed(t) => F.raiseError(t)
-        case b: Bound[F,_,R] => F.flatMap(F.attempt(b.fx)) {
-          case Left(err) => b.handleError(err).run
-          case Right(x) => b.tryBind(x).run
-        }
+      self.viewL.get match {
+        case Pure(r) => F.pure(r)
+        case Fail(e) => F.raiseError(e)
+        case Bind(fr, k) =>
+          F.flatMap(F.attempt(fr.asInstanceOf[Eval[F,Any]].fr)) { e => k(e).run }
+        case Eval(_) => sys.error("impossible")
       }
     }
   }

--- a/core/shared/src/test/scala/fs2/ErrorHandlingSpec.scala
+++ b/core/shared/src/test/scala/fs2/ErrorHandlingSpec.scala
@@ -66,12 +66,14 @@ class ErrorHandlingSpec extends Fs2Spec {
     }
 
     "ex7" in {
-      pending // FAILING CURRENTLY
-      (Stream.range(0, 3).covary[IO] ++ Stream.fail(Err)).unchunk.pull.echo.stream.run.unsafeRunSync
+      try {
+        (Stream.range(0, 3).covary[IO] ++ Stream.fail(Err)).unchunk.pull.echo.stream.run.unsafeRunSync
+        fail("SHOULD NOT REACH")
+      }
+      catch { case e: Throwable => () }
     }
 
     "ex8" in {
-      pending // FAILING CURRENTLY
       var i = 0
       (Stream.range(0, 3).covary[IO] ++ Stream.fail(Err)).unchunk.pull.echo.onError { t => i += 1; println(i); Pull.done }.stream.run.unsafeRunSync
       i shouldBe 1


### PR DESCRIPTION
Tests are passing except for this one in `StreamSpec`:

```Scala
    "onError (1)" in {
      pending // fails when exception thrown from pure code - e.g., s.map(_ => throw Err)
      forAll { (s: PureStream[Int], f: Failure) =>
        val s2 = s.get ++ f.get
        runLog(s2.onError(_ => Stream.empty)) shouldBe runLog(s.get)
      }
    }
```