### PR TITLE
Added test case showing that join/joinUnbounded release resources from outer stream too early

### DIFF
--- a/core/jvm/src/test/scala/fs2/MergeJoinSpec.scala
+++ b/core/jvm/src/test/scala/fs2/MergeJoinSpec.scala
@@ -44,6 +44,15 @@ class MergeJoinSpec extends Fs2Spec {
       runLog { s1.get.flatMap(_.get) }.toSet
     }
 
+    "join - resources acquired in outer stream are released after inner streams complete" in {
+      val bracketed = Stream.bracket(IO(new java.util.concurrent.atomic.AtomicBoolean(true)))(Stream(_), b => IO(b.set(false)))
+      // Starts an inner stream which fails if the resource b is finalized
+      val s: Stream[IO,Stream[IO,Unit]] = bracketed.map { b =>
+        Stream.eval(IO(b.get)).flatMap(b => if (b) Stream(()) else Stream.fail(Err)).repeat.take(10000)
+      }
+      s.joinUnbounded.run.unsafeRunSync()
+    }
+
     "merge (left/right failure)" in forAll { (s1: PureStream[Int], f: Failure) =>
       an[Err.type] should be thrownBy {
         s1.get.merge(f.get).run.unsafeRunSync()

--- a/io/src/test/scala/fs2/io/tcp/SocketSpec.scala
+++ b/io/src/test/scala/fs2/io/tcp/SocketSpec.scala
@@ -38,9 +38,9 @@ class SocketSpec extends Fs2Spec with BeforeAndAfterAll {
         serverWithLocalAddress[IO](new InetSocketAddress(InetAddress.getByName(null), 0)).flatMap {
           case Left(local) => Stream.eval_(localBindAddress.setAsyncPure(local))
           case Right(s) =>
-            Stream.emit(s.flatMap { socket =>
+            s.map { socket =>
               socket.reads(1024).to(socket.writes()).onFinalize(socket.endOfOutput)
-            })
+            }
         }.joinUnbounded
       }
 


### PR DESCRIPTION
See #967 