### PR TITLE
Recycle input buffer only in unsafeReadInputStream{,Async}

### DIFF
--- a/io/src/main/scala/fs2/io/io.scala
+++ b/io/src/main/scala/fs2/io/io.scala
@@ -17,8 +17,8 @@ package object io {
    *
    * Blocks the current thread.
    */
-  def readInputStream[F[_]: Sync](fis: F[InputStream], chunkSize: Int, closeAfterUse: Boolean = true): Stream[F, Byte] =
-    readInputStreamGeneric(fis, chunkSize, readBytesFromInputStream[F], closeAfterUse)
+  def readInputStream[F[_]](fis: F[InputStream], chunkSize: Int, closeAfterUse: Boolean = true)(implicit F: Sync[F]): Stream[F, Byte] =
+    readInputStreamGeneric(fis, F.delay(new Array[Byte](chunkSize)), readBytesFromInputStream[F], closeAfterUse)
 
   /**
    * Reads all bytes from the specified `InputStream` with a buffer size of `chunkSize`.
@@ -31,7 +31,40 @@ package object io {
     def readAsync(is: InputStream, buf: Array[Byte]) =
       async.start(readBytesFromInputStream(is, buf)).flatten
 
-    readInputStreamGeneric(fis, chunkSize, readAsync, closeAfterUse)
+    readInputStreamGeneric(fis, F.delay(new Array[Byte](chunkSize)), readAsync, closeAfterUse)
+  }
+
+  /**
+   * Reads all bytes from the specified `InputStream` with a buffer size of `chunkSize`.
+   * Set `closeAfterUse` to false if the `InputStream` should not be closed after use.
+   *
+   * Recycles an underlying input buffer for performance. It is safe to call
+   * this as long as whatever consumes this `Stream` stores the `Chunk` returned
+   * or pipes it to a combinator (like `buffer`) that does.  Use `readInputStream`
+   * for a safe version.
+   *
+   * Blocks the current thread.
+   */
+  def unsafeReadInputStream[F[_]](fis: F[InputStream], chunkSize: Int, closeAfterUse: Boolean = true)(implicit F: Sync[F]): Stream[F, Byte] =
+    readInputStreamGeneric(fis, F.pure(new Array[Byte](chunkSize)), readBytesFromInputStream[F], closeAfterUse)
+
+  /**
+   * Reads all bytes from the specified `InputStream` with a buffer size of `chunkSize`.
+   * Set `closeAfterUse` to false if the `InputStream` should not be closed after use.
+   *
+   * This will block a thread in the `ExecutionContext`, so the size of any associated
+   * threadpool should be sized appropriately.
+   * 
+   * Recycles an underlying input buffer for performance. It is safe to call
+   * this as long as whatever consumes this `Stream` stores the `Chunk` returned
+   * or pipes it to a combinator (like `buffer`) that does.  Use `readInputStream`
+   * for a safe version.
+   */
+  def unsafeReadInputStreamAsync[F[_]](fis: F[InputStream], chunkSize: Int, closeAfterUse: Boolean = true)(implicit F: Effect[F], ec: ExecutionContext): Stream[F, Byte] = {
+    def readAsync(is: InputStream, buf: Array[Byte]) =
+      async.start(readBytesFromInputStream(is, buf)).flatten
+
+    readInputStreamGeneric(fis, F.pure(new Array[Byte](chunkSize)), readAsync, closeAfterUse)
   }
 
   /**

--- a/io/src/main/scala/fs2/io/io.scala
+++ b/io/src/main/scala/fs2/io/io.scala
@@ -39,9 +39,9 @@ package object io {
    * Set `closeAfterUse` to false if the `InputStream` should not be closed after use.
    *
    * Recycles an underlying input buffer for performance. It is safe to call
-   * this as long as whatever consumes this `Stream` stores the `Chunk` returned
-   * or pipes it to a combinator (like `buffer`) that does.  Use `readInputStream`
-   * for a safe version.
+   * this as long as whatever consumes this `Stream` does not store the `Chunk`
+   * returned or pipe it to a combinator that does (e.g., `buffer`). Use
+   * `readInputStream` for a safe version.
    *
    * Blocks the current thread.
    */
@@ -54,11 +54,11 @@ package object io {
    *
    * This will block a thread in the `ExecutionContext`, so the size of any associated
    * threadpool should be sized appropriately.
-   * 
+   *
    * Recycles an underlying input buffer for performance. It is safe to call
-   * this as long as whatever consumes this `Stream` stores the `Chunk` returned
-   * or pipes it to a combinator (like `buffer`) that does.  Use `readInputStream`
-   * for a safe version.
+   * this as long as whatever consumes this `Stream` does not store the `Chunk`
+   * returned or pipe it to a combinator that does (e.g. `buffer`). Use
+   * `readInputStream` for a safe version.
    */
   def unsafeReadInputStreamAsync[F[_]](fis: F[InputStream], chunkSize: Int, closeAfterUse: Boolean = true)(implicit F: Effect[F], ec: ExecutionContext): Stream[F, Byte] = {
     def readAsync(is: InputStream, buf: Array[Byte]) =

--- a/io/src/test/scala/fs2/io/IoSpec.scala
+++ b/io/src/test/scala/fs2/io/IoSpec.scala
@@ -1,0 +1,57 @@
+package fs2.io
+
+import java.io.{ByteArrayInputStream, InputStream}
+import cats.effect.IO
+import fs2.Fs2Spec
+
+class IoSpec extends Fs2Spec {
+  "readInputStream" - {
+    "arbitrary.runLog" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
+      val is: InputStream = new ByteArrayInputStream(bytes)
+      val stream = readInputStream(IO(is), chunkSize.get)
+      val example = stream.runLog.unsafeRunSync.toArray
+      example shouldBe bytes
+    }
+
+    "arbitrary.buffer.runLog" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
+      val is: InputStream = new ByteArrayInputStream(bytes)
+      val stream = readInputStream(IO(is), chunkSize.get)
+      val example = stream.buffer(chunkSize.get * 2).runLog.unsafeRunSync.toArray
+      example shouldBe bytes
+    }
+  }
+
+  "readInputStreamAsync" - {
+    "arbitrary.runLog" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
+      val is: InputStream = new ByteArrayInputStream(bytes)
+      val stream = readInputStreamAsync(IO(is), chunkSize.get)
+      val example = stream.runLog.unsafeRunSync.toArray
+      example shouldBe bytes
+    }
+
+    "arbitrary.buffer.runLog" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
+      val is: InputStream = new ByteArrayInputStream(bytes)
+      val stream = readInputStreamAsync(IO(is), chunkSize.get)
+      val example = stream.buffer(chunkSize.get * 2).runLog.unsafeRunSync.toArray
+      example shouldBe bytes
+    }
+  }
+
+  "unsafeReadInputStream" - {
+    "arbitrary.runLog" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
+      val is: InputStream = new ByteArrayInputStream(bytes)
+      val stream = unsafeReadInputStream(IO(is), chunkSize.get)
+      val example = stream.runLog.unsafeRunSync.toArray
+      example shouldBe bytes
+    }
+  }
+
+  "unsafeReadInputStreamAsync" - {
+    "arbitrary.runLog" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
+      val is: InputStream = new ByteArrayInputStream(bytes)
+      val stream = unsafeReadInputStreamAsync(IO(is), chunkSize.get)
+      val example = stream.runLog.unsafeRunSync.toArray
+      example shouldBe bytes
+    }
+  }
+}


### PR DESCRIPTION
The existing `readInputStream` recycles the input buffer.  This is akin to the behavior of scalaz-stream's `unsafeChunkR`, except it is not advertised as unsafe.

This passes the input buffer into `readInputStreamGeneric` in `F`.  `readInputStream` and `readInputStreamAsync` create a new array on each invocation, while `unsafeReadInputStream` and `unsafeReadInputStreamAsync` behave as the previous versions.