### PR TITLE
Fixes memory leak in recursive streams

### DIFF
--- a/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
+++ b/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
@@ -84,3 +84,8 @@ object ConstantEvalSanityTest extends App {
     }
   }) }.run.unsafeRunSync
 }
+
+object RecursiveFlatMapTest extends App {
+  def loop: Stream[IO,Unit] = Stream(()).covary[IO].flatMap(_ => loop)
+  loop.run.unsafeRunSync
+}

--- a/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
+++ b/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
@@ -89,3 +89,38 @@ object RecursiveFlatMapTest extends App {
   def loop: Stream[IO,Unit] = Stream(()).covary[IO].flatMap(_ => loop)
   loop.run.unsafeRunSync
 }
+
+object StepperSanityTest extends App {
+  import Pipe.Stepper
+  def id[I,O](p: Pipe[Pure,I,O]): Pipe[Pure,I,O] = {
+    def go(stepper: Stepper[I,O], s: Stream[Pure,I]): Pull[Pure,O,Unit] = {
+      stepper.step match {
+        case Stepper.Done => Pull.done
+        case Stepper.Fail(err) => Pull.fail(err)
+        case Stepper.Emits(segment, next) =>
+          Pull.output(segment) >> go(next, s)
+        case Stepper.Await(receive) =>
+          s.pull.uncons.flatMap {
+            case Some((hd,tl)) => go(receive(Some(hd)), tl)
+            case None => go(receive(None), Stream.empty)
+          }
+      }
+    }
+    s => go(Pipe.stepper(p), s).stream
+  }
+  val incr: Pipe[Pure,Int,Int] = _.map(_ + 1)
+  Stream.constant(0).covary[IO].through(id(incr)).run.unsafeRunSync
+}
+
+object StepperSanityTest2 extends App {
+  import Pipe.Stepper
+  def go[I,O](i: I)(s: Stepper[I,O]): Unit = {
+    s.step match {
+      case Stepper.Done => ()
+      case Stepper.Fail(err) => throw err
+      case Stepper.Emits(s,n) => go(i)(n)
+      case Stepper.Await(r) => go(i)(r(Some(Segment(i))))
+    }
+  }
+  go(0)(Pipe.stepper(_.map(_ + 1)))
+}

--- a/core/jvm/src/test/scala/fs2/PipeSpec.scala
+++ b/core/jvm/src/test/scala/fs2/PipeSpec.scala
@@ -457,5 +457,33 @@ class PipeSpec extends Fs2Spec {
         }
       }
     }
+
+    "stepping" - {
+      "example" in {
+        import Pipe.Stepper
+        // Note: this is a useful but unsafe function - for each input (I,A), it remembers the A value, feeds the inner pipe, and then
+        // tags any output values with the remembered A value. This scheme breaks when the inner pipe buffers elements before emitting.
+        def first[I,O,A](p: Pipe[Pure,I,O]): Pipe[Pure,(I,A),(O,A)] = {
+          def go(last: Option[A], stepper: Stepper[I,O], s: Stream[Pure,(I,A)]): Pull[Pure,(O,A),Unit] = {
+            stepper.step match {
+              case Stepper.Done => Pull.done
+              case Stepper.Fail(err) => Pull.fail(err)
+              case Stepper.Emits(segment, next) =>
+                last match {
+                  case Some(a) => Pull.output(segment.map { o => (o,a) }) >> go(last, next, s)
+                  case None => go(last, next, s)
+                }
+              case Stepper.Await(receive) =>
+                s.pull.uncons1.flatMap {
+                  case Some(((i,a),s)) => go(Some(a), receive(Some(Chunk.singleton(i))), s)
+                  case None => go(last, receive(None), s)
+                }
+            }
+          }
+          s => go(None, Pipe.stepper(p), s).stream
+        }
+        Stream.range(0, 100).map(i => (i,i)).through(first(_.map(_ + 1).take(5))).toList shouldBe List((1,0), (2,1), (3,2), (4,3), (5,4))
+      }
+    }
   }
 }

