### PR TITLE
It is possible - and indeed does happen intermittently when rapidly f…

### DIFF
--- a/core/shared/src/main/scala/fs2/Segment.scala
+++ b/core/shared/src/main/scala/fs2/Segment.scala
@@ -333,11 +333,12 @@ abstract class Segment[+O,+R] { self =>
 
       outerStep.map { outer =>
         step {
+          val innerRem: Segment[O2,S] = if (inner eq null) Segment.empty else inner.remainder
           outerResult match {
             case Some(r) =>
-              if (q.isEmpty) inner.remainder.mapResult(s => r -> s)
-              else Chunk.seq(q.toIndexedSeq).asResult(r).flatMapAccumulate(state)(f).prepend(inner.remainder)
-            case None => outer.remainder.prepend(Chunk.seq(q.toIndexedSeq)).flatMapAccumulate(state)(f).prepend(inner.remainder)
+              if (q.isEmpty) innerRem.mapResult(s => r -> s)
+              else Chunk.seq(q.toIndexedSeq).asResult(r).flatMapAccumulate(state)(f).prepend(innerRem)
+            case None => outer.remainder.prepend(Chunk.seq(q.toIndexedSeq)).flatMapAccumulate(state)(f).prepend(innerRem)
           }
         } {
           if (inner eq null) {


### PR DESCRIPTION
…lat mapping segment - for inner to be referenced when null.  This fix was suggested by @mpilquist to plug this hole.   I could not derive a minimized test that consistently causes this to occur, though using this as a pipe with sufficiently high traffiked input stream and sufficiently small rate duration (e.g., 1 or 2 millisecond) causes it to intermittently occur in tests: https://github.com/scodec/scodec-protocols/blob/series/1.1.x/src/main/scala/scodec/protocols/time/TimeStamped.scala#L104