### PR TITLE
Fixed memory leak in scope management.

### DIFF
--- a/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
+++ b/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
@@ -123,3 +123,10 @@ object StepperSanityTest2 extends App {
   }
   go(0)(Pipe.stepper(_.map(_ + 1)))
 }
+
+object EvalFlatMapMapTest extends App {
+  Stream.eval(IO(())).
+    flatMap(_ => Stream.emits(Seq())).
+    map(x => x).
+    repeat.run.unsafeRunSync()
+}


### PR DESCRIPTION
When a scope is closed, it should be unregistered from its parent scope
so that it is eligible for GC. This PR implements this by tracking
spawned scopes via a token based LinkedHashMap and upon scope closure,
removing the entry in the parent's map.

Fixes #962.