### PR TITLE
Fixed 2 bugs in scope management

### DIFF
--- a/core/shared/src/main/scala/fs2/internal/Algebra.scala
+++ b/core/shared/src/main/scala/fs2/internal/Algebra.scala
@@ -261,7 +261,7 @@ private[fs2] object Algebra {
       }
     }
 
-    def root: Scope[F] = parent match {
+    @annotation.tailrec def root: Scope[F] = parent match {
       case Some(p) => p.root
       case None => this
     }


### PR DESCRIPTION
Scope#releaseResource only searched the local resources map for a
resource, so if the resource was in a spawn's map or a parent map, the
release was skipped. This masked a bug in the new join import/export
support, which treated explicit resource releases as forced releases,
skipping reference counting.