### PR TITLE
Add link to Actor docs

### DIFF
--- a/core/shared/src/main/scala/fs2/internal/Actor.scala
+++ b/core/shared/src/main/scala/fs2/internal/Actor.scala
@@ -28,6 +28,8 @@ import java.util.concurrent.atomic.AtomicReference
  * Implementation based on non-intrusive MPSC node-based queue, described by Dmitriy Vyukov:
  * [[http://www.1024cores.net/home/lock-free-algorithms/queues/non-intrusive-mpsc-node-based-queue]]
  *
+ * A detailed analysis of the behaviour of Actor is available at [[https://gist.github.com/djspiewak/671deab9d7ea027cdc42]]
+ * 
  * @param handler  The message handler
  * @param onError  Exception handler, called if the message handler throws any `Throwable`.
  * @param ec       Execution context


### PR DESCRIPTION
This would have saved me  a  _ton_ of time when I was first learning about Actor, so I think it's worth linking.

I do have a question though: the article explains how the state of the queue is correctly shared in the presence of concurrency, but what about the state that the handler mutates?

In other words, let's say two calls to `act` happen on 2 different threads, and the handler is mutating a variable `myVar` , how will the update to `myVar` from one call be propagated to the other thread? (also assume that any call to `!` is happening on another thread still).  `act` doesn't write to any `volatile` (or Atomic*) field after running `handler`, so I don't see where the memory barrier is.

There's a comment saying:
"Memory consistency guarantee: when each message is processed by the `handler`, any memory that it mutates is guaranteed to be visible by the `handler` when it processes the next message, even if the execution context runs the invocations of `handler` on separate threads. This is achieved because the `Actor` reads a volatile memory location before entering its event loop, and writes to the same location before suspending."

but that doesn't seem to reflect what the code is doing (I think it refers to an older version of actor with an AtomicInteger called `suspended`). What am I missing?