--- a/core/shared/src/main/scala/fs2/Pipe.scala
+++ b/core/shared/src/main/scala/fs2/Pipe.scala
@@ -6,8 +6,72 @@ import cats.effect.Effect
 import cats.implicits._
 
 import fs2.async.mutable.Queue
+import fs2.internal.{ Algebra, FreeC, NonFatal }
 
 object Pipe {
+
+  /** Creates a [[Stepper]], which allows incrementally stepping a pure pipe. */
+  def stepper[I,O](p: Pipe[Pure,I,O]): Stepper[I,O] = {
+    type ReadSegment[R] = Option[Segment[I,Unit]] => R
+    type Read[R] = FreeC[ReadSegment, R]
+    type UO = Option[(Segment[O,Unit],Stream[Read,O])]
+
+    def prompts: Stream[Read,I] =
+      Stream.eval[Read,Option[Segment[I,Unit]]](FreeC.Eval(identity)).flatMap {
+        case None => Stream.empty
+        case Some(segment) => Stream.segment(segment).append(prompts)
+      }
+
+    // Steps `s` without overhead of resource tracking
+    def stepf(s: Stream[Read,O]): Read[UO] = {
+      Algebra.runFold_(Algebra.uncons(s.get).flatMap {
+        case Some((hd,tl)) => Algebra.output1[Read,UO](Some((hd,Stream.fromFreeC(tl))))
+        case None => Algebra.pure[Read,UO,Unit](())
+      }, None: UO)((x,y) => y, new Algebra.Scope[Read])
+    }
+
+    def go(s: Read[UO]): Stepper[I,O] = Stepper.Suspend { () =>
+      s.viewL.get match {
+        case FreeC.Pure(None) => Stepper.Done
+        case FreeC.Pure(Some((hd,tl))) => Stepper.Emits(hd, go(stepf(tl)))
+        case FreeC.Fail(t) => Stepper.Fail(t)
+        case bound: FreeC.Bind[ReadSegment,_,UO] =>
+          val f = bound.asInstanceOf[FreeC.Bind[ReadSegment,Any,UO]].f
+          val fx = bound.fx.asInstanceOf[FreeC.Eval[ReadSegment,UO]].fr
+          Stepper.Await(segment => try go(f(Right(fx(segment)))) catch { case NonFatal(t) => go(f(Left(t))) })
+        case e => sys.error("FreeC.ViewL structure must be Pure(a), Fail(e), or Bind(Eval(fx),k), was: " + e)
+      }
+    }
+    go(stepf(prompts.through(p)))
+  }
+
+  /**
+   * Allows stepping of a pure pipe. Each invocation of [[step]] results in
+   * a value of the [[Stepper.Step]] algebra, indicating that the pipe is either done, it
+   * failed with an exception, it emitted a chunk of output, or it is awaiting input.
+   */
+  sealed abstract class Stepper[-A,+B] {
+    @annotation.tailrec
+    final def step: Stepper.Step[A,B] = this match {
+      case Stepper.Suspend(s) => s().step
+      case _ => this.asInstanceOf[Stepper.Step[A,B]]
+    }
+  }
+
+  object Stepper {
+    private[fs2] final case class Suspend[A,B](force: () => Stepper[A,B]) extends Stepper[A,B]
+
+    /** Algebra describing the result of stepping a pure pipe. */
+    sealed abstract class Step[-A,+B] extends Stepper[A,B]
+    /** Pipe indicated it is done. */
+    final case object Done extends Step[Any,Nothing]
+    /** Pipe failed with the specified exception. */
+    final case class Fail(err: Throwable) extends Step[Any,Nothing]
+    /** Pipe emitted a segment of elements. */
+    final case class Emits[A,B](segment: Segment[B,Unit], next: Stepper[A,B]) extends Step[A,B]
+    /** Pipe is awaiting input. */
+    final case class Await[A,B](receive: Option[Segment[A,Unit]] => Stepper[A,B]) extends Step[A,B]
+  }
 
   /** Queue based version of [[join]] that uses the specified queue. */
   def joinQueued[F[_],A,B](q: F[Queue[F,Option[Segment[A,Unit]]]])(s: Stream[F,Pipe[F,A,B]])(implicit F: Effect[F], ec: ExecutionContext): Pipe[F,A,B] = in => {

--- a/core/shared/src/main/scala/fs2/Pipe2.scala
+++ b/core/shared/src/main/scala/fs2/Pipe2.scala
@@ -1,0 +1,80 @@
+package fs2
+
+import fs2.internal.{ Algebra, FreeC, NonFatal }
+
+object Pipe2 {
+  /** Creates a [[Stepper]], which allows incrementally stepping a pure `Pipe2`. */
+  def stepper[I,I2,O](p: Pipe2[Pure,I,I2,O]): Stepper[I,I2,O] = {
+    type ReadSegment[R] = Either[Option[Segment[I,Unit]] => R, Option[Segment[I2,Unit]] => R]
+    type Read[R] = FreeC[ReadSegment,R]
+    type UO = Option[(Segment[O,Unit],Stream[Read,O])]
+
+    def prompts[X](id: ReadSegment[Option[Segment[X,Unit]]]): Stream[Read,X] = {
+      Stream.eval[Read,Option[Segment[X,Unit]]](FreeC.Eval(id)).flatMap {
+        case None => Stream.empty
+        case Some(segment) => Stream.segment(segment).append(prompts(id))
+      }
+    }
+    def promptsL: Stream[Read,I] = prompts[I](Left(identity))
+    def promptsR: Stream[Read,I2] = prompts[I2](Right(identity))
+
+    // Steps `s` without overhead of resource tracking
+    def stepf(s: Stream[Read,O]): Read[UO] = {
+      Algebra.runFold_(Algebra.uncons(s.get).flatMap {
+        case Some((hd,tl)) => Algebra.output1[Read,UO](Some((hd,Stream.fromFreeC(tl))))
+        case None => Algebra.pure[Read,UO,Unit](())
+      }, None: UO)((x,y) => y, new Algebra.Scope[Read])
+    }
+
+    def go(s: Read[UO]): Stepper[I,I2,O] = Stepper.Suspend { () =>
+      s.viewL.get match {
+        case FreeC.Pure(None) => Stepper.Done
+        case FreeC.Pure(Some((hd,tl))) => Stepper.Emits(hd, go(stepf(tl)))
+        case FreeC.Fail(t) => Stepper.Fail(t)
+        case bound: FreeC.Bind[ReadSegment,_,UO] =>
+          val f = bound.asInstanceOf[FreeC.Bind[ReadSegment,Any,UO]].f
+          val fx = bound.fx.asInstanceOf[FreeC.Eval[ReadSegment,UO]].fr
+          fx match {
+            case Left(recv) =>
+              Stepper.AwaitL(segment => try go(f(Right(recv(segment)))) catch { case NonFatal(t) => go(f(Left(t))) })
+            case Right(recv) =>
+              Stepper.AwaitR(segment => try go(f(Right(recv(segment)))) catch { case NonFatal(t) => go(f(Left(t))) })
+          }
+        case e => sys.error("FreeC.ViewL structure must be Pure(a), Fail(e), or Bind(Eval(fx),k), was: " + e)
+      }
+    }
+    go(stepf(p.covary[Read].apply(promptsL, promptsR)))
+  }
+
+  /**
+   * Allows stepping of a pure pipe. Each invocation of [[step]] results in
+   * a value of the [[Stepper.Step]] algebra, indicating that the pipe is either done, it
+   * failed with an exception, it emitted a chunk of output, or it is awaiting input
+   * from either the left or right branch.
+   */
+  sealed abstract class Stepper[-I,-I2,+O] {
+    import Stepper._
+    @annotation.tailrec
+    final def step: Step[I,I2,O] = this match {
+      case Suspend(s) => s().step
+      case _ => this.asInstanceOf[Step[I,I2,O]]
+    }
+  }
+
+  object Stepper {
+    private[fs2] final case class Suspend[I,I2,O](force: () => Stepper[I,I2,O]) extends Stepper[I,I2,O]
+
+    /** Algebra describing the result of stepping a pure `Pipe2`. */
+    sealed abstract class Step[-I,-I2,+O] extends Stepper[I,I2,O]
+    /** Pipe indicated it is done. */
+    final case object Done extends Step[Any,Any,Nothing]
+    /** Pipe failed with the specified exception. */
+    final case class Fail(err: Throwable) extends Step[Any,Any,Nothing]
+    /** Pipe emitted a segment of elements. */
+    final case class Emits[I,I2,O](segment: Segment[O,Unit], next: Stepper[I,I2,O]) extends Step[I,I2,O]
+    /** Pipe is awaiting input from the left. */
+    final case class AwaitL[I,I2,O](receive: Option[Segment[I,Unit]] => Stepper[I,I2,O]) extends Step[I,I2,O]
+    /** Pipe is awaiting input from the right. */
+    final case class AwaitR[I,I2,O](receive: Option[Segment[I2,Unit]] => Stepper[I,I2,O]) extends Step[I,I2,O]
+  }
+}

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -5,7 +5,7 @@ import scala.concurrent.duration.FiniteDuration
 
 import cats.{ ~>, Applicative, Eq, Functor, Monoid, Semigroup }
 import cats.effect.{ Effect, IO, Sync }
-import cats.implicits._
+import cats.implicits.{ catsSyntaxEither => _, _ }
 
 import fs2.async.mutable.Queue
 import fs2.internal.{ Algebra, FreeC }

--- a/core/shared/src/main/scala/fs2/internal/Algebra.scala
+++ b/core/shared/src/main/scala/fs2/internal/Algebra.scala
@@ -191,7 +191,7 @@ private[fs2] object Algebra {
           case algebra => // Eval, Acquire, Release, OpenScope, CloseScope, UnconsAsync
             FreeC.Bind[Algebra[F,X,?],Any,Option[(Segment[O,Unit], FreeC[Algebra[F,O,?],Unit])]](
               FreeC.Eval[Algebra[F,X,?],Any](algebra.asInstanceOf[Algebra[F,X,Any]]),
-              f andThen (s => uncons[F,X,O](s, chunkSize))
+              (x: Either[Throwable,Any]) => uncons[F,X,O](f(x), chunkSize)
             )
         }
       case e => sys.error("FreeC.ViewL structure must be Pure(a), Fail(e), or Bind(Eval(fx),k), was: " + e)


### PR DESCRIPTION
This PR fixes a memory leak in `Stream#flatMap` when defining a recursive stream. Consider:

```scala
def loop: Stream[IO,Unit] = Stream(()).covary[IO].flatMap(_ => loop)
loop.run.unsafeRunSync
```

Before this PR, running this program would fill the heap within seconds. This was due to this code in `Stream#flatMap`:

```scala
hd.map(f).foldRightLazy(Stream.fromFreeC(tl).flatMap(f))(_ ++ _).get
```

Each element is mapped to a `Stream[F,O2]` and the resulting `Segment[Stream[F,O2],Unit]` is then lazily folded in to a `Stream[F,O2]` via the `++` operator.

Recursive streams of the form of `loop` emit a single element at a time, but the fold turns that in to `f(hd(0)) ++ Stream.empty.flatMap(f)`. This is equivalent to `f(hd(0))` but pushes the concatenation of `Stream.empty.flatMap(f)` in to a `Bind` node in the resulting `FreeC`. Hence, each iteration through the recursive `flatMap` lengthens the overall stream by an additional `Bind`.

This PR special cases `Stream#flatMap` for singleton streams in order to support this pattern. I think it's okay to special case singleton streams b/c the non-singleton case is expected to run in non-constant memory.

Note that this also fixes `Pipe.Stepper` and `Pipe2.Stepper` -- the `prompts` stream used in each had a recursive call inside `flatMap`.