### PR TITLE
[0.9] Suspend deflated streams so they are pure

### DIFF
--- a/core/jvm/src/main/scala/fs2/compress.scala
+++ b/core/jvm/src/main/scala/fs2/compress.scala
@@ -22,12 +22,12 @@ object compress {
               bufferSize: Int = 1024 * 32,
               strategy: Int = Deflater.DEFAULT_STRATEGY): Pipe[F,Byte,Byte] = {
     val pure: Pipe[Pure,Byte,Byte] =
-      _ pull {
+      in => Stream.suspend(in pull {
         val deflater = new Deflater(level, nowrap)
         deflater.setStrategy(strategy)
         val buffer = new Array[Byte](bufferSize)
         _deflate_handle(deflater, buffer)
-      }
+      })
     pipe.covary[F,Byte,Byte](pure)
   }
   private def _deflate_step(deflater: Deflater, buffer: Array[Byte]): ((Chunk[Byte], Handle[Pure, Byte])) => Pull[Pure, Byte, Handle[Pure, Byte]] = {

--- a/core/jvm/src/test/scala/fs2/CompressSpec.scala
+++ b/core/jvm/src/test/scala/fs2/CompressSpec.scala
@@ -77,5 +77,13 @@ class CompressSpec extends Fs2Spec {
 
       compressed.length should be < uncompressed.length
     }
+
+    "inflate and deflate are pure" in forAll { (s: PureStream[Byte]) =>
+      // We need to deflate to inflate an arbitrary stream, so the two
+      // pipes are tested together.  We want to be sure the underlying
+      // {in,de}flater is not closed.
+      val p = s.get.through(compress.deflate()).through(compress.inflate())
+      p.toVector shouldBe p.toVector
+    }
   }
 }


### PR DESCRIPTION
Without this, a deflated stream fails on second run because the deflater has been closed.  This is similar to the behavior in 0.10, where the pull is suspended.