### PR TITLE
Make Sync instances for Stream and Pull implicit

### DIFF
--- a/core/jvm/src/main/scala/fs2/compress.scala
+++ b/core/jvm/src/main/scala/fs2/compress.scala
@@ -96,7 +96,7 @@ object compress {
     }
   }
   private def _inflate_finish[F[_]](inflater: Inflater): Pull[F, Nothing, Unit] = {
-    if (!inflater.finished) Pull.fail(new DataFormatException("Insufficient data"))
+    if (!inflater.finished) Pull.raiseError(new DataFormatException("Insufficient data"))
     else { inflater.end(); Pull.done }
   }
 }

--- a/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
+++ b/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
@@ -95,7 +95,7 @@ object StepperSanityTest extends App {
     def go(stepper: Stepper[I,O], s: Stream[Pure,I]): Pull[Pure,O,Unit] = {
       stepper.step match {
         case Stepper.Done => Pull.done
-        case Stepper.Fail(err) => Pull.fail(err)
+        case Stepper.Fail(err) => Pull.raiseError(err)
         case Stepper.Emits(segment, next) =>
           Pull.output(segment) *> go(next, s)
         case Stepper.Await(receive) =>

--- a/core/jvm/src/test/scala/fs2/MergeJoinSpec.scala
+++ b/core/jvm/src/test/scala/fs2/MergeJoinSpec.scala
@@ -48,7 +48,7 @@ class MergeJoinSpec extends Fs2Spec {
       val bracketed = Stream.bracket(IO(new java.util.concurrent.atomic.AtomicBoolean(true)))(Stream(_), b => IO(b.set(false)))
       // Starts an inner stream which fails if the resource b is finalized
       val s: Stream[IO,Stream[IO,Unit]] = bracketed.map { b =>
-        Stream.eval(IO(b.get)).flatMap(b => if (b) Stream(()) else Stream.fail(Err)).repeat.take(10000)
+        Stream.eval(IO(b.get)).flatMap(b => if (b) Stream(()) else Stream.raiseError(Err)).repeat.take(10000)
       }
       s.joinUnbounded.run.unsafeRunSync()
     }
@@ -85,7 +85,7 @@ class MergeJoinSpec extends Fs2Spec {
     }
 
     "join - outer-failed" in {
-      an[Err.type] should be thrownBy { runLog(Stream(mkScheduler.flatMap(_.sleep_[IO](1 minute)), Stream.fail(Err).covary[IO]).joinUnbounded) }
+      an[Err.type] should be thrownBy { runLog(Stream(mkScheduler.flatMap(_.sleep_[IO](1 minute)), Stream.raiseError(Err).covary[IO]).joinUnbounded) }
     }
   }
 }

--- a/core/jvm/src/test/scala/fs2/PipeSpec.scala
+++ b/core/jvm/src/test/scala/fs2/PipeSpec.scala
@@ -434,10 +434,10 @@ class PipeSpec extends Fs2Spec {
     "handle errors from observing sink" in {
       forAll { (s: PureStream[Int]) =>
         runLog {
-          s.get.covary[IO].observe { _ => Stream.fail(Err) }.attempt
+          s.get.covary[IO].observe { _ => Stream.raiseError(Err) }.attempt
         } should contain theSameElementsAs Left(Err) +: s.get.toVector.map(Right(_))
         runLog {
-          s.get.covary[IO].observeAsync(2) { _ => Stream.fail(Err) }.attempt
+          s.get.covary[IO].observeAsync(2) { _ => Stream.raiseError(Err) }.attempt
         } should contain theSameElementsAs Left(Err) +: s.get.toVector.map(Right(_))
       }
     }
@@ -484,7 +484,7 @@ class PipeSpec extends Fs2Spec {
           def go(last: Option[A], stepper: Stepper[I,O], s: Stream[Pure,(I,A)]): Pull[Pure,(O,A),Unit] = {
             stepper.step match {
               case Stepper.Done => Pull.done
-              case Stepper.Fail(err) => Pull.fail(err)
+              case Stepper.Fail(err) => Pull.raiseError(err)
               case Stepper.Emits(segment, next) =>
                 last match {
                   case Some(a) => Pull.output(segment.map { o => (o,a) }) *> go(last, next, s)

--- a/core/jvm/src/test/scala/fs2/ResourceSafetySpec.scala
+++ b/core/jvm/src/test/scala/fs2/ResourceSafetySpec.scala
@@ -11,7 +11,7 @@ class ResourceSafetySpec extends Fs2Spec with EventuallySupport {
 
     "pure fail" in {
       an[Err.type] should be thrownBy {
-        Stream.emit(0).flatMap(_ => Stream.fail(Err)).toVector
+        Stream.emit(0).flatMap(_ => Stream.raiseError(Err)).toVector
         ()
       }
     }
@@ -106,8 +106,8 @@ class ResourceSafetySpec extends Fs2Spec with EventuallySupport {
     }
 
     "asynchronous resource allocation (2a)" in forAll { (u: Unit) =>
-      val s1 = Stream.fail(Err)
-      val s2 = Stream.fail(Err)
+      val s1 = Stream.raiseError(Err)
+      val s2 = Stream.raiseError(Err)
       val c = new AtomicLong(0)
       val b1 = bracket(c)(s1)
       val b2 = s2: Stream[IO,Int]

--- a/core/jvm/src/test/scala/fs2/ResourceSafetySpec.scala
+++ b/core/jvm/src/test/scala/fs2/ResourceSafetySpec.scala
@@ -35,7 +35,7 @@ class ResourceSafetySpec extends Fs2Spec with EventuallySupport {
     "1 million brackets in sequence" in {
       val c = new AtomicLong(0)
       val b = bracket(c)(Stream.emit(1))
-      val bs = Stream.range(0, 1000000).flatMap(_ => b)
+      val bs = Stream.range(0, 1000000).covary[IO].flatMap(_ => b)
       runLog { bs }
       c.get shouldBe 0
     }

--- a/core/jvm/src/test/scala/fs2/StreamPerformanceSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamPerformanceSpec.scala
@@ -59,7 +59,7 @@ class StreamPerformanceSpec extends Fs2Spec {
       }
     }}
 
-    "bracket + onError (1)" - { Ns.foreach { N =>
+    "bracket + handleErrorWith (1)" - { Ns.foreach { N =>
       N.toString in {
         val open = new AtomicInteger(0)
         val ok = new AtomicInteger(0)
@@ -67,19 +67,19 @@ class StreamPerformanceSpec extends Fs2Spec {
           _ => emit(1) ++ Stream.fail(FailWhale),
           _ => IO { ok.incrementAndGet; open.decrementAndGet; () }
         )
-        // left-associative onError chains
+        // left-associative handleErrorWith chains
         assert(throws (FailWhale) {
           List.fill(N)(bracketed).foldLeft(Stream.fail(FailWhale): Stream[IO,Int]) {
-            (acc,hd) => acc onError { _ => hd }
+            (acc,hd) => acc handleErrorWith { _ => hd }
           }
         })
         ok.get shouldBe N
         open.get shouldBe 0
         ok.set(0)
-        // right-associative onError chains
+        // right-associative handleErrorWith chains
         assert(throws (FailWhale) {
           List.fill(N)(bracketed).foldLeft(Stream.fail(FailWhale): Stream[IO,Int]) {
-            (tl,hd) => hd onError { _ => tl }
+            (tl,hd) => hd handleErrorWith { _ => tl }
           }
         })
         ok.get shouldBe N

--- a/core/jvm/src/test/scala/fs2/StreamPerformanceSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamPerformanceSpec.scala
@@ -64,12 +64,12 @@ class StreamPerformanceSpec extends Fs2Spec {
         val open = new AtomicInteger(0)
         val ok = new AtomicInteger(0)
         val bracketed = bracket(IO { open.incrementAndGet })(
-          _ => emit(1) ++ Stream.fail(FailWhale),
+          _ => emit(1) ++ Stream.raiseError(FailWhale),
           _ => IO { ok.incrementAndGet; open.decrementAndGet; () }
         )
         // left-associative handleErrorWith chains
         assert(throws (FailWhale) {
-          List.fill(N)(bracketed).foldLeft(Stream.fail(FailWhale): Stream[IO,Int]) {
+          List.fill(N)(bracketed).foldLeft(Stream.raiseError(FailWhale): Stream[IO,Int]) {
             (acc,hd) => acc handleErrorWith { _ => hd }
           }
         })
@@ -78,7 +78,7 @@ class StreamPerformanceSpec extends Fs2Spec {
         ok.set(0)
         // right-associative handleErrorWith chains
         assert(throws (FailWhale) {
-          List.fill(N)(bracketed).foldLeft(Stream.fail(FailWhale): Stream[IO,Int]) {
+          List.fill(N)(bracketed).foldLeft(Stream.raiseError(FailWhale): Stream[IO,Int]) {
             (tl,hd) => hd handleErrorWith { _ => tl }
           }
         })

--- a/core/jvm/src/test/scala/fs2/StreamSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamSpec.scala
@@ -20,11 +20,11 @@ class StreamSpec extends Fs2Spec with Inside {
     }
 
     "fail (2)" in {
-      assert(throws (Err) { Stream.fail(Err) })
+      assert(throws (Err) { Stream.raiseError(Err) })
     }
 
     "fail (3)" in {
-      assert(throws (Err) { Stream.emit(1) ++ Stream.fail(Err) })
+      assert(throws (Err) { Stream.emit(1) ++ Stream.raiseError(Err) })
     }
 
     "eval" in {
@@ -63,11 +63,11 @@ class StreamSpec extends Fs2Spec with Inside {
     }
 
     "handleErrorWith (2)" in {
-      runLog(Stream.fail(Err) handleErrorWith { _ => Stream.emit(1) }) shouldBe Vector(1)
+      runLog(Stream.raiseError(Err) handleErrorWith { _ => Stream.emit(1) }) shouldBe Vector(1)
     }
 
     "handleErrorWith (3)" in {
-      runLog(Stream.emit(1) ++ Stream.fail(Err) handleErrorWith { _ => Stream.emit(1) }) shouldBe Vector(1,1)
+      runLog(Stream.emit(1) ++ Stream.raiseError(Err) handleErrorWith { _ => Stream.emit(1) }) shouldBe Vector(1,1)
     }
 
     "handleErrorWith (4)" in {
@@ -77,9 +77,9 @@ class StreamSpec extends Fs2Spec with Inside {
     }
 
     "handleErrorWith (5)" in {
-      val r = Stream.fail(Err).covary[IO].handleErrorWith(e => Stream.emit(e)).flatMap(Stream.emit(_)).runLog.unsafeRunSync()
-      val r2 = Stream.fail(Err).covary[IO].handleErrorWith(e => Stream.emit(e)).map(identity).runLog.unsafeRunSync()
-      val r3 = Stream(Stream.emit(1).covary[IO], Stream.fail(Err).covary[IO], Stream.emit(2).covary[IO]).covary[IO].join(4).attempt.runLog.unsafeRunSync()
+      val r = Stream.raiseError(Err).covary[IO].handleErrorWith(e => Stream.emit(e)).flatMap(Stream.emit(_)).runLog.unsafeRunSync()
+      val r2 = Stream.raiseError(Err).covary[IO].handleErrorWith(e => Stream.emit(e)).map(identity).runLog.unsafeRunSync()
+      val r3 = Stream(Stream.emit(1).covary[IO], Stream.raiseError(Err).covary[IO], Stream.emit(2).covary[IO]).covary[IO].join(4).attempt.runLog.unsafeRunSync()
       r shouldBe Vector(Err)
       r2 shouldBe Vector(Err)
       r3.contains(Left(Err)) shouldBe true

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -9,8 +9,6 @@ import fs2.internal.{ Algebra, FreeC }
  *
  * Any resources acquired by `p` are freed following the call to `stream`.
  *
- * Much of the API of `Pull` is defined in [[Pull.InvariantOps]].
- *
  * Laws:
  *
  * `Pull` forms a monad in `R` with `pure` and `flatMap`:
@@ -22,7 +20,6 @@ import fs2.internal.{ Algebra, FreeC }
  * `fail` is caught by `onError`:
  *   - `onError(fail(e))(f) == f(e)`
  *
- * @hideImplicitConversion PureOps
  * @hideImplicitConversion covaryPure
  */
 final class Pull[+F[_],+O,+R] private(private val free: FreeC[Algebra[Nothing,Nothing,?],R]) extends AnyVal {
@@ -40,12 +37,26 @@ final class Pull[+F[_],+O,+R] private(private val free: FreeC[Algebra[Nothing,No
   def stream: Stream[F,O] = Stream.fromFreeC(this.scope.get[F,O,R].map(_ => ()))
 
   /**
-   * Like [[stream]] but no scope is inserted around the pull, resulting in any resources being 
+   * Like [[stream]] but no scope is inserted around the pull, resulting in any resources being
    * promoted to the parent scope of the stream, extending the resource lifetime. Typically used
    * as a performance optimization, where resource lifetime can be extended in exchange for faster
    * execution.
    */
   def streamNoScope: Stream[F,O] = Stream.fromFreeC(get[F,O,R].map(_ => ()))
+
+  /** Applies the resource of this pull to `f` and returns the result. */
+  def flatMap[F2[x]>:F[x],O2>:O,R2](f: R => Pull[F2,O2,R2]): Pull[F2,O2,R2] =
+    Pull.fromFreeC(get[F2,O2,R] flatMap { r => f(r).get })
+
+  /** Alias for `flatMap(_ => p2)`. */
+  def *>[F2[x]>:F[x],O2>:O,R2](p2: => Pull[F2,O2,R2]): Pull[F2,O2,R2] =
+    this flatMap { _ => p2 }
+
+  /** Lifts this pull to the specified effect type. */
+  def covary[F2[x]>:F[x]]: Pull[F2,O,R] = this.asInstanceOf[Pull[F2,O,R]]
+
+  /** Lifts this pull to the specified effect type, output type, and resource type. */
+  def covaryAll[F2[x]>:F[x],O2>:O,R2>:R]: Pull[F2,O2,R2] = this.asInstanceOf[Pull[F2,O2,R2]]
 
   /** Lifts this pull to the specified output type. */
   def covaryOutput[O2>:O]: Pull[F,O2,R] = this.asInstanceOf[Pull[F,O2,R]]
@@ -55,6 +66,17 @@ final class Pull[+F[_],+O,+R] private(private val free: FreeC[Algebra[Nothing,No
 
   /** Applies the resource of this pull to `f` and returns the result in a new `Pull`. */
   def map[R2](f: R => R2): Pull[F,O,R2] = Pull.fromFreeC(get map f)
+
+  /** Run `p2` after `this`, regardless of errors during `this`, then reraise any errors encountered during `this`. */
+  def onComplete[F2[x]>:F[x],O2>:O,R2>:R](p2: => Pull[F2,O2,R2]): Pull[F2,O2,R2] =
+    onError(e => p2 *> Pull.fail(e)) flatMap { _ =>  p2 }
+
+  /** If `this` terminates with `Pull.fail(e)`, invoke `h(e)`. */
+  def onError[F2[x]>:F[x],O2>:O,R2>:R](h: Throwable => Pull[F2,O2,R2]): Pull[F2,O2,R2] =
+    Pull.fromFreeC(get[F2,O2,R2] onError { e => h(e).get })
+
+  /** Tracks any resources acquired during this pull and releases them when the pull completes. */
+  def scope: Pull[F,O,R] = Pull.fromFreeC(Algebra.scope(get))
 }
 
 object Pull {
@@ -157,61 +179,11 @@ object Pull {
   private def release[F[_]](token: Algebra.Token): Pull[F,Nothing,Unit] =
     fromFreeC[F,Nothing,Unit](Algebra.release(token))
 
-  /** Provides syntax for pulls that are invariant in `F`, `O`, and `R`. */
-  implicit def InvariantOps[F[_],O,R](p: Pull[F,O,R]): InvariantOps[F,O,R] = new InvariantOps(p.get)
-  /** Provides syntax for pulls that are invariant in `F`, `O`, and `R`. */
-  final class InvariantOps[F[_],O,R] private[Pull] (private val free: FreeC[Algebra[F,O,?],R]) extends AnyVal {
-    private def self: Pull[F,O,R] = Pull.fromFreeC(free)
-
-    /** Lifts this pull to the specified effect type. */
-    def covary[F2[x]>:F[x]]: Pull[F2,O,R] = self.asInstanceOf[Pull[F2,O,R]]
-
-    /** Lifts this pull to the specified effect type, output type, and resource type. */
-    def covaryAll[F2[x]>:F[x],O2>:O,R2>:R]: Pull[F2,O2,R2] = self.asInstanceOf[Pull[F2,O2,R2]]
-
-    /** Applies the resource of this pull to `f` and returns the result. */
-    def flatMap[O2>:O,R2](f: R => Pull[F,O2,R2]): Pull[F,O2,R2] =
-      Pull.fromFreeC(self.get[F,O2,R] flatMap { r => f(r).get })
-
-    /** Alias for `flatMap(_ => p2)`. */
-    def *>[O2>:O,R2](p2: => Pull[F,O2,R2]): Pull[F,O2,R2] =
-      this flatMap { _ => p2 }
-
-    /** Run `p2` after `this`, regardless of errors during `this`, then reraise any errors encountered during `this`. */
-    def onComplete[O2>:O,R2>:R](p2: => Pull[F,O2,R2]): Pull[F,O2,R2] =
-      (self onError (e => p2 *> Pull.fail(e))) flatMap { _ =>  p2 }
-
-    /** If `this` terminates with `Pull.fail(e)`, invoke `h(e)`. */
-    def onError[O2>:O,R2>:R](h: Throwable => Pull[F,O2,R2]): Pull[F,O2,R2] =
-      Pull.fromFreeC(self.get[F,O2,R2] onError { e => h(e).get })
-
-    /** Tracks any resources acquired during this pull and releases them when the pull completes. */
-    def scope: Pull[F,O,R] = Pull.fromFreeC(Algebra.scope(free))
-  }
-
-  /** Provides syntax for pure pulls. */
-  implicit def PureOps[O,R](p: Pull[Pure,O,R]): PureOps[O,R] = new PureOps(p.get[Pure,O,R])
-  /** Provides syntax for pure pulls. */
-  final class PureOps[O,R] private[Pull] (private val free: FreeC[Algebra[Pure,O,?],R]) extends AnyVal {
-    private def self: Pull[Pure,O,R] = Pull.fromFreeC[Pure,O,R](free)
-    def covary[F[_]]: Pull[F,O,R] = self.asInstanceOf[Pull[F,O,R]]
-    def covaryAll[F[_],O2>:O,R2>:R]: Pull[F,O2,R2] = self.asInstanceOf[Pull[F,O2,R2]]
-    def flatMap[F[_],O2>:O,R2](f: R => Pull[F,O2,R2]): Pull[F,O2,R2] = covary[F].flatMap(f)
-    def *>[F[_],O2>:O,R2](p2: => Pull[F,O2,R2]): Pull[F,O2,R2] = covary[F] *> p2
-    def onComplete[F[_],O2>:O,R2>:R](p2: => Pull[F,O2,R2]): Pull[F,O2,R2] = covary[F].onComplete(p2)
-    def onError[F[_],O2>:O,R2>:R](h: Throwable => Pull[F,O2,R2]): Pull[F,O2,R2] = covary[F].onError(h)
-    def scope[F[_]]: Pull[F,O,R] = covary[F].scope
-  }
-
   /** Implicitly covaries a pull. */
-  implicit def covaryPure[F[_],O,R,O2>:O,R2>:R](p: Pull[Pure,O,R]): Pull[F,O2,R2] = p.covaryAll[F,O2,R2]
+  implicit def covaryPure[F[_],O,R,O2>:O,R2>:R](p: Pull[Pure,O,R]): Pull[F,O2,R2] = p.asInstanceOf[Pull[F,O,R]]
 
-  /**
-   * `Sync` instance for `Stream`.
-   *
-   * Note: non-implicit so that cats syntax doesn't override FS2 syntax
-   */
-  def syncInstance[F[_],O]: Sync[Pull[F,O,?]] = new Sync[Pull[F,O,?]] {
+  /** `Sync` instance for `Stream`. */
+  implicit def syncInstance[F[_],O]: Sync[Pull[F,O,?]] = new Sync[Pull[F,O,?]] {
     def pure[A](a: A): Pull[F,O,A] = Pull.pure(a)
     def handleErrorWith[A](p: Pull[F,O,A])(h: Throwable => Pull[F,O,A]) = p.onError(h)
     def raiseError[A](t: Throwable) = Pull.fail(t)

--- a/core/shared/src/main/scala/fs2/internal/Algebra.scala
+++ b/core/shared/src/main/scala/fs2/internal/Algebra.scala
@@ -58,7 +58,7 @@ private[fs2] object Algebra {
   def scope[F[_],O,R](pull: FreeC[Algebra[F,O,?],R]): FreeC[Algebra[F,O,?],R] =
     openScope flatMap { newScope =>
       FreeC.Bind(pull, (e: Either[Throwable,R]) => e match {
-        case Left(e) => closeScope(newScope) flatMap { _ => fail(e) }
+        case Left(e) => closeScope(newScope) flatMap { _ => raiseError(e) }
         case Right(r) => closeScope(newScope) map { _ => r }
       })
     }
@@ -72,7 +72,7 @@ private[fs2] object Algebra {
   def pure[F[_],O,R](r: R): FreeC[Algebra[F,O,?],R] =
     FreeC.Pure[Algebra[F,O,?],R](r)
 
-  def fail[F[_],O,R](t: Throwable): FreeC[Algebra[F,O,?],R] =
+  def raiseError[F[_],O,R](t: Throwable): FreeC[Algebra[F,O,?],R] =
     FreeC.Fail[Algebra[F,O,?],R](t)
 
   def suspend[F[_],O,R](f: => FreeC[Algebra[F,O,?],R]): FreeC[Algebra[F,O,?],R] =
@@ -274,7 +274,7 @@ private[fs2] object Algebra {
   def uncons[F[_],X,O](s: FreeC[Algebra[F,O,?],Unit], chunkSize: Int = 1024): FreeC[Algebra[F,X,?],Option[(Segment[O,Unit], FreeC[Algebra[F,O,?],Unit])]] = {
     s.viewL.get match {
       case done: FreeC.Pure[Algebra[F,O,?], Unit] => pure(None)
-      case failed: FreeC.Fail[Algebra[F,O,?], _] => fail(failed.error)
+      case failed: FreeC.Fail[Algebra[F,O,?], _] => raiseError(failed.error)
       case bound: FreeC.Bind[Algebra[F,O,?],_,Unit] =>
         val f = bound.f.asInstanceOf[Either[Throwable,Any] => FreeC[Algebra[F,O,?],Unit]]
         val fx = bound.fx.asInstanceOf[FreeC.Eval[Algebra[F,O,?],_]].fr

--- a/core/shared/src/test/scala/fs2/CompilationTest.scala
+++ b/core/shared/src/test/scala/fs2/CompilationTest.scala
@@ -52,4 +52,11 @@ object ThisModuleShouldCompile {
 
   val p: Pull[Pure,Nothing,Option[(Segment[Int,Unit],Stream[Pure,Int])]] = Stream(1, 2, 3).pull.uncons
   val q: Pull[IO,Nothing,Option[(Segment[Int,Unit],Stream[Pure,Int])]] = p
+
+  // With cats implicits enabled, some of the above fail to compile due to the cats syntax being invariant:
+  {
+    import cats.implicits._
+    Stream(1,2,3).covary[IO].flatMap(i => Stream.eval(IO.pure(i)))
+    (Stream(1,2,3).covary[IO].flatMap(i => Stream.eval(IO(i)))): Stream[IO,Int]
+  }
 }

--- a/core/shared/src/test/scala/fs2/ErrorHandlingSpec.scala
+++ b/core/shared/src/test/scala/fs2/ErrorHandlingSpec.scala
@@ -10,7 +10,7 @@ class ErrorHandlingSpec extends Fs2Spec {
       var i = 0
       try {
         Pull.pure(1)
-            .onError(_ => { i += 1; Pull.pure(2) })
+            .handleErrorWith(_ => { i += 1; Pull.pure(2) })
             .flatMap { _ => Pull.output1(i) *> Pull.fail(new RuntimeException("woot")) }
             .stream.toList
         fail("should not reach, exception thrown above")
@@ -22,7 +22,7 @@ class ErrorHandlingSpec extends Fs2Spec {
       var i = 0
       try {
         Pull.eval(IO(1))
-            .onError(_ => { i += 1; Pull.pure(2) })
+            .handleErrorWith(_ => { i += 1; Pull.pure(2) })
             .flatMap { _ => Pull.output1(i) *> Pull.fail(new RuntimeException("woot")) }
             .stream.runLog.unsafeRunSync
         fail("should not reach, exception thrown above")
@@ -35,7 +35,7 @@ class ErrorHandlingSpec extends Fs2Spec {
       try {
         Pull.eval(IO(1)).flatMap { x =>
           Pull.pure(x)
-              .onError(_ => { i += 1; Pull.pure(2) })
+              .handleErrorWith(_ => { i += 1; Pull.pure(2) })
               .flatMap { _ => Pull.output1(i) *> Pull.fail(new RuntimeException("woot")) }
         }.stream.runLog.unsafeRunSync
         fail("should not reach, exception thrown above")
@@ -45,7 +45,7 @@ class ErrorHandlingSpec extends Fs2Spec {
 
     "ex4" in {
       var i = 0
-      Pull.eval(IO(???)).onError(_ => Pull.pure(i += 1)).flatMap { _ => Pull.output1(i) }
+      Pull.eval(IO(???)).handleErrorWith(_ => Pull.pure(i += 1)).flatMap { _ => Pull.output1(i) }
           .stream.runLog.unsafeRunSync
       i shouldBe 1
     }
@@ -61,7 +61,7 @@ class ErrorHandlingSpec extends Fs2Spec {
 
     "ex6" in {
       var i = 0
-      (Stream.range(0, 10).covary[IO] ++ Stream.fail(Err)).onError { t => i += 1; Stream.empty }.run.unsafeRunSync
+      (Stream.range(0, 10).covary[IO] ++ Stream.fail(Err)).handleErrorWith { t => i += 1; Stream.empty }.run.unsafeRunSync
       i shouldBe 1
     }
 
@@ -75,7 +75,7 @@ class ErrorHandlingSpec extends Fs2Spec {
 
     "ex8" in {
       var i = 0
-      (Stream.range(0, 3).covary[IO] ++ Stream.fail(Err)).unchunk.pull.echo.onError { t => i += 1; println(i); Pull.done }.stream.run.unsafeRunSync
+      (Stream.range(0, 3).covary[IO] ++ Stream.fail(Err)).unchunk.pull.echo.handleErrorWith { t => i += 1; println(i); Pull.done }.stream.run.unsafeRunSync
       i shouldBe 1
     }
   }

--- a/core/shared/src/test/scala/fs2/ErrorHandlingSpec.scala
+++ b/core/shared/src/test/scala/fs2/ErrorHandlingSpec.scala
@@ -11,7 +11,7 @@ class ErrorHandlingSpec extends Fs2Spec {
       try {
         Pull.pure(1)
             .handleErrorWith(_ => { i += 1; Pull.pure(2) })
-            .flatMap { _ => Pull.output1(i) *> Pull.fail(new RuntimeException("woot")) }
+            .flatMap { _ => Pull.output1(i) *> Pull.raiseError(new RuntimeException("woot")) }
             .stream.toList
         fail("should not reach, exception thrown above")
       }
@@ -23,7 +23,7 @@ class ErrorHandlingSpec extends Fs2Spec {
       try {
         Pull.eval(IO(1))
             .handleErrorWith(_ => { i += 1; Pull.pure(2) })
-            .flatMap { _ => Pull.output1(i) *> Pull.fail(new RuntimeException("woot")) }
+            .flatMap { _ => Pull.output1(i) *> Pull.raiseError(new RuntimeException("woot")) }
             .stream.runLog.unsafeRunSync
         fail("should not reach, exception thrown above")
       }
@@ -36,7 +36,7 @@ class ErrorHandlingSpec extends Fs2Spec {
         Pull.eval(IO(1)).flatMap { x =>
           Pull.pure(x)
               .handleErrorWith(_ => { i += 1; Pull.pure(2) })
-              .flatMap { _ => Pull.output1(i) *> Pull.fail(new RuntimeException("woot")) }
+              .flatMap { _ => Pull.output1(i) *> Pull.raiseError(new RuntimeException("woot")) }
         }.stream.runLog.unsafeRunSync
         fail("should not reach, exception thrown above")
       }
@@ -61,13 +61,13 @@ class ErrorHandlingSpec extends Fs2Spec {
 
     "ex6" in {
       var i = 0
-      (Stream.range(0, 10).covary[IO] ++ Stream.fail(Err)).handleErrorWith { t => i += 1; Stream.empty }.run.unsafeRunSync
+      (Stream.range(0, 10).covary[IO] ++ Stream.raiseError(Err)).handleErrorWith { t => i += 1; Stream.empty }.run.unsafeRunSync
       i shouldBe 1
     }
 
     "ex7" in {
       try {
-        (Stream.range(0, 3).covary[IO] ++ Stream.fail(Err)).unchunk.pull.echo.stream.run.unsafeRunSync
+        (Stream.range(0, 3).covary[IO] ++ Stream.raiseError(Err)).unchunk.pull.echo.stream.run.unsafeRunSync
         fail("SHOULD NOT REACH")
       }
       catch { case e: Throwable => () }
@@ -75,7 +75,7 @@ class ErrorHandlingSpec extends Fs2Spec {
 
     "ex8" in {
       var i = 0
-      (Stream.range(0, 3).covary[IO] ++ Stream.fail(Err)).unchunk.pull.echo.handleErrorWith { t => i += 1; println(i); Pull.done }.stream.run.unsafeRunSync
+      (Stream.range(0, 3).covary[IO] ++ Stream.raiseError(Err)).unchunk.pull.echo.handleErrorWith { t => i += 1; println(i); Pull.done }.stream.run.unsafeRunSync
       i shouldBe 1
     }
   }

--- a/core/shared/src/test/scala/fs2/TestUtil.scala
+++ b/core/shared/src/test/scala/fs2/TestUtil.scala
@@ -98,7 +98,7 @@ trait TestUtil extends TestUtilPlatform {
 
   implicit def failingStreamArb: Arbitrary[Failure] = Arbitrary(
     Gen.oneOf[Failure](
-      Failure("pure-failure", Stream.fail(Err)),
+      Failure("pure-failure", Stream.raiseError(Err)),
       Failure("failure-inside-effect", Stream.eval(IO(throw Err))),
       Failure("failure-mid-effect", Stream.eval(IO.pure(()).flatMap(_ => throw Err))),
       Failure("failure-in-pure-code", Stream.emit(42).map(_ => throw Err)),

--- a/docs/ReadmeExample.md
+++ b/docs/ReadmeExample.md
@@ -98,7 +98,7 @@ There are a number of ways of interpreting the stream. In this case, we call `ru
 
 ```scala
 scala> val task: IO[Unit] = written.run
-task: cats.effect.IO[Unit] = IO$1351434562
+task: cats.effect.IO[Unit] = IO$1809609665
 ```
 
 We still haven't *done* anything yet. Effects only occur when we run the resulting task. We can run a `IO` by calling `unsafeRunSync()` -- the name is telling us that calling it performs effects and hence, it is not referentially transparent.

--- a/docs/ReadmeExample.md
+++ b/docs/ReadmeExample.md
@@ -98,7 +98,7 @@ There are a number of ways of interpreting the stream. In this case, we call `ru
 
 ```scala
 scala> val task: IO[Unit] = written.run
-task: cats.effect.IO[Unit] = IO$1426003670
+task: cats.effect.IO[Unit] = IO$1351434562
 ```
 
 We still haven't *done* anything yet. Effects only occur when we run the resulting task. We can run a `IO` by calling `unsafeRunSync()` -- the name is telling us that calling it performs effects and hence, it is not referentially transparent.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -137,13 +137,13 @@ val eff = Stream.eval(IO { println("TASK BEING RUN!!"); 1 + 1 })
 // eff: fs2.Stream[cats.effect.IO,Int] = Stream(..)
 
 val ra = eff.runLog // gather all output into a Vector
-// ra: cats.effect.IO[Vector[Int]] = IO$13579904
+// ra: cats.effect.IO[Vector[Int]] = IO$418696692
 
 val rb = eff.run // purely for effects
-// rb: cats.effect.IO[Unit] = IO$642121560
+// rb: cats.effect.IO[Unit] = IO$112534092
 
 val rc = eff.runFold(0)(_ + _) // run and accumulate some result
-// rc: cats.effect.IO[Int] = IO$615336848
+// rc: cats.effect.IO[Int] = IO$383810460
 ```
 
 Notice these all return a `IO` of some sort, but this process of compilation doesn't actually _perform_ any of the effects (nothing gets printed).
@@ -194,7 +194,7 @@ res16: fs2.Stream[fs2.Pure,Double] = Stream(..)
 
 ### Basic stream operations
 
-Streams have a small but powerful set of operations, some of which we've seen already. The key operations are `++`, `map`, `flatMap`, `onError`, and `bracket`:
+Streams have a small but powerful set of operations, some of which we've seen already. The key operations are `++`, `map`, `flatMap`, `handleErrorWith`, and `bracket`:
 
 ```scala
 scala> val appendEx1 = Stream(1,2,3) ++ Stream.emit(42)
@@ -220,7 +220,7 @@ scala> appendEx1.flatMap(i => Stream.emits(List(i,i))).toList
 res20: List[Int] = List(1, 1, 2, 2, 3, 3, 42, 42)
 ```
 
-Regardless of how a `Stream` is built up, each operation takes constant time. So `s ++ s2` takes constant time, regardless of whether `s` is `Stream.emit(1)` or it's a huge stream with millions of elements and lots of embedded effects. Likewise with `s.flatMap(f)` and `onError`, which we'll see in a minute. The runtime of these operations do not depend on the structure of `s`.
+Regardless of how a `Stream` is built up, each operation takes constant time. So `s ++ s2` takes constant time, regardless of whether `s` is `Stream.emit(1)` or it's a huge stream with millions of elements and lots of embedded effects. Likewise with `s.flatMap(f)` and `handleErrorWith`, which we'll see in a minute. The runtime of these operations do not depend on the structure of `s`.
 
 ### Error handling
 
@@ -256,14 +256,14 @@ scala> try err3.run.unsafeRunSync() catch { case e: Exception => println(e) }
 java.lang.Exception: error in effect!!!
 ```
 
-The `onError` method lets us catch any of these errors:
+The `handleErrorWith` method lets us catch any of these errors:
 
 ```scala
-scala> err.onError { e => Stream.emit(e.getMessage) }.toList
+scala> err.handleErrorWith { e => Stream.emit(e.getMessage) }.toList
 res24: List[String] = List(oh noes!)
 ```
 
-_Note: Don't use `onError` for doing resource cleanup; use `bracket` as discussed in the next section. Also see [this section of the appendix](#a1) for more details._
+_Note: Don't use `handleErrorWith` for doing resource cleanup; use `bracket` as discussed in the next section. Also see [this section of the appendix](#a1) for more details._
 
 ### Resource acquisition
 
@@ -274,10 +274,10 @@ scala> val count = new java.util.concurrent.atomic.AtomicLong(0)
 count: java.util.concurrent.atomic.AtomicLong = 0
 
 scala> val acquire = IO { println("incremented: " + count.incrementAndGet); () }
-acquire: cats.effect.IO[Unit] = IO$673375754
+acquire: cats.effect.IO[Unit] = IO$1153837958
 
 scala> val release = IO { println("decremented: " + count.decrementAndGet); () }
-release: cats.effect.IO[Unit] = IO$887603586
+release: cats.effect.IO[Unit] = IO$889325626
 ```
 
 ```scala
@@ -285,7 +285,7 @@ scala> Stream.bracket(acquire)(_ => Stream(1,2,3) ++ err, _ => release).run.unsa
 incremented: 1
 decremented: 0
 java.lang.Exception: oh noes!
-  ... 798 elided
+  ... 417 elided
 ```
 
 The inner stream fails, but notice the `release` action is still run:
@@ -554,7 +554,7 @@ import cats.effect.Sync
 // import cats.effect.Sync
 
 val T = Sync[IO]
-// T: cats.effect.Sync[cats.effect.IO] = cats.effect.IOInstances$$anon$1@6345acc2
+// T: cats.effect.Sync[cats.effect.IO] = cats.effect.IOInstances$$anon$1@29f93e7d
 
 val s = Stream.eval_(T.delay { destroyUniverse() }) ++ Stream("...moving on")
 // s: fs2.Stream[cats.effect.IO,String] = Stream(..)
@@ -611,12 +611,12 @@ val c = new Connection {
 
 // Effect extends both Sync and Async
 val T = cats.effect.Effect[IO]
-// T: cats.effect.Effect[cats.effect.IO] = cats.effect.IOInstances$$anon$1@6345acc2
+// T: cats.effect.Effect[cats.effect.IO] = cats.effect.IOInstances$$anon$1@29f93e7d
 
 val bytes = T.async[Array[Byte]] { (cb: Either[Throwable,Array[Byte]] => Unit) =>
   c.readBytesE(cb)
 }
-// bytes: cats.effect.IO[Array[Byte]] = IO$1390397804
+// bytes: cats.effect.IO[Array[Byte]] = IO$913520968
 
 Stream.eval(bytes).map(_.toList).runLog.unsafeRunSync()
 // res42: Vector[List[Byte]] = Vector(List(0, 1, 2))
@@ -690,8 +690,8 @@ In FS2, a stream can terminate in one of three ways:
 Regarding 3:
 
 * A stream will never be interrupted while it is acquiring a resource (via `bracket`) or while it is releasing a resource. The `bracket` function guarantees that if FS2 starts acquiring the resource, the corresponding release action will be run.
-* Other than that, Streams can be interrupted in between any two 'steps' of the stream. The steps themselves are atomic from the perspective of FS2. `Stream.eval(eff)` is a single step, `Stream.emit(1)` is a single step, `Stream(1,2,3)` is a single step (emitting a chunk), and all other operations (like `onError`, `++`, and `flatMap`) are multiple steps and can be interrupted. But importantly, user-provided effects that are passed to `eval` are never interrupted once they are started (and FS2 does not have enough knowledge of user-provided effects to know how to interrupt them anyway).
-* _Always use `bracket` or a `bracket`-based function like `onFinalize` for supplying resource cleanup logic or any other logic you want to be run regardless of how the stream terminates. Don't use `onError` or `++` for this purpose._
+* Other than that, Streams can be interrupted in between any two 'steps' of the stream. The steps themselves are atomic from the perspective of FS2. `Stream.eval(eff)` is a single step, `Stream.emit(1)` is a single step, `Stream(1,2,3)` is a single step (emitting a chunk), and all other operations (like `handleErrorWith`, `++`, and `flatMap`) are multiple steps and can be interrupted. But importantly, user-provided effects that are passed to `eval` are never interrupted once they are started (and FS2 does not have enough knowledge of user-provided effects to know how to interrupt them anyway).
+* _Always use `bracket` or a `bracket`-based function like `onFinalize` for supplying resource cleanup logic or any other logic you want to be run regardless of how the stream terminates. Don't use `handleErrorWith` or `++` for this purpose._
 
 Let's look at some examples of how this plays out, starting with the synchronous interruption case:
 
@@ -735,7 +735,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 scala> val s1 = (Stream(1) ++ Stream(2)).covary[IO]
 s1: fs2.Stream[cats.effect.IO,Int] = Stream(..)
 
-scala> val s2 = (Stream.empty ++ Stream.fail(Err)) onError { e => println(e); Stream.fail(e) }
+scala> val s2 = (Stream.empty ++ Stream.fail(Err)) handleErrorWith { e => println(e); Stream.fail(e) }
 s2: fs2.Stream[fs2.Pure,Nothing] = Stream(..)
 
 scala> val merged = s1 merge s2 take 1
@@ -746,6 +746,6 @@ The result is highly nondeterministic. Here are a few ways it can play out:
 
 * `s1` may complete before the error in `s2` is encountered, in which case nothing will be printed and no error will occur.
 * `s2` may encounter the error before any of `s1` is emitted. When the error is reraised by `s2`, that will terminate the `merge` and asynchronously interrupt `s1`, and the `take` terminates with that same error.
-* `s2` may encounter the error before any of `s1` is emitted, but during the period where the value is caught by `onError`, `s1` may emit a value and the `take(1)` may terminate, triggering interruption of both `s1` and `s2`, before the error is reraised but after the exception is printed! In this case, the stream will still terminate without error.
+* `s2` may encounter the error before any of `s1` is emitted, but during the period where the value is caught by `handleErrorWith`, `s1` may emit a value and the `take(1)` may terminate, triggering interruption of both `s1` and `s2`, before the error is reraised but after the exception is printed! In this case, the stream will still terminate without error.
 
-The correctness of your program should not depend on how different streams interleave, and once again, you should not use `onError` or other interruptible functions for resource cleanup. Use `bracket` or `onFinalize` for this purpose.
+The correctness of your program should not depend on how different streams interleave, and once again, you should not use `handleErrorWith` or other interruptible functions for resource cleanup. Use `bracket` or `onFinalize` for this purpose.

--- a/io/src/main/scala/fs2/io/tcp/Socket.scala
+++ b/io/src/main/scala/fs2/io/tcp/Socket.scala
@@ -166,7 +166,7 @@ protected[tcp] object Socket {
           } ++ go
         }
 
-        go.onError {
+        go.handleErrorWith {
           case err: AsynchronousCloseException =>
             if (sch.isOpen) Stream.fail(err)
             else Stream.empty

--- a/io/src/main/scala/fs2/io/tcp/Socket.scala
+++ b/io/src/main/scala/fs2/io/tcp/Socket.scala
@@ -168,9 +168,9 @@ protected[tcp] object Socket {
 
         go.handleErrorWith {
           case err: AsynchronousCloseException =>
-            if (sch.isOpen) Stream.fail(err)
+            if (sch.isOpen) Stream.raiseError(err)
             else Stream.empty
-          case err => Stream.fail(err)
+          case err => Stream.raiseError(err)
         }
       }
 

--- a/io/src/test/scala/fs2/io/udp/UdpSpec.scala
+++ b/io/src/test/scala/fs2/io/udp/UdpSpec.scala
@@ -46,7 +46,7 @@ class UdpSpec extends Fs2Spec with BeforeAndAfterAll {
             val serverAddress = new InetSocketAddress("localhost", serverPort)
             val server = serverSocket.reads().evalMap { packet => serverSocket.write(packet) }.drain
             val client = open[IO]().flatMap { clientSocket =>
-              Stream.emits(msgs.map { msg => Packet(serverAddress, msg) }).flatMap { msg =>
+              Stream.emits(msgs.map { msg => Packet(serverAddress, msg) }).covary[IO].flatMap { msg =>
                 Stream.eval_(clientSocket.write(msg)) ++ Stream.eval(clientSocket.read())
               }
             }


### PR DESCRIPTION
If you `import cats.implicits._`, the cats syntax for methods like `flatMap`, `*>`, and `handleErrorWith` overrides the methods from `Stream`. The cats versions of these methods don't support all the variance tricks that the FS2 equivalents support. Hence, users may need to use `covary` in more cases than they'd normally need to if they are importing cats syntax.

This exposed some inconsistencies with cats methods -- e.g., `onError` in cats means something different than `onError` in fs2, so I renamed `onError` to `handleErrorWith` to match the cats name. Similarly, I renamed `fail` to `raiseError` to match the cats name.

Note that the `Pull` API doesn't need the same variance tricks that `Stream` uses because (1) we don't create `Pull[Pure,O,R]` instances out of thin air (if we have one, it's because we are pulling on a pure stream) and (2) the pull constructors are all polymorphic in F.