### PR TITLE
Fixed a bug where an IllegalStateException is erroneously thrown from...

### DIFF
--- a/core/shared/src/main/scala/fs2/Pipe.scala
+++ b/core/shared/src/main/scala/fs2/Pipe.scala
@@ -27,7 +27,7 @@ object Pipe {
       Algebra.runFold_(Algebra.uncons(s.get).flatMap {
         case Some((hd,tl)) => Algebra.output1[Read,UO](Some((hd,Stream.fromFreeC(tl))))
         case None => Algebra.pure[Read,UO,Unit](())
-      }, None: UO)((x,y) => y, new Algebra.Scope[Read])
+      }, None, None: UO)((x,y) => y, new Algebra.Scope[Read])
     }
 
     def go(s: Read[UO]): Stepper[I,O] = Stepper.Suspend { () =>

--- a/core/shared/src/main/scala/fs2/Pipe2.scala
+++ b/core/shared/src/main/scala/fs2/Pipe2.scala
@@ -23,7 +23,7 @@ object Pipe2 {
       Algebra.runFold_(Algebra.uncons(s.get).flatMap {
         case Some((hd,tl)) => Algebra.output1[Read,UO](Some((hd,Stream.fromFreeC(tl))))
         case None => Algebra.pure[Read,UO,Unit](())
-      }, None: UO)((x,y) => y, new Algebra.Scope[Read])
+      }, None, None: UO)((x,y) => y, new Algebra.Scope[Read])
     }
 
     def go(s: Read[UO]): Stepper[I,I2,O] = Stepper.Suspend { () =>


### PR DESCRIPTION
...`run` with an error indicating a scope was closed with midAcquires > 0
and no uncons steps.

I was not able to reproduce this in a unit test. In the application I
experienced this issue, the issue is intermittent and very rare.

```
java.lang.IllegalStateException: FS2 bug: closing a scope with midAcquires 1 but no async steps
    at fs2.internal.Algebra$Scope.closeAndReturnFinalizers(Algebra.scala:142)
    at fs2.internal.Algebra$Scope.$anonfun$closeAndReturnFinalizers$1(Algebra.scala:127)
    at cats.instances.VectorInstances$$anon$1.$anonfun$traverse$2(vector.scala:78)
    at cats.instances.VectorInstances$$anon$1.loop$2(vector.scala:42)
    at cats.instances.VectorInstances$$anon$1.$anonfun$foldRight$2(vector.scala:43)
    at cats.Eval$Call$.cats$Eval$Call$$loop(Eval.scala:236)
    at cats.Eval$Call.value(Eval.scala:229)
```

Confirmed the fix by running it in a larger application and observing no
exceptions.