### PR TITLE
Add fs2.StreamApp from http4s

### DIFF
--- a/core/jvm/src/main/scala/fs2/ExitCode.scala
+++ b/core/jvm/src/main/scala/fs2/ExitCode.scala
@@ -1,0 +1,9 @@
+package fs2
+
+final case class ExitCode(code: Byte)
+
+object ExitCode {
+  def fromInt(code: Int): ExitCode = ExitCode(code.toByte)
+  val success: ExitCode = ExitCode(0)
+  val error: ExitCode = ExitCode(1)
+}

--- a/core/jvm/src/main/scala/fs2/ExitCode.scala
+++ b/core/jvm/src/main/scala/fs2/ExitCode.scala
@@ -1,9 +1,0 @@
-package fs2
-
-final case class ExitCode(code: Byte)
-
-object ExitCode {
-  def fromInt(code: Int): ExitCode = ExitCode(code.toByte)
-  val success: ExitCode = ExitCode(0)
-  val error: ExitCode = ExitCode(1)
-}

--- a/core/jvm/src/main/scala/fs2/StreamApp.scala
+++ b/core/jvm/src/main/scala/fs2/StreamApp.scala
@@ -1,0 +1,71 @@
+package fs2
+
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
+
+import cats.effect._
+import cats.effect.implicits._
+import cats.implicits._
+
+import fs2.async.Ref
+import fs2.async.mutable.Signal
+
+abstract class StreamApp[F[_]](implicit F: Effect[F]) {
+
+  /** An application stream that should never emit or emit a single ExitCode */
+  def stream(args: List[String], requestShutdown: F[Unit]): Stream[F,ExitCode]
+
+  /** Adds a shutdown hook that interrupts the stream and waits for it to finish */
+  private def addShutdownHook(requestShutdown: Signal[F,Boolean], halted: Signal[IO,Boolean]): F[Unit] =
+    F.delay {
+      sys.addShutdownHook {
+        (requestShutdown.set(true).runAsync(_ => IO.unit) *>
+          halted.discrete.takeWhile(_ == false).run).unsafeRunSync()
+      }
+      ()
+    }
+
+  private val directEC: ExecutionContextExecutor =
+    new ExecutionContextExecutor {
+      def execute(runnable: Runnable): Unit =
+        try runnable.run()
+        catch { case t: Throwable => reportFailure(t) }
+
+      def reportFailure(t: Throwable): Unit = ExecutionContext.defaultReporter(t)
+    }
+
+  /** Exposed for testing, so we can check exit values before the dramatic sys.exit */
+  private[fs2] def doMain(args: List[String]): IO[ExitCode] = {
+    implicit val ec: ExecutionContext = directEC
+    async.ref[IO, ExitCode].flatMap { exitCodeRef =>
+    async.signalOf[IO, Boolean](false).flatMap { halted =>
+      runStream(args, exitCodeRef, halted)
+    }}
+  }
+
+  /**
+    * Runs the application stream to an ExitCode.
+    *
+    * @param args The command line arguments
+    * @param exitCodeRef A ref that will be set to the exit code from the stream
+    * @param halted A signal that is set when the application stream is done
+    * @param ec Implicit EC to run the application stream
+    * @return An IO that will produce an ExitCode
+    */
+  private[fs2] def runStream(args: List[String], exitCodeRef: Ref[IO,ExitCode], halted: Signal[IO,Boolean])
+                            (implicit ec: ExecutionContext): IO[ExitCode] =
+    async.signalOf[F, Boolean](false).flatMap { requestShutdown =>
+      addShutdownHook(requestShutdown, halted) *>
+      stream(args, requestShutdown.set(true)).interruptWhen(requestShutdown).take(1).runLast
+    }.runAsync {
+      case Left(t) =>
+        IO(t.printStackTrace()) *>
+          halted.set(true) *>
+          exitCodeRef.setSyncPure(ExitCode.error)
+      case Right(exitCode) =>
+        halted.set(true) *>
+          exitCodeRef.setSyncPure(exitCode.getOrElse(ExitCode.success))
+    } *> exitCodeRef.get
+
+  def main(args: Array[String]): Unit =
+    sys.exit(doMain(args.toList).unsafeRunSync.code.toInt)
+}

