### PR TITLE
Performance improvements in Chunk#toArray

### DIFF
--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -2,6 +2,7 @@ package fs2
 
 import cats.Eval
 import scala.reflect.ClassTag
+import java.nio.ByteBuffer
 
 /**
  * Segment with a known size and that allows index-based random access of elements.
@@ -65,7 +66,7 @@ abstract class Chunk[+O] extends Segment[O,Unit] { self =>
   override def toArray[O2 >: O: ClassTag]: Array[O2] = {
     val arr = new Array[O2](size)
     var i = 0
-    this.map { b => arr(i) = b; i += 1 }.drain.run
+    while (i < size) { arr(i) = apply(i); i += 1 }
     arr
   }
 
@@ -284,6 +285,7 @@ object Chunk {
     protected def splitAtChunk_(n: Int): (Chunk[O], Chunk[O]) =
       Boxed(values, offset, n) -> Boxed(values, offset + n, length - n)
     protected def mapStrict[O2](f: O => O2): Chunk[O2] = seq(values.map(f))
+    override def toArray[O2 >: O: ClassTag]: Array[O2] = values.slice(offset, offset + length).asInstanceOf[Array[O2]]
   }
   object Boxed { def apply[O](values: Array[O]): Boxed[O] = Boxed(values, 0, values.length) }
 
@@ -301,6 +303,7 @@ object Chunk {
     protected def splitAtChunk_(n: Int): (Chunk[Boolean], Chunk[Boolean]) =
       Booleans(values, offset, n) -> Booleans(values, offset + n, length - n)
     protected def mapStrict[O2](f: Boolean => O2): Chunk[O2] = seq(values.map(f))
+    override def toArray[O2 >: Boolean: ClassTag]: Array[O2] = values.slice(offset, offset + length).asInstanceOf[Array[O2]]
   }
   object Booleans { def apply(values: Array[Boolean]): Booleans = Booleans(values, 0, values.length) }
 
@@ -318,6 +321,8 @@ object Chunk {
     protected def splitAtChunk_(n: Int): (Chunk[Byte], Chunk[Byte]) =
       Bytes(values, offset, n) -> Bytes(values, offset + n, length - n)
     protected def mapStrict[O2](f: Byte => O2): Chunk[O2] = seq(values.map(f))
+    override def toArray[O2 >: Byte: ClassTag]: Array[O2] = values.slice(offset, offset + length).asInstanceOf[Array[O2]]
+    def toByteBuffer: ByteBuffer = ByteBuffer.wrap(values, offset, length)
   }
   object Bytes { def apply(values: Array[Byte]): Bytes = Bytes(values, 0, values.length) }
 
@@ -335,6 +340,7 @@ object Chunk {
     protected def splitAtChunk_(n: Int): (Chunk[Short], Chunk[Short]) =
       Shorts(values, offset, n) -> Shorts(values, offset + n, length - n)
     protected def mapStrict[O2](f: Short => O2): Chunk[O2] = seq(values.map(f))
+    override def toArray[O2 >: Short: ClassTag]: Array[O2] = values.slice(offset, offset + length).asInstanceOf[Array[O2]]
   }
   object Shorts { def apply(values: Array[Short]): Shorts = Shorts(values, 0, values.length) }
 
@@ -352,6 +358,7 @@ object Chunk {
     protected def splitAtChunk_(n: Int): (Chunk[Int], Chunk[Int]) =
       Ints(values, offset, n) -> Ints(values, offset + n, length - n)
     protected def mapStrict[O2](f: Int => O2): Chunk[O2] = seq(values.map(f))
+    override def toArray[O2 >: Int: ClassTag]: Array[O2] = values.slice(offset, offset + length).asInstanceOf[Array[O2]]
   }
   object Ints { def apply(values: Array[Int]): Ints = Ints(values, 0, values.length) }
 
@@ -369,6 +376,7 @@ object Chunk {
     protected def splitAtChunk_(n: Int): (Chunk[Long], Chunk[Long]) =
       Longs(values, offset, n) -> Longs(values, offset + n, length - n)
     protected def mapStrict[O2](f: Long => O2): Chunk[O2] = seq(values.map(f))
+    override def toArray[O2 >: Long: ClassTag]: Array[O2] = values.slice(offset, offset + length).asInstanceOf[Array[O2]]
   }
   object Longs { def apply(values: Array[Long]): Longs = Longs(values, 0, values.length) }
 
@@ -386,6 +394,7 @@ object Chunk {
     protected def splitAtChunk_(n: Int): (Chunk[Float], Chunk[Float]) =
       Floats(values, offset, n) -> Floats(values, offset + n, length - n)
     protected def mapStrict[O2](f: Float => O2): Chunk[O2] = seq(values.map(f))
+    override def toArray[O2 >: Float: ClassTag]: Array[O2] = values.slice(offset, offset + length).asInstanceOf[Array[O2]]
   }
   object Floats { def apply(values: Array[Float]): Floats = Floats(values, 0, values.length) }
 
@@ -403,6 +412,7 @@ object Chunk {
     protected def splitAtChunk_(n: Int): (Chunk[Double], Chunk[Double]) =
       Doubles(values, offset, n) -> Doubles(values, offset + n, length - n)
     protected def mapStrict[O2](f: Double => O2): Chunk[O2] = seq(values.map(f))
+    override def toArray[O2 >: Double: ClassTag]: Array[O2] = values.slice(offset, offset + length).asInstanceOf[Array[O2]]
   }
   object Doubles { def apply(values: Array[Double]): Doubles = Doubles(values, 0, values.length) }
 

--- a/io/src/main/scala/fs2/io/file/FileHandle.scala
+++ b/io/src/main/scala/fs2/io/file/FileHandle.scala
@@ -134,7 +134,7 @@ private[file] object FileHandle {
 
       override def write(bytes: Chunk[Byte], offset: Long): F[Int] =
         F.map(
-          asyncCompletionHandler[F, Integer](f => chan.write(ByteBuffer.wrap(bytes.toArray), offset, null, f)))(
+          asyncCompletionHandler[F, Integer](f => chan.write(bytes.toBytes.toByteBuffer, offset, null, f)))(
           i => i.toInt
         )
     }
@@ -179,7 +179,7 @@ private[file] object FileHandle {
         F.delay(f.release())
 
       override def write(bytes: Chunk[Byte], offset: Long): F[Int] =
-        F.delay(chan.write(ByteBuffer.wrap(bytes.toArray), offset))
+        F.delay(chan.write(bytes.toBytes.toByteBuffer, offset))
     }
   }
 }

--- a/io/src/main/scala/fs2/io/tcp/Socket.scala
+++ b/io/src/main/scala/fs2/io/tcp/Socket.scala
@@ -276,11 +276,7 @@ protected[tcp] object Socket {
           }
         }
 
-        val bytes0 = bytes.toBytes
-        go(
-          ByteBuffer.wrap(bytes0.values, 0, bytes0.size)
-          , timeout.map(_.toMillis).getOrElse(0l)
-        )
+        go(bytes.toBytes.toByteBuffer, timeout.map(_.toMillis).getOrElse(0l))
       }
 
       ///////////////////////////////////


### PR DESCRIPTION
Fixes #977.

Includes a series of optimizations:
 - `Chunk#toArray` now simply uses a while loop instead of using the segment machinery to access each element (not sure why it ever did what it was doing...)
 - `toArray` is overridden on each array backed chunk subtype using `.slice` operation
 - `toByteBuffer` was added to `Chunk.Bytes` allowing a zero-copy view of the underlying array

@fiadliel could you take a look at this?