### PR TITLE
Fixed performance issue in Stream.flatMap exposed by streams like Stream.emits(...).flatMap(Stream(_))

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/StreamBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/StreamBenchmark.scala
@@ -2,7 +2,8 @@ package fs2
 package benchmark
 
 import cats.effect.IO
-import org.openjdk.jmh.annotations.{Benchmark, State, Scope}
+import org.openjdk.jmh.annotations.{Benchmark, BenchmarkMode, Mode, OutputTimeUnit, State, Scope}
+import java.util.concurrent.TimeUnit
 
 @State(Scope.Thread)
 class StreamBenchmark {
@@ -52,5 +53,11 @@ class StreamBenchmark {
         case None => Pull.pure(None)
       }
     }.covary[IO].runLast.unsafeRunSync.get
+  }
+
+  @GenerateN(1, 10, 100, 1000, 10000)
+  @Benchmark @BenchmarkMode(Array(Mode.AverageTime)) @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def emitsThenFlatMap(N: Int): Vector[Int] = {
+    Stream.emits(0 until N).flatMap(Stream(_)).toVector
   }
 }

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -22,14 +22,16 @@ import scala.reflect.ClassTag
 abstract class Chunk[+O] extends Segment[O,Unit] { self =>
 
   private[fs2]
-  def stage0 = (_, _, emit, emits, done) => Eval.now {
+  def stage0 = (_, _, emit, emits, done) => {
     var emitted = false
-    Segment.step(if (emitted) Segment.empty else this) {
-      if (!emitted) {
-        emitted = true
-        emits(this)
+    Eval.now {
+      Segment.step(if (emitted) Segment.empty else this) {
+        if (!emitted) {
+          emitted = true
+          emits(this)
+        }
+        done(())
       }
-      done(())
     }
   }
 

--- a/core/shared/src/main/scala/fs2/Segment.scala
+++ b/core/shared/src/main/scala/fs2/Segment.scala
@@ -417,17 +417,25 @@ abstract class Segment[+O,+R] { self =>
   }
 
   private[fs2] final def foldRightLazy[B](z: B)(f: (O,=>B) => B): B = {
-    unconsChunk match {
-      case Right((hd,tl)) =>
-        val sz = hd.size
-        if (sz == 1) f(hd(0), tl.foldRightLazy(z)(f))
-        else {
-          def go(idx: Int): B = {
-            if (idx < sz) f(hd(idx), go(idx + 1))
-            else tl.foldRightLazy(z)(f)
+    unconsChunks match {
+      case Right((hds,tl)) =>
+        def loop(hds: Catenable[Chunk[O]]): B = {
+          hds.uncons match {
+            case None => tl.foldRightLazy(z)(f)
+            case Some((hd,hds)) =>
+              val sz = hd.size
+              if (sz == 1) f(hd(0), tl.foldRightLazy(z)(f))
+              else {
+                def go(idx: Int): B = {
+                  if (idx < sz) f(hd(idx), go(idx + 1))
+                  else loop(hds)
+                }
+                go(0)
+              }
           }
-          go(0)
         }
+        loop(hds)
+
       case Left(_) => z
     }
   }


### PR DESCRIPTION
Fixes #958.

Before this fix:

```
[info] Benchmark                                   Mode  Cnt           Score   Error  Units
[info] StreamBenchmark.emitsThenFlatMap_1          avgt             2527.329          ns/op
[info] StreamBenchmark.emitsThenFlatMap_10         avgt            34048.764          ns/op
[info] StreamBenchmark.emitsThenFlatMap_100        avgt          1298487.894          ns/op
[info] StreamBenchmark.emitsThenFlatMap_1000       avgt         79365209.923          ns/op
[info] StreamBenchmark.emitsThenFlatMap_10000      avgt       6324507135.000          ns/op
```

After this fix:

```
[info] Benchmark                                   Mode  Cnt        Score   Error  Units
[info] StreamBenchmark.emitsThenFlatMap_1          avgt          2311.262          ns/op
[info] StreamBenchmark.emitsThenFlatMap_10         avgt         10316.613          ns/op
[info] StreamBenchmark.emitsThenFlatMap_100        avgt         76033.740          ns/op
[info] StreamBenchmark.emitsThenFlatMap_1000       avgt        588334.872          ns/op
[info] StreamBenchmark.emitsThenFlatMap_10000      avgt       9377237.551          ns/op
```