### PR TITLE
Added Segment#mapConcat

### DIFF
--- a/core/shared/src/main/scala/fs2/Segment.scala
+++ b/core/shared/src/main/scala/fs2/Segment.scala
@@ -242,6 +242,19 @@ abstract class Segment[+O,+R] { self =>
   }
 
   /**
+   * Flattens a `Segment[Chunk[O2],R]` in to a `Segment[O2,R]`.
+   *
+   * @example {{{
+   * scala> Segment(Chunk(1, 2), Chunk(3, 4, 5)).flattenChunks.toVector
+   * res0: Vector[Int] = Vector(1, 2, 3, 4, 5)
+   * }}}
+   */
+  def flattenChunks[O2](implicit ev: O <:< Chunk[O2]): Segment[O2,R] = {
+    val _ = ev
+    this.asInstanceOf[Segment[Chunk[O2],R]].mapConcat(identity)
+  }
+
+  /**
    * Folds the output elements of this segment and returns the result as the result of the returned segment.
    *
    * @example {{{

--- a/core/shared/src/test/scala/fs2/SegmentSpec.scala
+++ b/core/shared/src/test/scala/fs2/SegmentSpec.scala
@@ -77,6 +77,13 @@ class SegmentSpec extends Fs2Spec {
       }
     }
 
+    "flatMap (2)" in {
+      forAll { (s: Segment[Int,Unit], f: Int => Segment[Int,Unit], n: Int) =>
+        val s2 = s.flatMap(f).take(n).void.run.toOption
+        s2.foreach { _.toVector shouldBe s.toVector.flatMap(i => f(i).toVector).drop(n) }
+      }
+    }
+
     "fold" in {
       forAll { (s: Segment[Int,Unit], init: Int, f: (Int, Int) => Int) =>
         s.fold(init)(f).run shouldBe s.toChunk.toVector.foldLeft(init)(f)

--- a/core/shared/src/test/scala/fs2/SegmentSpec.scala
+++ b/core/shared/src/test/scala/fs2/SegmentSpec.scala
@@ -71,6 +71,12 @@ class SegmentSpec extends Fs2Spec {
       }
     }
 
+    "flatMap" in {
+      forAll { (s: Segment[Int,Unit], f: Int => Segment[Int,Unit]) =>
+        s.flatMap(f).toVector shouldBe s.toVector.flatMap(i => f(i).toVector)
+      }
+    }
+
     "fold" in {
       forAll { (s: Segment[Int,Unit], init: Int, f: (Int, Int) => Int) =>
         s.fold(init)(f).run shouldBe s.toChunk.toVector.foldLeft(init)(f)

--- a/core/shared/src/test/scala/fs2/SegmentSpec.scala
+++ b/core/shared/src/test/scala/fs2/SegmentSpec.scala
@@ -84,6 +84,15 @@ class SegmentSpec extends Fs2Spec {
       }
     }
 
+    "flatMapAccumulate" in {
+      forAll { (s: Segment[Int,Unit], init: Double, f: (Double,Int) => (Double,Int)) =>
+        val s1 = s.flatMapAccumulate(init) { (s,i) => val (s2,o) = f(s,i); Segment.singleton(o).asResult(s2) }
+        val s2 = s.mapAccumulate(init)(f)
+        s1.toVector shouldBe s2.toVector
+        s1.void.run shouldBe s2.void.run
+      }
+    }
+
     "fold" in {
       forAll { (s: Segment[Int,Unit], init: Int, f: (Int, Int) => Int) =>
         s.fold(init)(f).run shouldBe s.toChunk.toVector.foldLeft(init)(f)

--- a/scodec/shared/src/main/scala/fs2/interop/scodec/ByteVectorChunk.scala
+++ b/scodec/shared/src/main/scala/fs2/interop/scodec/ByteVectorChunk.scala
@@ -14,6 +14,9 @@ final class ByteVectorChunk private (val toByteVector: ByteVector) extends Chunk
     val (before,after) = toByteVector.splitAt(n)
     (ByteVectorChunk(before), ByteVectorChunk(after))
   }
+
+  protected def mapStrict[O2](f: Byte => O2): Chunk[O2] =
+    Chunk.indexedSeq(toByteVector.toIndexedSeq.map(f))
 }
 
 object ByteVectorChunk {


### PR DESCRIPTION
Like a hypothetical `flatMap` but `f` returns a `Chunk[O2]` instead of `Segment[O2,R]`, allowing for a fused implementation with same performance as `map`.