### PR TITLE
Fixes #907

### DIFF
--- a/core/jvm/src/test/scala/fs2/ConcurrentlySpec.scala
+++ b/core/jvm/src/test/scala/fs2/ConcurrentlySpec.scala
@@ -1,0 +1,37 @@
+package fs2
+
+import scala.concurrent.duration._
+import cats.effect.IO
+
+class ConcurrentlySpec extends Fs2Spec {
+
+  "concurrently" - {
+
+    "when background stream terminates, overall stream continues" in forAll { (s1: PureStream[Int], s2: PureStream[Int]) =>
+      runLog(Scheduler[IO](1).flatMap(scheduler => (scheduler.sleep_[IO](25.millis) ++ s1.get).concurrently(s2.get))) shouldBe s1.get.toVector
+    }
+
+    "when background stream fails, overall stream fails" in forAll { (s: PureStream[Int], f: Failure) =>
+      val prg = Scheduler[IO](1).flatMap(scheduler => (scheduler.sleep_[IO](25.millis) ++ s.get).concurrently(f.get))
+      val throws = f.get.drain.run.attempt.unsafeRunSync.isLeft
+      if (throws) an[Err.type] should be thrownBy runLog(prg)
+      else runLog(prg)
+    }
+
+    "when primary stream fails, overall stream fails and background stream is terminated" in forAll { (f: Failure) =>
+      var bgDone = false
+      val bg = Stream.repeatEval(IO(1)).onFinalize(IO(bgDone = true))
+      val prg = Scheduler[IO](1).flatMap(scheduler => (scheduler.sleep_[IO](25.millis) ++ f.get).concurrently(bg))
+      an[Err.type] should be thrownBy runLog(prg)
+      bgDone shouldBe true
+    }
+
+    "when primary stream termiantes, background stream is terminated" in forAll { (s: PureStream[Int]) =>
+      var bgDone = false
+      val bg = Stream.repeatEval(IO(1)).onFinalize(IO(bgDone = true))
+      val prg = Scheduler[IO](1).flatMap(scheduler => (scheduler.sleep_[IO](25.millis) ++ s.get).concurrently(bg))
+      runLog(prg)
+      bgDone shouldBe true
+    }
+  }
+}

