### PR TITLE
Add setSync to `Async.Ref`

### DIFF
--- a/core/jvm/src/test/scala/fs2/TaskSpec.scala
+++ b/core/jvm/src/test/scala/fs2/TaskSpec.scala
@@ -31,6 +31,18 @@ class TaskSpec extends Fs2Spec{
           }
         }.unsafeRun() shouldBe false
       }
+
+      "set sync should be synchronous" in forAll { (x: Int, y: Int) =>
+        val failOnError: fs2.util.Attempt[Unit] => Unit = {
+          case Left(err) => fail(err)
+          case Right(()) => ()
+        }
+        Task.ref[Int].flatMap { ref =>
+          ref.setSyncPure(x).unsafeRunAsync(failOnError)
+          ref.setSyncPure(y).unsafeRunAsync(failOnError)
+          ref.get
+        }.unsafeRun() shouldBe y
+      }
     }
 
     "fromAttempt" - {

--- a/core/shared/src/main/scala/fs2/Task.scala
+++ b/core/shared/src/main/scala/fs2/Task.scala
@@ -342,6 +342,9 @@ object Task extends TaskPlatform with TaskInstances {
     def set(t: Task[A]): Task[Unit] =
       Task.delay { S { t.unsafeRunAsync { r => actor ! Msg.Set(r) } }}
 
+    def setSync(t: Task[A]): Task[Unit] =
+      Task.delay { t.unsafeRunAsync { r => actor ! Msg.Set(r) }}
+
     private def getStamped(msg: MsgId): Task[(A,Long)] =
       Task.unforkedAsync[(A,Long)] { cb => actor ! Msg.Read(cb, msg) }
 

--- a/core/shared/src/main/scala/fs2/util/Async.scala
+++ b/core/shared/src/main/scala/fs2/util/Async.scala
@@ -129,6 +129,18 @@ object Async {
      * Satisfies: `r.setPure(a) flatMap { _ => r.get(a) } == pure(a)`.
      */
     def setPure(a: A): F[Unit] = set(F.pure(a))
+
+    /**
+      * Synchronously sets a reference.
+      * 
+      */
+    def setSync(a: F[A]): F[Unit]
+
+    /**
+      * Synchronously sets a reference to a pure value.
+      * 
+      */
+    def setSyncPure(a: A): F[Unit] = setSync(F.pure(a))
   }
 
   /**

--- a/core/shared/src/main/scala/fs2/util/Async.scala
+++ b/core/shared/src/main/scala/fs2/util/Async.scala
@@ -129,18 +129,6 @@ object Async {
      * Satisfies: `r.setPure(a) flatMap { _ => r.get(a) } == pure(a)`.
      */
     def setPure(a: A): F[Unit] = set(F.pure(a))
-
-    /**
-      * Synchronously sets a reference.
-      * 
-      */
-    def setSync(a: F[A]): F[Unit]
-
-    /**
-      * Synchronously sets a reference to a pure value.
-      * 
-      */
-    def setSyncPure(a: A): F[Unit] = setSync(F.pure(a))
   }
 
   /**


### PR DESCRIPTION
Adds `setSync` and `setSyncPure` methods to `Async.Ref`, as discussed in #923 .