--- a/core/jvm/src/main/scala/fs2/StreamApp.scala
+++ b/core/jvm/src/main/scala/fs2/StreamApp.scala
@@ -8,6 +8,7 @@ import cats.implicits._
 
 import fs2.async.Ref
 import fs2.async.mutable.Signal
+import fs2.StreamApp.ExitCode
 
 abstract class StreamApp[F[_]](implicit F: Effect[F]) {
 
@@ -68,4 +69,14 @@ abstract class StreamApp[F[_]](implicit F: Effect[F]) {
 
   def main(args: Array[String]): Unit =
     sys.exit(doMain(args.toList).unsafeRunSync.code.toInt)
+}
+
+object StreamApp {
+  final case class ExitCode(code: Byte)
+
+  object ExitCode {
+    def fromInt(code: Int): ExitCode = ExitCode(code.toByte)
+    val success: ExitCode = ExitCode(0)
+    val error: ExitCode = ExitCode(1)
+  }
 }

--- a/core/jvm/src/main/scala/fs2/StreamApp.scala
+++ b/core/jvm/src/main/scala/fs2/StreamApp.scala
@@ -61,10 +61,10 @@ abstract class StreamApp[F[_]](implicit F: Effect[F]) {
       case Left(t) =>
         IO(t.printStackTrace()) *>
           halted.set(true) *>
-          exitCodeRef.setSyncPure(ExitCode.error)
+          exitCodeRef.setSyncPure(ExitCode.Error)
       case Right(exitCode) =>
         halted.set(true) *>
-          exitCodeRef.setSyncPure(exitCode.getOrElse(ExitCode.success))
+          exitCodeRef.setSyncPure(exitCode.getOrElse(ExitCode.Success))
     } *> exitCodeRef.get
 
   def main(args: Array[String]): Unit =
@@ -76,7 +76,7 @@ object StreamApp {
 
   object ExitCode {
     def fromInt(code: Int): ExitCode = ExitCode(code.toByte)
-    val success: ExitCode = ExitCode(0)
-    val error: ExitCode = ExitCode(1)
+    val Success: ExitCode = ExitCode(0)
+    val Error: ExitCode = ExitCode(1)
   }
 }

--- a/core/jvm/src/test/scala/fs2/StreamAppSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamAppSpec.scala
@@ -1,0 +1,68 @@
+package fs2
+
+import scala.concurrent.duration._
+
+import cats.effect.IO
+import cats.implicits._
+
+class StreamAppSpec extends Fs2Spec {
+
+  "StreamApp" - {
+    /**
+      * Simple Test Rig For Stream Apps
+      * Takes the Stream that constitutes the Stream App
+      * and observably cleans up when the process is stopped.
+      */
+    class TestStreamApp(stream: IO[Unit] => Stream[IO, ExitCode]) extends StreamApp[IO] {
+      val cleanedUp = async.signalOf[IO,Boolean](false).unsafeRunSync
+
+      override def stream(args: List[String], requestShutdown: IO[Unit]): Stream[IO, ExitCode] =
+        stream(requestShutdown).onFinalize(cleanedUp.set(true))
+    }
+
+    "Terminate server on a failed stream" in {
+      val testApp = new TestStreamApp(_ => Stream.raiseError(new Throwable("Bad Initial Process")))
+      testApp.doMain(List.empty).unsafeRunSync shouldBe ExitCode.error
+      testApp.cleanedUp.get.unsafeRunSync shouldBe true
+    }
+
+    "Terminate server on a valid stream" in {
+      val testApp = new TestStreamApp(_ => Stream.emit(ExitCode.success))
+      testApp.doMain(List.empty).unsafeRunSync shouldBe ExitCode.success
+      testApp.cleanedUp.get.unsafeRunSync shouldBe true
+    }
+
+    "Terminate server on an empty stream" in {
+      val testApp = new TestStreamApp(_ => Stream.empty)
+      testApp.doMain(List.empty).unsafeRunSync shouldBe ExitCode.success
+      testApp.cleanedUp.get.unsafeRunSync shouldBe true
+    }
+
+    "Terminate server with a specific exit code" in {
+      val testApp = new TestStreamApp(_ => Stream.emit(ExitCode(42)))
+      testApp.doMain(List.empty).unsafeRunSync shouldBe ExitCode(42)
+      testApp.cleanedUp.get.unsafeRunSync shouldBe true
+    }
+
+    "Shut down a server from a separate thread" in {
+      val requestShutdown = async.signalOf[IO,IO[Unit]](IO.unit).unsafeRunSync
+
+      val testApp = new TestStreamApp(
+        shutdown =>
+          Stream.eval(requestShutdown.set(shutdown)) *>
+            // run forever, emit nothing
+            Stream.eval_(IO.async[Nothing] { _ =>
+            }))
+
+      (for {
+        runApp <- async.start(testApp.doMain(List.empty))
+        // Wait for app to start
+        _ <- requestShutdown.discrete.takeWhile(_ == IO.unit).run
+        // Run shutdown task
+        _ <- requestShutdown.get.flatten
+        result <- runApp
+        cleanedUp <- testApp.cleanedUp.get
+      } yield (result, cleanedUp)).unsafeRunTimed(5.seconds) shouldBe Some((ExitCode.success, true))
+    }
+  }
+}

--- a/core/jvm/src/test/scala/fs2/StreamAppSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamAppSpec.scala
@@ -24,19 +24,19 @@ class StreamAppSpec extends Fs2Spec {
 
     "Terminate server on a failed stream" in {
       val testApp = new TestStreamApp(_ => Stream.raiseError(new Throwable("Bad Initial Process")))
-      testApp.doMain(List.empty).unsafeRunSync shouldBe ExitCode.error
+      testApp.doMain(List.empty).unsafeRunSync shouldBe ExitCode.Error
       testApp.cleanedUp.get.unsafeRunSync shouldBe true
     }
 
     "Terminate server on a valid stream" in {
-      val testApp = new TestStreamApp(_ => Stream.emit(ExitCode.success))
-      testApp.doMain(List.empty).unsafeRunSync shouldBe ExitCode.success
+      val testApp = new TestStreamApp(_ => Stream.emit(ExitCode.Success))
+      testApp.doMain(List.empty).unsafeRunSync shouldBe ExitCode.Success
       testApp.cleanedUp.get.unsafeRunSync shouldBe true
     }
 
     "Terminate server on an empty stream" in {
       val testApp = new TestStreamApp(_ => Stream.empty)
-      testApp.doMain(List.empty).unsafeRunSync shouldBe ExitCode.success
+      testApp.doMain(List.empty).unsafeRunSync shouldBe ExitCode.Success
       testApp.cleanedUp.get.unsafeRunSync shouldBe true
     }
 
@@ -64,7 +64,7 @@ class StreamAppSpec extends Fs2Spec {
         _ <- requestShutdown.get.flatten
         result <- runApp
         cleanedUp <- testApp.cleanedUp.get
-      } yield (result, cleanedUp)).unsafeRunTimed(5.seconds) shouldBe Some((ExitCode.success, true))
+      } yield (result, cleanedUp)).unsafeRunTimed(5.seconds) shouldBe Some((ExitCode.Success, true))
     }
   }
 }

--- a/core/jvm/src/test/scala/fs2/StreamAppSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamAppSpec.scala
@@ -5,6 +5,8 @@ import scala.concurrent.duration._
 import cats.effect.IO
 import cats.implicits._
 
+import fs2.StreamApp.ExitCode
+
 class StreamAppSpec extends Fs2Spec {
 
   "StreamApp" - {


### PR DESCRIPTION
This is a first attempt at a `StreamApp` in fs2. I've taken the one in http4s, tried to conform to the code style in fs2 and named it `fs2.StreamApp`. I've also added `fs2.ExitCode`. It could live in the same file as `StreamApp`, to keep the entire machinery contained in one file.

I have added the tests we had in http4s as well.

Closes #973 