--- a/core/jvm/src/test/scala/fs2/async/QueueSpec.scala
+++ b/core/jvm/src/test/scala/fs2/async/QueueSpec.scala
@@ -1,56 +1,56 @@
-// package fs2
-// package async
-//
-// import cats.effect.IO
-//
-// class QueueSpec extends Fs2Spec {
-//   "Queue" - {
-//     "unbounded producer/consumer" in {
-//       forAll { (s: PureStream[Int]) =>
-//         withClue(s.tag) {
-//           runLog(Stream.eval(async.unboundedQueue[IO,Int]).flatMap { q =>
-//             q.dequeue.merge(s.get.evalMap(q.enqueue1).drain).take(s.get.toVector.size)
-//           }) shouldBe s.get.toVector
-//         }
-//       }
-//     }
-//     "circularBuffer" in {
-//       forAll { (s: PureStream[Int], maxSize: SmallPositive) =>
-//         withClue(s.tag) {
-//           runLog(Stream.eval(async.circularBuffer[IO,Option[Int]](maxSize.get + 1)).flatMap { q =>
-//             s.get.noneTerminate.evalMap(q.enqueue1).drain ++ q.dequeue.through(pipe.unNoneTerminate)
-//           }) shouldBe s.get.toVector.takeRight(maxSize.get)
-//         }
-//       }
-//     }
-//     "dequeueAvailable" in {
-//       forAll { (s: PureStream[Int]) =>
-//         withClue(s.tag) {
-//           val result = runLog(Stream.eval(async.unboundedQueue[IO,Option[Int]]).flatMap { q =>
-//             s.get.noneTerminate.evalMap(q.enqueue1).drain ++ q.dequeueAvailable.through(pipe.unNoneTerminate).chunks
-//           })
-//           result.size should be < 2
-//           result.flatMap(_.toVector) shouldBe s.get.toVector
-//         }
-//       }
-//     }
-//     "dequeueBatch unbounded" in {
-//       forAll { (s: PureStream[Int], batchSize: SmallPositive) =>
-//         withClue(s.tag) {
-//           runLog(Stream.eval(async.unboundedQueue[IO,Option[Int]]).flatMap { q =>
-//             s.get.noneTerminate.evalMap(q.enqueue1).drain ++ Stream.constant(batchSize.get).through(q.dequeueBatch).through(pipe.unNoneTerminate)
-//           }) shouldBe s.get.toVector
-//         }
-//       }
-//     }
-//     "dequeueBatch circularBuffer" in {
-//       forAll { (s: PureStream[Int], maxSize: SmallPositive, batchSize: SmallPositive) =>
-//         withClue(s.tag) {
-//           runLog(Stream.eval(async.circularBuffer[IO,Option[Int]](maxSize.get + 1)).flatMap { q =>
-//             s.get.noneTerminate.evalMap(q.enqueue1).drain ++ Stream.constant(batchSize.get).through(q.dequeueBatch).through(pipe.unNoneTerminate)
-//           }) shouldBe s.get.toVector.takeRight(maxSize.get)
-//         }
-//       }
-//     }
-//   }
-// }
+package fs2
+package async
+
+import cats.effect.IO
+
+class QueueSpec extends Fs2Spec {
+  "Queue" - {
+    "unbounded producer/consumer" in {
+      forAll { (s: PureStream[Int]) =>
+        withClue(s.tag) {
+          runLog(Stream.eval(async.unboundedQueue[IO,Int]).flatMap { q =>
+            q.dequeue.merge(s.get.evalMap(q.enqueue1).drain).take(s.get.toVector.size)
+          }) shouldBe s.get.toVector
+        }
+      }
+    }
+    "circularBuffer" in {
+      forAll { (s: PureStream[Int], maxSize: SmallPositive) =>
+        withClue(s.tag) {
+          runLog(Stream.eval(async.circularBuffer[IO,Option[Int]](maxSize.get + 1)).flatMap { q =>
+            s.get.noneTerminate.evalMap(q.enqueue1).drain ++ q.dequeue.unNoneTerminate
+          }) shouldBe s.get.toVector.takeRight(maxSize.get)
+        }
+      }
+    }
+    "dequeueAvailable" in {
+      forAll { (s: PureStream[Int]) =>
+        withClue(s.tag) {
+          val result = runLog(Stream.eval(async.unboundedQueue[IO,Option[Int]]).flatMap { q =>
+            s.get.noneTerminate.evalMap(q.enqueue1).drain ++ q.dequeueAvailable.unNoneTerminate.segments
+          })
+          result.size should be < 2
+          result.flatMap(_.toVector) shouldBe s.get.toVector
+        }
+      }
+    }
+    "dequeueBatch unbounded" in {
+      forAll { (s: PureStream[Int], batchSize: SmallPositive) =>
+        withClue(s.tag) {
+          runLog(Stream.eval(async.unboundedQueue[IO,Option[Int]]).flatMap { q =>
+            s.get.noneTerminate.evalMap(q.enqueue1).drain ++ Stream.constant(batchSize.get).covary[IO].through(q.dequeueBatch).unNoneTerminate
+          }) shouldBe s.get.toVector
+        }
+      }
+    }
+    "dequeueBatch circularBuffer" in {
+      forAll { (s: PureStream[Int], maxSize: SmallPositive, batchSize: SmallPositive) =>
+        withClue(s.tag) {
+          runLog(Stream.eval(async.circularBuffer[IO,Option[Int]](maxSize.get + 1)).flatMap { q =>
+            s.get.noneTerminate.evalMap(q.enqueue1).drain ++ Stream.constant(batchSize.get).covary[IO].through(q.dequeueBatch).unNoneTerminate
+          }) shouldBe s.get.toVector.takeRight(maxSize.get)
+        }
+      }
+    }
+  }
+}

--- a/core/jvm/src/test/scala/fs2/async/SignalSpec.scala
+++ b/core/jvm/src/test/scala/fs2/async/SignalSpec.scala
@@ -24,6 +24,7 @@ class SignalSpec extends Fs2Spec {
         })
       }
     }
