### PR TITLE
Fix an issue in `Chunk#toBytes`

### DIFF
--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -82,15 +82,11 @@ abstract class Chunk[+O] extends Segment[O,Unit] { self =>
 
   /**
    * Converts this chunk to a `Chunk.Bytes`, allowing access to the underlying array of elements.
-   * If this chunk is already backed by an unboxed array of bytes, this method runs in constant time.
-   * Otherwise, this method will copy of the elements of this chunk in to a single array.
+   * This method will copy of the elements of this chunk (up to size) in to a single array.
    */
   def toBytes[B >: O](implicit ev: B =:= Byte): Chunk.Bytes = {
     val _ = ev // Convince scalac that ev is used
-    this match {
-      case c: Chunk.Bytes => c
-      case other => Chunk.Bytes(this.asInstanceOf[Chunk[Byte]].toArray, 0, size)
-    }
+    Chunk.Bytes(this.asInstanceOf[Chunk[Byte]].toArray, 0, size)
   }
 
   /**


### PR DESCRIPTION
Fixes an issue where too many bytes are returned from `Chunk#toBytes`, when a `Chunk.Bytes` has a `length` less than the backing array.

This may not be the most elegant, efficient or even correct way to fix this, but it certainly causes the test case that I have added to pass, where it previously failed.