### PR TITLE
Avoids creating a new array in chunk if chunk is already a Chunk.Byte…

### DIFF
--- a/io/src/main/scala/fs2/io/udp/AsynchronousSocketGroup.scala
+++ b/io/src/main/scala/fs2/io/udp/AsynchronousSocketGroup.scala
@@ -217,7 +217,7 @@ object AsynchronousSocketGroup {
 
     private def write1(key: SelectionKey, channel: DatagramChannel, attachment: Attachment, p: Packet, cb: Option[Throwable] => Unit): Boolean = {
       try {
-        val sent = channel.send(ByteBuffer.wrap(p.bytes.toArray), p.remote)
+        val sent = channel.send(ByteBuffer.wrap(p.bytes.toBytes.values), p.remote)
         if (sent > 0) {
           cb(None)
           true


### PR DESCRIPTION
…s - which can be expensive depending on the size of the array and behavior of map strict in the chunk implementation, since the chunk.toArray is invoked on the selector thread.