### PR TITLE
Link to fs2-rabbit library added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,13 @@ The previous stable release is 0.8.4 ([source](https://github.com/functional-str
 If you have a project you'd like to include in this list, either open a PR or let us know in [the gitter channel](https://gitter.im/functional-streams-for-scala/fs2) and we'll add a link to it here.
 
 * [doobie](https://github.com/tpolecat/doobie): Pure functional JDBC built on fs2.
-* [fs2-http](https://github.com/Spinoco/fs2-http): Http server and client library implemented in fs2
+* [fs2-http](https://github.com/Spinoco/fs2-http): Http server and client library implemented in fs2.
 * [http4s](http://http4s.org/): Minimal, idiomatic Scala interface for HTTP services using fs2.
-* [fs2-kafka](https://github.com/Spinoco/fs2-kafka): Simple client for Apache Kafka 
+* [fs2-kafka](https://github.com/Spinoco/fs2-kafka): Simple client for Apache Kafka. 
+* [fs2-rabbit](https://github.com/gvolpe/fs2-rabbit): Stream-based client for RabbitMQ built on top of Fs2.
 * [scodec-stream](https://github.com/scodec/scodec-stream): A library for streaming binary decoding and encoding, built using fs2 and [scodec](https://github.com/scodec/scodec).
 * [streamz](https://github.com/krasserm/streamz): A library that supports the conversion of [Akka Stream](http://doc.akka.io/docs/akka/2.4/scala/stream/index.html) `Source`s, `Flow`s and `Sink`s to and from FS2 `Stream`s, `Pipe`s and `Sink`s, respectively. It also supports the usage of [Apache Camel](http://camel.apache.org/) endpoints in FS2 `Stream`s and Akka Stream `Source`s, `Flow`s and `SubFlow`s.
-* [fs2-zk](https://github.com/Spinoco/fs2-zk): Simple Apache Zookeeper bindings for fs2
+* [fs2-zk](https://github.com/Spinoco/fs2-zk): Simple Apache Zookeeper bindings for fs2.
 * [fs2-reactive-streams](https://github.com/zainab-ali/fs2-reactive-streams): A reactive streams implementation for fs2.
 
 ### Related projects ###


### PR DESCRIPTION
Just seen this PR: https://github.com/functional-streams-for-scala/fs2/pull/882/files adding the fs2-kafka library and reminded me of adding fs2-rabbit.