+
     "discrete" in {
       // verifies that discrete always receives the most recent value, even when updates occur rapidly
       forAll { (v0: Long, vsTl: List[Long]) =>
@@ -36,6 +37,10 @@ class SignalSpec extends Fs2Spec {
         while (r.get != last) {}
         true
       }
+    }
+
+    "holdOption" in {
+      runLog(async.holdOption(Stream.range(1,10).covary[IO]))
     }
   }
 }

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1772,7 +1772,7 @@ object Stream {
      * concurrent data structure and merging it with a consumer from the same
      * data structure. In such cases, use `consumer.concurrently(producer)`
      * instead of `consumer.mergeHaltR(producer.drain)` to ensure the producer
-     * continues to run in paralle with consumer processing.
+     * continues to run in parallel with consumer processing.
      *
      * @example {{{
      * scala> import scala.concurrent.duration._, scala.concurrent.ExecutionContext.Implicits.global, cats.effect.IO

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -941,7 +941,7 @@ final class Stream[+F[_],+O] private(private val free: FreeC[Algebra[Nothing,Not
    * res0: List[Int] = List(0, 1, 2, 3, 4)
    * }}}
    */
-  def takeWhile(p: O => Boolean): Stream[F,O] = this.pull.takeWhile(p).stream
+  def takeWhile(p: O => Boolean, takeFailure: Boolean = false): Stream[F,O] = this.pull.takeWhile(p, takeFailure).stream
 
   /**
    * Converts the input to a stream of 1-element chunks.
@@ -1436,7 +1436,8 @@ object Stream {
      * @example {{{
      * scala> import cats.effect.IO, scala.concurrent.ExecutionContext.Implicits.global
      * scala> val data: Stream[IO,Int] = Stream.range(1, 10).covary[IO]
-     * scala> Stream.eval(async.signalOf[IO,Int](0)).flatMap(s => Stream(s).concurrently(data.evalMap(s.set))).flatMap(_.discrete).takeWhile(_ < 9).runLast.unsafeRunSync
+     * scala> Stream.eval(async.signalOf[IO,Int](0)).flatMap(s => Stream(s).concurrently(data.evalMap(s.set))).flatMap(_.discrete).takeWhile(_ < 9, true).runLast.unsafeRunSync
+     * res0: Option[Int] = Some(9)
      * }}}
      */
     def concurrently[O2](that: Stream[F,O2])(implicit F: Effect[F], ec: ExecutionContext): Stream[F,O] = {
@@ -2608,7 +2609,7 @@ object Stream {
      * and returns the remaining `Stream`. If non-empty, the returned stream will have
      * a first element `i` for which `p(i)` is `false`.
      */
-    def takeWhile(p: O => Boolean): Pull[F,O,Option[Stream[F,O]]] = takeWhile_(p, false)
+    def takeWhile(p: O => Boolean, takeFailure: Boolean = false): Pull[F,O,Option[Stream[F,O]]] = takeWhile_(p, takeFailure)
 
     private def takeWhile_(p: O => Boolean, takeFailure: Boolean): Pull[F,O,Option[Stream[F,O]]] =
       uncons.flatMap {

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1437,7 +1437,6 @@ object Stream {
      * scala> import cats.effect.IO, scala.concurrent.ExecutionContext.Implicits.global
      * scala> val data: Stream[IO,Int] = Stream.range(1, 10).covary[IO]
      * scala> Stream.eval(async.signalOf[IO,Int](0)).flatMap(s => Stream(s).concurrently(data.evalMap(s.set))).flatMap(_.discrete).takeWhile(_ < 9).runLast.unsafeRunSync
-     * res0: Option[Int] = Some(8)
      * }}}
      */
     def concurrently[O2](that: Stream[F,O2])(implicit F: Effect[F], ec: ExecutionContext): Stream[F,O] = {

--- a/core/shared/src/main/scala/fs2/async/async.scala
+++ b/core/shared/src/main/scala/fs2/async/async.scala
@@ -59,7 +59,7 @@ package object async {
    */
   def hold[F[_],A](initial: A, source:Stream[F,A])(implicit F: Effect[F], ec: ExecutionContext): Stream[F,immutable.Signal[F,A]] =
     Stream.eval(signalOf[F,A](initial)) flatMap { sig =>
-      Stream(sig).concurrently(source.flatMap(a => Stream.eval_(sig.set(a))))
+      Stream(sig).concurrently(source.evalMap(sig.set))
     }
 
   /** Defined as `[[hold]](None, source.map(Some(_)))` */

--- a/core/shared/src/main/scala/fs2/async/immutable/Signal.scala
+++ b/core/shared/src/main/scala/fs2/async/immutable/Signal.scala
@@ -6,7 +6,6 @@ import cats.Functor
 import cats.effect.Effect
 
 import fs2.Stream
-import fs2.async.immutable
 
 /** Data type of a single value of type `A` that can be read in the effect `F`. */
 abstract class Signal[F[_], A] { self =>
@@ -54,16 +53,4 @@ object Signal {
   implicit class BooleanSignalSyntax[F[_]] (val self: Signal[F,Boolean]) {
     def interrupt[A](s: Stream[F,A])(implicit F: Effect[F], ec: ExecutionContext): Stream[F,A] = s.interruptWhen(self)
   }
-
-  /**
-   * Constructs Stream from the input stream `source`. If `source` terminates
-   * then resulting stream terminates as well.
-   */
-  def holdOption[F[_],A](source:Stream[F,A])(implicit F: Effect[F], ec: ExecutionContext): Stream[F,immutable.Signal[F,Option[A]]] =
-    hold(None, source.map(Some(_)))
-
-  def hold[F[_],A](initial: A, source:Stream[F,A])(implicit F: Effect[F], ec: ExecutionContext): Stream[F,immutable.Signal[F,A]] =
-    Stream.eval(fs2.async.signalOf[F,A](initial)) flatMap { sig =>
-      Stream(sig).merge(source.flatMap(a => Stream.eval_(sig.set(a))))
-    }
 }

--- a/docs/ReadmeExample.md
+++ b/docs/ReadmeExample.md
@@ -98,7 +98,7 @@ There are a number of ways of interpreting the stream. In this case, we call `ru
 
 ```scala
 scala> val task: IO[Unit] = written.run
-task: cats.effect.IO[Unit] = IO$904324306
+task: cats.effect.IO[Unit] = IO$1130771996
 ```
 
 We still haven't *done* anything yet. Effects only occur when we run the resulting task. We can run a `IO` by calling `unsafeRunSync()` -- the name is telling us that calling it performs effects and hence, it is not referentially transparent.

--- a/docs/migration-guide-0.10.md
+++ b/docs/migration-guide-0.10.md
@@ -140,7 +140,7 @@ The general idea behind this pattern is to create a producer and a consumer and 
 
 To address this use case, the `concurrently` method has been added. Instead of `consumer.mergeHaltR(producer.drain)`, use `consumer.concurrently(producer)`. See the ScalaDoc for `concurrently` for more details.
 
-Given that most usage of merging a drained stream with another stream should be replaced with `concurrently`, we've removed `mergeHaltL` and `mergeHaltR`.
+Given that most usage of merging a drained stream with another stream should be replaced with `concurrently`, we've removed `mergeDrainL` and `mergeDrainR`.
 
 ### Minor API Changes
 

--- a/docs/migration-guide-0.10.md
+++ b/docs/migration-guide-0.10.md
@@ -126,6 +126,22 @@ Scheduler[IO](corePoolSize = 1).flatMap { scheduler =>
 
 The `debounce` pipe has moved to the `Scheduler` class also. As a result, FS2 no longer requires passing schedulers implicitly.
 
+#### Merging
+
+The semantics of merging a drained stream with another stream have changed. In 0.9, it was generally safe to do things like:
+
+```scala
+Stream.eval(async.signalOf[IO]).flatMap { s =>
+  Stream.emit(s) mergeHaltR source.evalMap(s.set).drain
+}
+```
+
+The general idea behind this pattern is to create a producer and a consumer and then combine them in to a single stream by merging the consumer with the result of draining the producer. In 0.10, the two streams used in a merge are only consulted when downstream needs an element. As a result, it's possible to deadlock when using this pattern. This pattern relies on the fact that the drained producer will continue to execute in parallel with the consumer, *even when the downstream never asks for another element from the merged stream*.
+
+To address this use case, the `concurrently` method has been added. Instead of `consumer.mergeHaltR(producer.drain)`, use `consumer.concurrently(producer)`. See the ScalaDoc for `concurrently` for more details.
+
+Given that most usage of merging a drained stream with another stream should be replaced with `concurrently`, we've removed `mergeHaltL` and `mergeHaltR`.
+
 ### Minor API Changes
 
 - The `fs2.concurrent` object has been removed in favor of calling the `join` method on a `Stream` (e.g., `s.join(n)`).


### PR DESCRIPTION
Introduced `s.concurrently(t)` as a safe replacement for `s.mergeHaltR(t.drain)`. Removed `mergeHaltL` and `mergeHaltR`. Changed `hold` to be implemented with `concurrently`.

@pchlupacek This should cover everything from #911. /cc @SystemFw 