### PR TITLE
Fixed issue where translate after translateSync should restore any UnconsAsync steps

### DIFF
--- a/core/jvm/src/test/scala/fs2/StreamSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamSpec.scala
@@ -109,6 +109,10 @@ class StreamSpec extends Fs2Spec with Inside {
       runLog(s.get.translateSync(cats.arrow.FunctionK.id[Pure]).covary[IO]) shouldBe runLog(s.get)
     }
 
+    "translateSync followed by translate" in forAll { (s: PureStream[Int]) =>
+      runLog(s.get.covary[IO].prefetch.translateSync(cats.arrow.FunctionK.id).translate(cats.arrow.FunctionK.id).covary[IO]) shouldBe runLog(s.get)
+    }
+
     "toList" in forAll { (s: PureStream[Int]) =>
       s.get.toList shouldBe runLog(s.get).toList
     }

--- a/core/shared/src/main/scala/fs2/internal/Algebra.scala
+++ b/core/shared/src/main/scala/fs2/internal/Algebra.scala
@@ -23,6 +23,8 @@ private[fs2] object Algebra {
   final case class Release[F[_],O](token: Token) extends Algebra[F,O,Unit]
   final case class UnconsAsync[F[_],X,Y,O](s: FreeC[Algebra[F,O,?],Unit], effect: Effect[F], ec: ExecutionContext)
     extends Algebra[F,X,AsyncPull[F,Option[(Segment[O,Unit],FreeC[Algebra[F,O,?],Unit])]]]
+  final case class UnconsAsyncDeferred[F[_],G[_],X,Y,O](s: FreeC[Algebra[G,O,?],Unit], gToF: G ~> F, ec: ExecutionContext)
+    extends Algebra[F,X,AsyncPull[F,Option[(Segment[O,Unit],FreeC[Algebra[F,O,?],Unit])]]]
   final case class OpenScope[F[_],O]() extends Algebra[F,O,(Scope[F],Scope[F])]
   final case class CloseScope[F[_],O](toClose: Scope[F], scopeAfterClose: Scope[F]) extends Algebra[F,O,Unit]
   final case class Suspend[F[_],O,R](thunk: () => FreeC[Algebra[F,O,?],R]) extends Algebra[F,O,R]
@@ -287,6 +289,9 @@ private[fs2] object Algebra {
               }
               F.flatMap(asyncPull) { ap => go(scope, asyncSupport, acc, f(Right(ap)).viewL) }
 
+            case deferred: Algebra.UnconsAsyncDeferred[_,_,_,_,_] =>
+              F.raiseError(new IllegalStateException("unconsAsync encountered but stream was translated via translateSync - try translating again via translate before running"))
+
             case s: Algebra.Suspend[F2,O,_] =>
               F.suspend {
                 try go(scope, asyncSupport, acc, FreeC.Bind(s.thunk(), f).viewL)
@@ -315,8 +320,14 @@ private[fs2] object Algebra {
         case ua: UnconsAsync[F,_,_,_] =>
           val uu: UnconsAsync[F2,Any,Any,Any] = ua.asInstanceOf[UnconsAsync[F2,Any,Any,Any]]
           G match {
-            case None => Algebra.Eval(u(uu.effect.raiseError[X](new IllegalStateException("unconsAsync encountered while translating synchronously"))))
+            case None => UnconsAsyncDeferred(uu.s, u, uu.ec).asInstanceOf[Algebra[G,O2,X]]
             case Some(ef) => UnconsAsync(uu.s.translate[Algebra[G,Any,?]](algFtoG), ef, uu.ec).asInstanceOf[Algebra[G,O2,X]]
+          }
+        case ua: UnconsAsyncDeferred[_,_,_,_,_] =>
+          val uu: UnconsAsyncDeferred[F2,Any,Any,Any,Any] = ua.asInstanceOf[UnconsAsyncDeferred[F2,Any,Any,Any,Any]]
+          G match {
+            case None => UnconsAsyncDeferred[G,Any,Any,Any,Any](uu.s, uu.gToF andThen u, uu.ec).asInstanceOf[Algebra[G,O2,X]]
+            case Some(ef) => UnconsAsync[G,Any,Any,Any](translate[Any,G,Any,Unit](uu.s, uu.gToF andThen u, G), ef, uu.ec).asInstanceOf[Algebra[G,O2,X]]
           }
         case s: Suspend[F,O2,X] => Suspend(() => s.thunk().translate(algFtoG))
       }


### PR DESCRIPTION
This came up in a discussion with @tpolecat on Gitter today. Example use case is translating from `IO` to some free algebra that doesn't have an `Effect` instance via `translateSync` and then at the end of the program, translating back to `IO` via `translate`.

Prior to this PR, any `UnconsAsync` steps in the program (e.g., those arising from `unconsAsync`, `merge`) were replaced with an `Eval(F.raiseError(new IllegalStateException(...)))`. In this PR, I introduced a new `UnconsAsyncDeferred` constructor which acts as a sort of higher kinded `Coyoneda`. When calling `translate` later, any `UnconsAsyncDeferred` steps are rewritten to `UnconsAsync` steps using the captured `Effect` instance.

I have a more drastic idea on how to fix this, where we no longer capture the `Effect` instance on `unconsAsync`, `merge`, etc. and instead, the instance is provided at the edge of the program on calls to `run`, `runFold`, etc. This will mean changing these functions to take an `Effect[F]` instead of `Sync[F]` but I plan to add alternatives like `runSync`, `runFoldSync`, and so on which require only a `Sync` instance. I'll do this as a separate PR if it works out.