### PR TITLE
Changed UnconsAsync so that it does not capture Effect[F] instance, resulting in proper translate signature

### DIFF
--- a/core/jvm/src/test/scala/fs2/StreamSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamSpec.scala
@@ -100,17 +100,9 @@ class StreamSpec extends Fs2Spec with Inside {
         IndexedSeq.range(0, 100)
     }
 
-    "translate (1)" in forAll { (s: PureStream[Int]) =>
+    "translate" in forAll { (s: PureStream[Int]) =>
       runLog(s.get.flatMap(i => Stream.eval(IO.pure(i))).translate(cats.arrow.FunctionK.id[IO])) shouldBe
       runLog(s.get)
-    }
-
-    "translate (2)" in forAll { (s: PureStream[Int]) =>
-      runLog(s.get.translateSync(cats.arrow.FunctionK.id[Pure]).covary[IO]) shouldBe runLog(s.get)
-    }
-
-    "translateSync followed by translate" in forAll { (s: PureStream[Int]) =>
-      runLog(s.get.covary[IO].prefetch.translateSync(cats.arrow.FunctionK.id).translate(cats.arrow.FunctionK.id).covary[IO]) shouldBe runLog(s.get)
     }
 
     "toList" in forAll { (s: PureStream[Int]) =>

--- a/core/shared/src/main/scala/fs2/Pipe.scala
+++ b/core/shared/src/main/scala/fs2/Pipe.scala
@@ -24,10 +24,14 @@ object Pipe {
 
     // Steps `s` without overhead of resource tracking
     def stepf(s: Stream[Read,O]): Read[UO] = {
-      Algebra.runFold_(Algebra.uncons(s.get).flatMap {
-        case Some((hd,tl)) => Algebra.output1[Read,UO](Some((hd,Stream.fromFreeC(tl))))
-        case None => Algebra.pure[Read,UO,Unit](())
-      }, None, None: UO)((x,y) => y, new Algebra.Scope[Read](None))
+      Algebra.runFoldScope(
+        Algebra.Scope.newRoot[Read],
+        None,
+        None,
+        Algebra.uncons(s.get).flatMap {
+          case Some((hd,tl)) => Algebra.output1[Read,UO](Some((hd,Stream.fromFreeC(tl))))
+          case None => Algebra.pure[Read,UO,Unit](())
+        }, None: UO)((x,y) => y)
     }
 
     def go(s: Read[UO]): Stepper[I,O] = Stepper.Suspend { () =>

--- a/core/shared/src/main/scala/fs2/Pipe2.scala
+++ b/core/shared/src/main/scala/fs2/Pipe2.scala
@@ -20,10 +20,14 @@ object Pipe2 {
 
     // Steps `s` without overhead of resource tracking
     def stepf(s: Stream[Read,O]): Read[UO] = {
-      Algebra.runFold_(Algebra.uncons(s.get).flatMap {
-        case Some((hd,tl)) => Algebra.output1[Read,UO](Some((hd,Stream.fromFreeC(tl))))
-        case None => Algebra.pure[Read,UO,Unit](())
-      }, None, None: UO)((x,y) => y, new Algebra.Scope[Read](None))
+      Algebra.runFoldScope(
+        Algebra.Scope.newRoot[Read],
+        None,
+        None,
+        Algebra.uncons(s.get).flatMap {
+          case Some((hd,tl)) => Algebra.output1[Read,UO](Some((hd,Stream.fromFreeC(tl))))
+          case None => Algebra.pure[Read,UO,Unit](())
+        }, None: UO)((x,y) => y)
     }
 
     def go(s: Read[UO]): Stepper[I,I2,O] = Stepper.Suspend { () =>

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1962,7 +1962,7 @@ object Stream {
      * Behaves like `identity`, but starts fetching the next segment before emitting the current,
      * enabling processing on either side of the `prefetch` to run in parallel.
      */
-    def prefetch(implicit F: Effect[F], ec: ExecutionContext): Stream[F,O] =
+    def prefetch(implicit ec: ExecutionContext): Stream[F,O] =
       self repeatPull { _.uncons.flatMap {
         case None => Pull.pure(None)
         case Some((hd, tl)) => tl.pull.prefetch flatMap { p => Pull.output(hd) >> p }
@@ -2000,9 +2000,19 @@ object Stream {
      * When this method has returned, the stream has not begun execution -- this method simply
      * compiles the stream down to the target effect type.
      *
-     * To call this method, a `Sync[F]` instance must be implicitly available.
+     * To call this method, an `Effect[F]` instance must be implicitly available. If there's no
+     * `Effect` instance for `F`, consider using [[runSync]] instead, which only requires a
+     * `Sync[F]`.
      */
-    def run(implicit F: Sync[F]): F[Unit] =
+    def run(implicit F: Effect[F]): F[Unit] =
+      runFold(())((u, _) => u)
+
+    /**
+     * Like [[run]] but only requires a `Sync` instance instead of an `Effect` instance.
+     * If an `unconsAsync` step is encountered while running the stream, an `IllegalStateException`
+     * is raised in `F`.
+     */
+    def runSync(implicit F: Effect[F]): F[Unit] =
       runFold(())((u, _) => u)
 
     /**
@@ -2013,10 +2023,20 @@ object Stream {
      * When this method has returned, the stream has not begun execution -- this method simply
      * compiles the stream down to the target effect type.
      *
-     * To call this method, a `Sync[F]` instance must be implicitly available.
+     * To call this method, an `Effect[F]` instance must be implicitly available. If there's no
+     * `Effect` instance for `F`, consider using [[runFoldSync]] instead, which only requires a
+     * `Sync[F]`.
      */
-    def runFold[B](init: B)(f: (B, O) => B)(implicit F: Sync[F]): F[B] =
-      Algebra.runFold(self.get, init)(f)
+    def runFold[B](init: B)(f: (B, O) => B)(implicit F: Effect[F]): F[B] =
+      Algebra.runFoldEffect(self.get, init)(f)
+
+    /**
+     * Like [[runFold]] but only requires a `Sync` instance instead of an `Effect` instance.
+     * If an `unconsAsync` step is encountered while running the stream, an `IllegalStateException`
+     * is raised in `F`.
+     */
+    def runFoldSync[B](init: B)(f: (B, O) => B)(implicit F: Sync[F]): F[B] =
+      Algebra.runFoldSync(self.get, init)(f)
 
     /**
      * Like [[runFold]] but uses the implicitly available `Monoid[O]` to combine elements.
@@ -2027,8 +2047,16 @@ object Stream {
      * res0: Int = 15
      * }}}
      */
-    def runFoldMonoid(implicit F: Sync[F], O: Monoid[O]): F[O] =
+    def runFoldMonoid(implicit F: Effect[F], O: Monoid[O]): F[O] =
       runFold(O.empty)(O.combine)
+
+    /**
+     * Like [[runFoldMonoid]] but only requires a `Sync` instance instead of an `Effect` instance.
+     * If an `unconsAsync` step is encountered while running the stream, an `IllegalStateException`
+     * is raised in `F`.
+     */
+    def runFoldMonoidSync(implicit F: Sync[F], O: Monoid[O]): F[O] =
+      runFoldSync(O.empty)(O.combine)
 
     /**
      * Like [[runFold]] but uses the implicitly available `Semigroup[O]` to combine elements.
@@ -2042,8 +2070,16 @@ object Stream {
      * res1: Option[Int] = None
      * }}}
      */
-    def runFoldSemigroup(implicit F: Sync[F], O: Semigroup[O]): F[Option[O]] =
+    def runFoldSemigroup(implicit F: Effect[F], O: Semigroup[O]): F[Option[O]] =
       runFold(Option.empty[O])((acc, o) => acc.map(O.combine(_, o)).orElse(Some(o)))
+
+    /**
+     * Like [[runFoldSemigroup]] but only requires a `Sync` instance instead of an `Effect` instance.
+     * If an `unconsAsync` step is encountered while running the stream, an `IllegalStateException`
+     * is raised in `F`.
+     */
+    def runFoldSemigroupSync(implicit F: Sync[F], O: Monoid[O]): F[Option[O]] =
+      runFoldSync(Option.empty[O])((acc, o) => acc.map(O.combine(_, o)).orElse(Some(o)))
 
     /**
      * Interprets this stream in to a value of the target effect type `F` by logging
@@ -2060,9 +2096,19 @@ object Stream {
      * res0: Vector[Int] = Vector(0, 1, 2, 3, 4)
      * }}}
      */
-    def runLog(implicit F: Sync[F]): F[Vector[O]] = {
+    def runLog(implicit F: Effect[F]): F[Vector[O]] = {
       import scala.collection.immutable.VectorBuilder
       F.suspend(F.map(runFold(new VectorBuilder[O])(_ += _))(_.result))
+    }
+
+    /**
+     * Like [[runLog]] but only requires a `Sync` instance instead of an `Effect` instance.
+     * If an `unconsAsync` step is encountered while running the stream, an `IllegalStateException`
+     * is raised in `F`.
+     */
+    def runLogSync(implicit F: Sync[F]): F[Vector[O]] = {
+      import scala.collection.immutable.VectorBuilder
+      F.suspend(F.map(runFoldSync(new VectorBuilder[O])(_ += _))(_.result))
     }
 
     /**
@@ -2081,8 +2127,16 @@ object Stream {
      * res0: Option[Int] = Some(4)
      * }}}
      */
-    def runLast(implicit F: Sync[F]): F[Option[O]] =
+    def runLast(implicit F: Effect[F]): F[Option[O]] =
       self.runFold(Option.empty[O])((_, a) => Some(a))
+
+    /**
+     * Like [[runLast]] but only requires a `Sync` instance instead of an `Effect` instance.
+     * If an `unconsAsync` step is encountered while running the stream, an `IllegalStateException`
+     * is raised in `F`.
+     */
+    def runLastSync(implicit F: Sync[F]): F[Option[O]] =
+      self.runFoldSync(Option.empty[O])((_, a) => Some(a))
 
     /**
      * Like `scan` but `f` is applied to each segment of the source stream.
@@ -2151,23 +2205,10 @@ object Stream {
     def to(f: Sink[F,O]): Stream[F,Unit] = f(self)
 
     /**
-     * Translates effect type from `F` to `G` using the supplied `FunctionK` and using
-     * the supplied `Effect[G]` for any `unconsAsync` steps encountered.
-     */
-    def translate[G[_]](u: F ~> G)(implicit G: Effect[G]): Stream[G,O] =
-      translate_(u, Some(G))
-
-    /**
      * Translates effect type from `F` to `G` using the supplied `FunctionK`.
-     * If any `unconsAsync` steps are encountered, an error is raised in the resulting
-     * stream. To translate such streams successfully, use [[translate]] instead and
-     * provide an `Effect[G]` instance.
      */
-    def translateSync[G[_]](u: F ~> G): Stream[G,O] =
-      translate_(u, None)
-
-    private def translate_[G[_]](u: F ~> G, G: Option[Effect[G]]): Stream[G,O] =
-      Stream.fromFreeC[G,O](Algebra.translate[F,G,O,Unit](self.get, u, G))
+    def translate[G[_]](u: F ~> G): Stream[G,O] =
+      Stream.fromFreeC[G,O](Algebra.translate[F,G,O,Unit](self.get, u))
 
     private type ZipWithCont[G[_],I,O2,R] = Either[(Segment[I,Unit], Stream[G,I]), Stream[G,I]] => Pull[G,O2,Option[R]]
 
@@ -2422,8 +2463,8 @@ object Stream {
      * For example, `merge` is implemented by calling `unconsAsync` on each stream, racing the
      * resultant `AsyncPull`s, emitting winner of the race, and then repeating.
      */
-    def unconsAsync(implicit F: Effect[F], ec: ExecutionContext): Pull[F,Nothing,AsyncPull[F,Option[(Segment[O,Unit], Stream[F,O])]]] =
-      Pull.fromFreeC(Algebra.unconsAsync(self.get)).map(_.map(_.map { case (hd, tl) => (hd, Stream.fromFreeC(tl)) }))
+    def unconsAsync(implicit ec: ExecutionContext): Pull[F,Nothing,AsyncPull[F,Option[(Segment[O,Unit], Stream[F,O])]]] =
+      Pull.fromFreeC(Algebra.unconsAsync(self.get, ec)).map(_.map(_.map { case (hd, tl) => (hd, Stream.fromFreeC(tl)) }))
 
     /**
      * Like [[uncons]], but returns a segment of no more than `n` elements.
@@ -2588,7 +2629,7 @@ object Stream {
      * Like [[uncons]], but runs the `uncons` asynchronously. A `flatMap` into
      * inner `Pull` logically blocks until this await completes.
      */
-    def prefetch(implicit F: Effect[F], ec: ExecutionContext): Pull[F,Nothing,Pull[F,Nothing,Option[Stream[F,O]]]] =
+    def prefetch(implicit ec: ExecutionContext): Pull[F,Nothing,Pull[F,Nothing,Option[Stream[F,O]]]] =
       unconsAsync.map { _.pull.map { _.map { case (hd, h) => h cons hd } } }
 
     /**

--- a/core/shared/src/main/scala/fs2/internal/Algebra.scala
+++ b/core/shared/src/main/scala/fs2/internal/Algebra.scala
@@ -4,6 +4,7 @@ import scala.collection.mutable.LinkedHashMap
 import scala.concurrent.ExecutionContext
 import cats.~>
 import cats.effect.{ Effect, IO, Sync }
+import cats.implicits._
 
 import fs2.{ AsyncPull, Catenable, Segment }
 import fs2.async
@@ -21,9 +22,7 @@ private[fs2] object Algebra {
   final case class Eval[F[_],O,R](value: F[R]) extends Algebra[F,O,R]
   final case class Acquire[F[_],O,R](resource: F[R], release: R => F[Unit]) extends Algebra[F,O,(R,Token)]
   final case class Release[F[_],O](token: Token) extends Algebra[F,O,Unit]
-  final case class UnconsAsync[F[_],X,Y,O](s: FreeC[Algebra[F,O,?],Unit], effect: Effect[F], ec: ExecutionContext)
-    extends Algebra[F,X,AsyncPull[F,Option[(Segment[O,Unit],FreeC[Algebra[F,O,?],Unit])]]]
-  final case class UnconsAsyncDeferred[F[_],G[_],X,Y,O](s: FreeC[Algebra[G,O,?],Unit], gToF: G ~> F, ec: ExecutionContext)
+  final case class UnconsAsync[F[_],X,Y,O](s: FreeC[Algebra[F,O,?],Unit], ec: ExecutionContext)
     extends Algebra[F,X,AsyncPull[F,Option[(Segment[O,Unit],FreeC[Algebra[F,O,?],Unit])]]]
   final case class OpenScope[F[_],O]() extends Algebra[F,O,Scope[F]]
   final case class CloseScope[F[_],O](toClose: Scope[F]) extends Algebra[F,O,Unit]
@@ -47,8 +46,8 @@ private[fs2] object Algebra {
   def release[F[_],O](token: Token): FreeC[Algebra[F,O,?],Unit] =
     FreeC.Eval[Algebra[F,O,?],Unit](Release(token))
 
-  def unconsAsync[F[_],X,Y,O](s: FreeC[Algebra[F,O,?],Unit])(implicit F: Effect[F], ec: ExecutionContext): FreeC[Algebra[F,X,?],AsyncPull[F,Option[(Segment[O,Unit], FreeC[Algebra[F,O,?],Unit])]]] =
-    FreeC.Eval[Algebra[F,X,?],AsyncPull[F,Option[(Segment[O,Unit],FreeC[Algebra[F,O,?],Unit])]]](UnconsAsync(s, F, ec))
+  def unconsAsync[F[_],X,Y,O](s: FreeC[Algebra[F,O,?],Unit], ec: ExecutionContext): FreeC[Algebra[F,X,?],AsyncPull[F,Option[(Segment[O,Unit], FreeC[Algebra[F,O,?],Unit])]]] =
+    FreeC.Eval[Algebra[F,X,?],AsyncPull[F,Option[(Segment[O,Unit],FreeC[Algebra[F,O,?],Unit])]]](UnconsAsync(s, ec))
 
   private def openScope[F[_],O]: FreeC[Algebra[F,O,?],Scope[F]] =
     FreeC.Eval[Algebra[F,O,?],Scope[F]](OpenScope())
@@ -73,7 +72,7 @@ private[fs2] object Algebra {
   def suspend[F[_],O,R](f: => FreeC[Algebra[F,O,?],R]): FreeC[Algebra[F,O,?],R] =
     FreeC.Eval[Algebra[F,O,?],R](Suspend(() => f))
 
-  final class Scope[F[_]](private val parent: Option[Scope[F]])(implicit F: Sync[F]) {
+  final class Scope[F[_]] private (private val parent: Option[Scope[F]])(implicit F: Sync[F]) {
     private val monitor = this
     private var closing: Boolean = false
     private var closed: Boolean = false
@@ -184,6 +183,10 @@ private[fs2] object Algebra {
     override def toString: String = ##.toString
   }
 
+  object Scope {
+    def newRoot[F[_]: Sync]: Scope[F] = new Scope[F](None)
+  }
+
   def uncons[F[_],X,O](s: FreeC[Algebra[F,O,?],Unit], chunkSize: Int = 1024): FreeC[Algebra[F,X,?],Option[(Segment[O,Unit], FreeC[Algebra[F,O,?],Unit])]] = {
     s.viewL.get match {
       case done: FreeC.Pure[Algebra[F,O,?], Unit] => pure(None)
@@ -218,115 +221,120 @@ private[fs2] object Algebra {
     }
   }
 
-  /** Left-fold the output of a stream. */
-  def runFold[F2[_],O,B](stream: FreeC[Algebra[F2,O,?],Unit], init: B)(f: (B, O) => B)(implicit F: Sync[F2]): F2[B] =
-    F.flatMap(F.delay(new Scope[F2](None))) { scope =>
-      F.flatMap(F.attempt(runFold_(stream, None, init)(f, scope))) {
-        case Left(t) => F.flatMap(scope.close(None))(_ => F.raiseError(t))
-        case Right(b) => F.flatMap(scope.close(None))(_ => F.pure(b))
+  /** Left-fold the output of a stream, supporting unconsAsync steps. */
+  def runFoldEffect[F[_],O,B](stream: FreeC[Algebra[F,O,?],Unit], init: B)(f: (B, O) => B)(implicit F: Effect[F]): F[B] =
+    runFold(stream, Some(F), init)(f)
+
+  /** Left-fold the output of a stream, not supporting unconsAsync steps. */
+  def runFoldSync[F[_],O,B](stream: FreeC[Algebra[F,O,?],Unit], init: B)(f: (B, O) => B)(implicit F: Sync[F]): F[B] =
+    runFold(stream, None, init)(f)
+
+  private def runFold[F[_],O,B](stream: FreeC[Algebra[F,O,?],Unit], effect: Option[Effect[F]], init: B)(f: (B, O) => B)(implicit F: Sync[F]): F[B] =
+    F.delay(Scope.newRoot).flatMap { scope =>
+      runFoldScope[F,O,B](scope, effect, None, stream, init)(f).attempt.flatMap {
+        case Left(t) => scope.close(None) *> F.raiseError(t)
+        case Right(b) => scope.close(None).as(b)
       }
     }
 
-  def runFold_[F2[_],O,B](stream: FreeC[Algebra[F2,O,?],Unit], asyncSupport: Option[(Effect[F2],ExecutionContext)], init: B)(
-      g: (B, O) => B, scope: Scope[F2])(implicit F: Sync[F2]): F2[B] = {
-    type AlgebraF[x] = Algebra[F,O,x]
-    type F[x] = F2[x] // scala bug, if don't put this here, inner function thinks `F` has kind *
-    def go(scope: Scope[F], asyncSupport: Option[(Effect[F],ExecutionContext)], acc: B, v: FreeC.ViewL[AlgebraF, Option[(Segment[O,Unit], FreeC[Algebra[F,O,?],Unit])]]): F[B] = {
-      v.get match {
-        case done: FreeC.Pure[AlgebraF, Option[(Segment[O,Unit], FreeC[Algebra[F,O,?],Unit])]] => done.r match {
-          case None => F.pure(acc)
-          case Some((hd, tl)) =>
-            F.suspend {
-              try go(scope, asyncSupport, hd.fold(acc)(g).run, uncons(tl).viewL)
-              catch { case NonFatal(e) => go(scope, asyncSupport, acc, uncons(tl.asHandler(e)).viewL) }
-            }
-        }
-        case failed: FreeC.Fail[AlgebraF, _] => F.raiseError(failed.error)
-        case bound: FreeC.Bind[AlgebraF, _, Option[(Segment[O,Unit], FreeC[Algebra[F,O,?],Unit])]] =>
-          val f = bound.f.asInstanceOf[
-            Either[Throwable,Any] => FreeC[AlgebraF, Option[(Segment[O,Unit], FreeC[Algebra[F,O,?],Unit])]]]
-          val fx = bound.fx.asInstanceOf[FreeC.Eval[AlgebraF,_]].fr
-          fx match {
-            case wrap: Algebra.Eval[F, O, _] =>
-              F.flatMap(F.attempt(wrap.value)) { e => go(scope, asyncSupport, acc, f(e).viewL) }
+  private[fs2] def runFoldScope[F[_],O,B](scope: Scope[F], effect: Option[Effect[F]], ec: Option[ExecutionContext], stream: FreeC[Algebra[F,O,?],Unit], init: B)(g: (B, O) => B)(implicit F: Sync[F]): F[B] =
+    runFoldLoop[F,O,B](scope, effect, ec, init, g, uncons(stream).viewL)
 
-            case acquire: Algebra.Acquire[F2,_,_] =>
-              val resource = acquire.resource
-              val release = acquire.release
-              if (scope.beginAcquire) {
-                F.flatMap(F.attempt(resource)) {
-                  case Left(err) =>
-                    scope.cancelAcquire
-                    go(scope, asyncSupport, acc, f(Left(err)).viewL)
-                  case Right(r) =>
-                    val token = new Token()
-                    lazy val finalizer_ = release(r)
-                    val finalizer = F.suspend { finalizer_ }
-                    scope.finishAcquire(token, finalizer)
-                    go(scope, asyncSupport, acc, f(Right((r, token))).viewL)
-                }
-              } else {
-                F.raiseError(Interrupted)
-              }
-
-            case release: Algebra.Release[F2,_] =>
-              scope.releaseResource(release.token) match {
-                case None => F.suspend { go(scope, asyncSupport, acc, f(Right(())).viewL) }
-                case Some(finalizer) => F.flatMap(F.attempt(finalizer)) { e =>
-                  go(scope, asyncSupport, acc, f(e).viewL)
-                }
-              }
-
-            case c: Algebra.CloseScope[F2,_] =>
-              F.flatMap(c.toClose.close(asyncSupport)) { e =>
-                val scopeAfterClose = c.toClose.openAncestor.fold(identity, identity)
-                go(scopeAfterClose, asyncSupport, acc, f(e).viewL)
-              }
-
-            case o: Algebra.OpenScope[F2,_] =>
-              F.suspend {
-                val innerScope = scope.open
-                go(innerScope, asyncSupport, acc, f(Right(innerScope)).viewL)
-              }
-
-            case unconsAsync: Algebra.UnconsAsync[F2,_,_,_] =>
-              val s = unconsAsync.s
-              val effect = unconsAsync.effect
-              val ec = unconsAsync.ec
-              val asyncSupport = Some(effect -> ec)
-              type UO = Option[(Segment[_,Unit], FreeC[Algebra[F,Any,?],Unit])]
-              val asyncPull: F[AsyncPull[F,UO]] = F.flatMap(async.ref[F,Either[Throwable,UO]](effect, ec)) { ref =>
-                F.map(async.fork {
-                  F.flatMap(F.attempt(
-                    runFold_(
-                      uncons(s.asInstanceOf[FreeC[Algebra[F,Any,?],Unit]]).flatMap(output1(_)),
-                      asyncSupport,
-                      None: UO
-                    )((o,a) => a, scope)
-                  )) { o => ref.setAsyncPure(o) }
-                }(effect, ec))(_ => AsyncPull.readAttemptRef(ref))
-              }
-              F.flatMap(asyncPull) { ap => go(scope, asyncSupport, acc, f(Right(ap)).viewL) }
-
-            case deferred: Algebra.UnconsAsyncDeferred[_,_,_,_,_] =>
-              F.raiseError(new IllegalStateException("unconsAsync encountered but stream was translated via translateSync - try translating again via translate before running"))
-
-            case s: Algebra.Suspend[F2,O,_] =>
-              F.suspend {
-                try go(scope, asyncSupport, acc, FreeC.Bind(s.thunk(), f).viewL)
-                catch { case NonFatal(e) => go(scope, asyncSupport, acc, f(Left(e)).viewL) }
-              }
-
-            case _ => sys.error("impossible Segment or Output following uncons")
+  private def runFoldLoop[F[_],O,B](scope: Scope[F], effect: Option[Effect[F]], ec: Option[ExecutionContext], acc: B, g: (B, O) => B, v: FreeC.ViewL[Algebra[F,O,?], Option[(Segment[O,Unit], FreeC[Algebra[F,O,?],Unit])]])(implicit F: Sync[F]): F[B] = {
+    v.get match {
+      case done: FreeC.Pure[Algebra[F,O,?], Option[(Segment[O,Unit], FreeC[Algebra[F,O,?],Unit])]] => done.r match {
+        case None => F.pure(acc)
+        case Some((hd, tl)) =>
+          F.suspend {
+            try runFoldLoop[F,O,B](scope, effect, ec, hd.fold(acc)(g).run, g, uncons(tl).viewL)
+            catch { case NonFatal(e) => runFoldLoop[F,O,B](scope, effect, ec, acc, g, uncons(tl.asHandler(e)).viewL) }
           }
-        case e => sys.error("FreeC.ViewL structure must be Pure(a), Fail(e), or Bind(Eval(fx),k), was: " + e)
       }
+      case failed: FreeC.Fail[Algebra[F,O,?], _] => F.raiseError(failed.error)
+      case bound: FreeC.Bind[Algebra[F,O,?], _, Option[(Segment[O,Unit], FreeC[Algebra[F,O,?],Unit])]] =>
+        val f = bound.f.asInstanceOf[
+          Either[Throwable,Any] => FreeC[Algebra[F,O,?], Option[(Segment[O,Unit], FreeC[Algebra[F,O,?],Unit])]]]
+        val fx = bound.fx.asInstanceOf[FreeC.Eval[Algebra[F,O,?],_]].fr
+        fx match {
+          case wrap: Algebra.Eval[F, O, _] =>
+            F.flatMap(F.attempt(wrap.value)) { e => runFoldLoop(scope, effect, ec, acc, g, f(e).viewL) }
+
+          case acquire: Algebra.Acquire[F,_,_] =>
+            val resource = acquire.resource
+            val release = acquire.release
+            if (scope.beginAcquire) {
+              F.flatMap(F.attempt(resource)) {
+                case Left(err) =>
+                  scope.cancelAcquire
+                  runFoldLoop(scope, effect, ec, acc, g, f(Left(err)).viewL)
+                case Right(r) =>
+                  val token = new Token()
+                  lazy val finalizer_ = release(r)
+                  val finalizer = F.suspend { finalizer_ }
+                  scope.finishAcquire(token, finalizer)
+                  runFoldLoop(scope, effect, ec, acc, g, f(Right((r, token))).viewL)
+              }
+            } else {
+              F.raiseError(Interrupted)
+            }
+
+          case release: Algebra.Release[F,_] =>
+            scope.releaseResource(release.token) match {
+              case None => F.suspend { runFoldLoop(scope, effect, ec, acc, g, f(Right(())).viewL) }
+              case Some(finalizer) => F.flatMap(F.attempt(finalizer)) { e =>
+                runFoldLoop(scope, effect, ec, acc, g, f(e).viewL)
+              }
+            }
+
+          case c: Algebra.CloseScope[F,_] =>
+            F.flatMap(c.toClose.close((effect, ec).tupled)) { e =>
+              val scopeAfterClose = c.toClose.openAncestor.fold(identity, identity)
+              runFoldLoop(scopeAfterClose, effect, ec, acc, g, f(e).viewL)
+            }
+
+          case o: Algebra.OpenScope[F,_] =>
+            F.suspend {
+              val innerScope = scope.open
+              runFoldLoop(innerScope, effect, ec, acc, g, f(Right(innerScope)).viewL)
+            }
+
+          case unconsAsync: Algebra.UnconsAsync[F,_,_,_] =>
+            effect match {
+              case Some(eff) =>
+                val s = unconsAsync.s
+                val ec = unconsAsync.ec
+                type UO = Option[(Segment[_,Unit], FreeC[Algebra[F,Any,?],Unit])]
+                val asyncPull: F[AsyncPull[F,UO]] = F.flatMap(async.ref[F,Either[Throwable,UO]](eff, ec)) { ref =>
+                  F.map(async.fork {
+                    F.flatMap(F.attempt(
+                      runFoldScope(
+                        scope,
+                        effect,
+                        Some(ec),
+                        uncons(s.asInstanceOf[FreeC[Algebra[F,Any,?],Unit]]).flatMap(output1(_)),
+                        None: UO
+                      )((_, snd) => snd)
+                    )) { o => ref.setAsyncPure(o) }
+                  }(eff, ec))(_ => AsyncPull.readAttemptRef(ref))
+                }
+                F.flatMap(asyncPull) { ap => runFoldLoop(scope, effect, Some(ec), acc, g, f(Right(ap)).viewL) }
+              case None =>
+                F.raiseError(new IllegalStateException("unconsAsync encountered but stream was run synchronously"))
+            }
+
+          case s: Algebra.Suspend[F,O,_] =>
+            F.suspend {
+              try runFoldLoop(scope, effect, ec, acc, g, FreeC.Bind(s.thunk(), f).viewL)
+              catch { case NonFatal(e) => runFoldLoop(scope, effect, ec, acc, g, f(Left(e)).viewL) }
+            }
+
+          case _ => sys.error("impossible Segment or Output following uncons")
+        }
+      case e => sys.error("FreeC.ViewL structure must be Pure(a), Fail(e), or Bind(Eval(fx),k), was: " + e)
     }
-    F.suspend { go(scope, asyncSupport, init, uncons(stream).viewL) }
   }
 
-  def translate[F[_],G[_],O,R](fr: FreeC[Algebra[F,O,?],R], u: F ~> G, G: Option[Effect[G]]): FreeC[Algebra[G,O,?],R] = {
-    type F2[x] = F[x] // nb: workaround for scalac kind bug, where in the unconsAsync case, scalac thinks F has kind 0
+  def translate[F[_],G[_],O,R](fr: FreeC[Algebra[F,O,?],R], u: F ~> G): FreeC[Algebra[G,O,?],R] = {
     def algFtoG[O2]: Algebra[F,O2,?] ~> Algebra[G,O2,?] = new (Algebra[F,O2,?] ~> Algebra[G,O2,?]) { self =>
       def apply[X](in: Algebra[F,O2,X]): Algebra[G,O2,X] = in match {
         case o: Output[F,O2] => Output[G,O2](o.values)
@@ -337,17 +345,8 @@ private[fs2] object Algebra {
         case os: OpenScope[F,O2] => os.asInstanceOf[Algebra[G,O2,X]]
         case cs: CloseScope[F,O2] => cs.asInstanceOf[CloseScope[G,O2]]
         case ua: UnconsAsync[F,_,_,_] =>
-          val uu: UnconsAsync[F2,Any,Any,Any] = ua.asInstanceOf[UnconsAsync[F2,Any,Any,Any]]
-          G match {
-            case None => UnconsAsyncDeferred(uu.s, u, uu.ec).asInstanceOf[Algebra[G,O2,X]]
-            case Some(ef) => UnconsAsync(uu.s.translate[Algebra[G,Any,?]](algFtoG), ef, uu.ec).asInstanceOf[Algebra[G,O2,X]]
-          }
-        case ua: UnconsAsyncDeferred[_,_,_,_,_] =>
-          val uu: UnconsAsyncDeferred[F2,Any,Any,Any,Any] = ua.asInstanceOf[UnconsAsyncDeferred[F2,Any,Any,Any,Any]]
-          G match {
-            case None => UnconsAsyncDeferred[G,Any,Any,Any,Any](uu.s, uu.gToF andThen u, uu.ec).asInstanceOf[Algebra[G,O2,X]]
-            case Some(ef) => UnconsAsync[G,Any,Any,Any](translate[Any,G,Any,Unit](uu.s, uu.gToF andThen u, G), ef, uu.ec).asInstanceOf[Algebra[G,O2,X]]
-          }
+          val uu: UnconsAsync[F,Any,Any,Any] = ua.asInstanceOf[UnconsAsync[F,Any,Any,Any]]
+          UnconsAsync(uu.s.translate[Algebra[G,Any,?]](algFtoG), uu.ec).asInstanceOf[Algebra[G,O2,X]]
         case s: Suspend[F,O2,X] => Suspend(() => s.thunk().translate(algFtoG))
       }
     }

--- a/docs/ReadmeExample.md
+++ b/docs/ReadmeExample.md
@@ -98,7 +98,7 @@ There are a number of ways of interpreting the stream. In this case, we call `ru
 
 ```scala
 scala> val task: IO[Unit] = written.run
-task: cats.effect.IO[Unit] = IO$1130771996
+task: cats.effect.IO[Unit] = IO$1426003670
 ```
 
 We still haven't *done* anything yet. Effects only occur when we run the resulting task. We can run a `IO` by calling `unsafeRunSync()` -- the name is telling us that calling it performs effects and hence, it is not referentially transparent.

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -120,7 +120,7 @@ rc.unsafeRunSync()
 
 Here we finally see the tasks being executed. As is shown with `rc`, rerunning a task executes the entire computation again; nothing is cached for you automatically.
 
-_Note:_ The various `run*` functions aren't specialized to `IO` and work for any `F[_]` with an implicit `Sync[F]` --- FS2 needs to know how to catch errors that occur during evaluation of `F` effects and how to suspend computations.
+_Note:_ The various `run*` functions aren't specialized to `IO` and work for any `F[_]` with an implicit `Effect[F]` (or `Sync[F]` for the `run*Sync` functions) --- FS2 needs to know how to catch errors that occur during evaluation of `F` effects, how to suspend computations, and sometimes how to do asynchronous evaluation.
 
 ### Segments & Chunks
 


### PR DESCRIPTION
This is the more ambitious version of the fix for #948.

The `Algebra.UnconsAsync` case no longer captures the `Effect[F]` instance, which means we can have the standard definition of `Stream#translate`. However, running a stream now requires an `Effect[F]` instead of a `Sync[F]`. I provided an alternative for each run function that requires a `Sync[F]` but that fails if an `UnconsAsync` step is encountered.

Overall, the expressiveness of the library is not changed by this PR. Rather, we moved where `Effect` instances are required.

/cc @tpolecat