### PR TITLE
Segment over Chunk for Stream Emits

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1186,7 +1186,7 @@ object Stream {
   def emits[O](os: Seq[O]): Stream[Pure,O] = {
     if (os.isEmpty) empty
     else if (os.size == 1) emit(os.head)
-    else fromFreeC(Algebra.output[Pure,O](Chunk.seq(os)))
+    else fromFreeC(Algebra.output[Pure,O](Segment.seq(os)))
   }
 
   private[fs2] val empty_ = fromFreeC[Nothing,Nothing](Algebra.pure[Nothing,Nothing,Unit](())): Stream[Nothing,Nothing]


### PR DESCRIPTION
While [Algebra takes a Segment](https://github.com/functional-streams-for-scala/fs2/blob/series/0.10/core/shared/src/main/scala/fs2/internal/Algebra.scala#L19) and I'm sure many of us have been told to use Segment for anything that does not require index based access. However [`Stream.emits`](https://github.com/functional-streams-for-scala/fs2/blob/series/0.10/core/shared/src/main/scala/fs2/Stream.scala#L1189) uses `Chunk.seq`.

In order to help I build it out of Segment, to later realize [`Segment.seq`](https://github.com/functional-streams-for-scala/fs2/blob/series/0.10/core/shared/src/main/scala/fs2/Segment.scala#L1235) uses [`Chunk.seq`](https://github.com/functional-streams-for-scala/fs2/blob/series/0.10/core/shared/src/main/scala/fs2/Chunk.scala#L246) which uses [`Chunk.indexedSeq`](https://github.com/functional-streams-for-scala/fs2/blob/series/0.10/core/shared/src/main/scala/fs2/Chunk.scala#L237) which is definitely designed for index based access. 

Is this intended and what should be the preferred invocation, both internally and for a user.