### PR TITLE
Segmented repartition

### DIFF
--- a/core/jvm/src/test/scala/fs2/StreamSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamSpec.scala
@@ -101,14 +101,14 @@ class StreamSpec extends Fs2Spec with Inside {
     }
 
     "repartition" in {
-      Stream("Lore", "m ip", "sum dolo", "r sit amet").repartition(_.split(" ").toIndexedSeq).toList ==
+      Stream("Lore", "m ip", "sum dolo", "r sit amet").repartition(s => Segment.array(s.split(" "))).toList ==
         List("Lorem", "ipsum", "dolor", "sit", "amet") &&
-      Stream("hel", "l", "o Wor", "ld").repartition(_.grouped(2).toVector).toList ==
+      Stream("hel", "l", "o Wor", "ld").repartition(s => Segment.indexedSeq(s.grouped(2).toVector)).toList ==
         List("he", "ll", "o ", "Wo", "rl", "d") &&
-      Stream(1, 2, 3, 4, 5).repartition(i => Vector(i, i)).toList ==
+      Stream(1, 2, 3, 4, 5).repartition(i => Segment.indexedSeq(Vector(i, i))).toList ==
         List(1, 3, 6, 10, 15, 15) &&
-      (Stream(): Stream[Nothing, String]).repartition(_ => Vector()).toList == List() &&
-      Stream("hello").repartition(_ => Vector()).toList == List()
+      (Stream(): Stream[Nothing, String]).repartition(_ => Segment.empty).toList == List() &&
+      Stream("hello").repartition(_ => Segment.empty).toList == List()
     }
 
     "translate" in forAll { (s: PureStream[Int]) =>

--- a/core/jvm/src/test/scala/fs2/StreamSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamSpec.scala
@@ -101,14 +101,14 @@ class StreamSpec extends Fs2Spec with Inside {
     }
 
     "repartition" in {
-      Stream("Lore", "m ip", "sum dolo", "r sit amet").repartition(s => Segment.array(s.split(" "))).toList ==
-        List("Lorem", "ipsum", "dolor", "sit", "amet") &&
-      Stream("hel", "l", "o Wor", "ld").repartition(s => Segment.indexedSeq(s.grouped(2).toVector)).toList ==
-        List("he", "ll", "o ", "Wo", "rl", "d") &&
-      Stream(1, 2, 3, 4, 5).repartition(i => Segment.indexedSeq(Vector(i, i))).toList ==
-        List(1, 3, 6, 10, 15, 15) &&
-      (Stream(): Stream[Nothing, String]).repartition(_ => Segment.empty).toList == List() &&
-      Stream("hello").repartition(_ => Segment.empty).toList == List()
+      Stream("Lore", "m ip", "sum dolo", "r sit amet").repartition(s => Segment.array(s.split(" "))).toList shouldBe
+        List("Lorem", "ipsum", "dolor", "sit", "amet")
+      Stream("hel", "l", "o Wor", "ld").repartition(s => Segment.indexedSeq(s.grouped(2).toVector)).toList shouldBe
+        List("he", "ll", "o ", "Wo", "rl", "d")
+      Stream(1, 2, 3, 4, 5).repartition(i => Segment.indexedSeq(Vector(i, i))).toList shouldBe
+        List(1, 3, 6, 10, 15, 15)
+      (Stream(): Stream[Nothing, String]).repartition(_ => Segment.empty).toList shouldBe List()
+      Stream("hello").repartition(_ => Segment.empty).toList shouldBe List()
     }
 
     "translate" in forAll { (s: PureStream[Int]) =>

--- a/core/jvm/src/test/scala/fs2/StreamSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamSpec.scala
@@ -105,10 +105,20 @@ class StreamSpec extends Fs2Spec with Inside {
         List("Lorem", "ipsum", "dolor", "sit", "amet")
       Stream("hel", "l", "o Wor", "ld").repartition(s => Segment.indexedSeq(s.grouped(2).toVector)).toList shouldBe
         List("he", "ll", "o ", "Wo", "rl", "d")
-      Stream(1, 2, 3, 4, 5).repartition(i => Segment.indexedSeq(Vector(i, i))).toList shouldBe
-        List(1, 3, 6, 10, 15, 15)
-      (Stream(): Stream[Nothing, String]).repartition(_ => Segment.empty).toList shouldBe List()
+      Stream.empty.covaryOutput[String].repartition(_ => Segment.empty).toList shouldBe List()
       Stream("hello").repartition(_ => Segment.empty).toList shouldBe List()
+
+      def input = Stream("ab").repeat
+      def ones(s: String) = Segment vector s.grouped(1).toVector
+      input.take(2).repartition(ones).toVector shouldBe Vector("a", "b", "a", "b")
+      input.take(4).repartition(ones).toVector shouldBe Vector("a", "b", "a", "b", "a", "b", "a", "b")
+      input.repartition(ones).take(2).toVector shouldBe Vector("a", "b")
+      input.repartition(ones).take(4).toVector shouldBe Vector("a", "b", "a", "b")
+      Stream.emits(input.take(4).toVector).repartition(ones).toVector shouldBe Vector("a", "b", "a", "b", "a", "b", "a", "b")
+
+      Stream(1, 2, 3, 4, 5).repartition(i => Segment(i, i)).toList shouldBe List(1, 3, 6, 10, 15, 15)
+
+      Stream(1, 10, 100).repartition(i => Segment.from(i).map(_.toInt)).take(4).toList shouldBe List(1, 2, 3, 4)
     }
 
     "translate" in forAll { (s: PureStream[Int]) =>

--- a/core/jvm/src/test/scala/fs2/StreamSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamSpec.scala
@@ -100,6 +100,17 @@ class StreamSpec extends Fs2Spec with Inside {
         IndexedSeq.range(0, 100)
     }
 
+    "repartition" in {
+      Stream("Lore", "m ip", "sum dolo", "r sit amet").repartition(_.split(" ").toIndexedSeq).toList ==
+        List("Lorem", "ipsum", "dolor", "sit", "amet") &&
+      Stream("hel", "l", "o Wor", "ld").repartition(_.grouped(2).toVector).toList ==
+        List("he", "ll", "o ", "Wo", "rl", "d") &&
+      Stream(1, 2, 3, 4, 5).repartition(i => Vector(i, i)).toList ==
+        List(1, 3, 6, 10, 15, 15) &&
+      (Stream(): Stream[Nothing, String]).repartition(_ => Vector()).toList == List() &&
+      Stream("hello").repartition(_ => Vector()).toList == List()
+    }
+
     "translate" in forAll { (s: PureStream[Int]) =>
       runLog(s.get.flatMap(i => Stream.eval(IO.pure(i))).translate(cats.arrow.FunctionK.id[IO])) shouldBe
       runLog(s.get)

--- a/core/jvm/src/test/scala/fs2/StreamSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamSpec.scala
@@ -108,24 +108,24 @@ class StreamSpec extends Fs2Spec with Inside {
     }
 
     "repartition" in {
-      Stream("Lore", "m ip", "sum dolo", "r sit amet").repartition(s => Segment.array(s.split(" "))).toList shouldBe
+      Stream("Lore", "m ip", "sum dolo", "r sit amet").repartition(s => Chunk.array(s.split(" "))).toList shouldBe
         List("Lorem", "ipsum", "dolor", "sit", "amet")
-      Stream("hel", "l", "o Wor", "ld").repartition(s => Segment.indexedSeq(s.grouped(2).toVector)).toList shouldBe
+      Stream("hel", "l", "o Wor", "ld").repartition(s => Chunk.indexedSeq(s.grouped(2).toVector)).toList shouldBe
         List("he", "ll", "o ", "Wo", "rl", "d")
-      Stream.empty.covaryOutput[String].repartition(_ => Segment.empty).toList shouldBe List()
-      Stream("hello").repartition(_ => Segment.empty).toList shouldBe List()
+      Stream.empty.covaryOutput[String].repartition(_ => Chunk.empty).toList shouldBe List()
+      Stream("hello").repartition(_ => Chunk.empty).toList shouldBe List()
 
       def input = Stream("ab").repeat
-      def ones(s: String) = Segment vector s.grouped(1).toVector
+      def ones(s: String) = Chunk vector s.grouped(1).toVector
       input.take(2).repartition(ones).toVector shouldBe Vector("a", "b", "a", "b")
       input.take(4).repartition(ones).toVector shouldBe Vector("a", "b", "a", "b", "a", "b", "a", "b")
       input.repartition(ones).take(2).toVector shouldBe Vector("a", "b")
       input.repartition(ones).take(4).toVector shouldBe Vector("a", "b", "a", "b")
       Stream.emits(input.take(4).toVector).repartition(ones).toVector shouldBe Vector("a", "b", "a", "b", "a", "b", "a", "b")
 
-      Stream(1, 2, 3, 4, 5).repartition(i => Segment(i, i)).toList shouldBe List(1, 3, 6, 10, 15, 15)
+      Stream(1, 2, 3, 4, 5).repartition(i => Chunk(i, i)).toList shouldBe List(1, 3, 6, 10, 15, 15)
 
-      Stream(1, 10, 100).repartition(i => Segment.from(i).map(_.toInt)).take(4).toList shouldBe List(1, 2, 3, 4)
+      Stream(1, 10, 100).repartition(i => Segment.from(i).map(_.toInt).take(1000).toChunk).take(4).toList shouldBe List(1, 2, 3, 4)
     }
 
     "translate" in forAll { (s: PureStream[Int]) =>

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2036,13 +2036,13 @@ object Stream {
                 (parts, parts2) match {
                   case (Left(()), _) => go(None, tl)
                   case (Right((phd, ptl)), Left(())) => go(Some(phd), tl)
-                  case (Right((phd, ptl)), Right(_)) => Pull.output1(phd) >> go(None, tl, ptl)
+                  case (Right((phd, ptl)), Right(_)) => Pull.output1(phd) *> go(None, tl, ptl)
                 }
             case None =>
               carry.fold[Pull[F, O, Unit]](Pull.done)(c => Pull.output1(c))
           }
         },
-        ps => ps._2.uncons1.fold(_ => go(Some(ps._1), s, ps._2), _ => Pull.output1(ps._1) >> go(None, s, ps._2)))
+        ps => ps._2.uncons1.fold(_ => go(Some(ps._1), s, ps._2), _ => Pull.output1(ps._1) *> go(None, s, ps._2)))
       }
       go(None, self).stream
     }


### PR DESCRIPTION
The PR builds off of #950 and implements `repartition` such that each segment in the underlying stream is scanned instead of unconsing single elements.

Note I had to change the repartition function to return a `Chunk` instead of a `Segment` but this is okay -- repartitioning a single element should not require an expansion in to an infinite segment.

@soumyarupsarkar -- please take a look. This uses the double layer scanning algorithm I attempted to describe in one of the reviews of #950.