### PR TITLE
Queue#peek1 and timedPeek1

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,3 +16,4 @@ Also see the [GitHub contributor stats](https://github.com/functional-streams-fo
 - Rúnar Ó. Bjarnason ([@runarorama](https://github.com/runarorama)): Various processes and combinators, circular buffers, compression. I'm an ideas man, Michael.
 - Jed Wesley-Smith ([@jedws](https://github.com/jedws)): really very minor tweaks, cleanups and pestering, hardly worth the mention
 - Michael Pilquist ([@mpilquist](https://github.com/mpilquist)): 0.9 redesign work, maintenance
+- Daniel Urban ([@durban](https://github.com/durban)): queue peek implementation

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,8 @@ lazy val contributors = Seq(
   "fthomas" -> "Frank Thomas",
   "runarorama" -> "Rúnar Ó. Bjarnason",
   "jedws" -> "Jed Wesley-Smith",
-  "mpilquist" -> "Michael Pilquist"
+  "mpilquist" -> "Michael Pilquist",
+  "durban" -> "Daniel Urban"
 )
 
 lazy val commonSettings = Seq(

--- a/core/jvm/src/test/scala/fs2/async/QueueSpec.scala
+++ b/core/jvm/src/test/scala/fs2/async/QueueSpec.scala
@@ -3,6 +3,7 @@ package async
 
 import scala.concurrent.duration._
 import cats.effect.IO
+import cats.implicits._
 
 class QueueSpec extends Fs2Spec {
   "Queue" - {
@@ -83,6 +84,116 @@ class QueueSpec extends Fs2Spec {
     }
     "size signal is initialized to zero" in {
       runLog(Stream.eval(async.unboundedQueue[IO,Int]).flatMap(_.size.discrete).take(1)) shouldBe Vector(0)
+    }
+    "peek1" in {
+      runLog(Stream.eval(
+        for {
+          q <- async.unboundedQueue[IO, Int]
+          f <- async.start(q.peek1)
+          g <- async.start(q.peek1)
+          _ <- q.enqueue1(42)
+          x <- f
+          y <- g
+        } yield List(x, y)
+      )).flatten shouldBe Vector(42, 42)
+    }
+    "peek1 with dequeue1" in {
+      runLog(Stream.eval(
+        for {
+          q <- async.unboundedQueue[IO, Int]
+          f <- async.start(q.peek1 product q.dequeue1)
+          _ <- q.enqueue1(42)
+          x <- f
+          g <- async.start((q.peek1 product q.dequeue1) product (q.peek1 product q.dequeue1))
+          _ <- q.enqueue1(43)
+          _ <- q.enqueue1(44)
+          yz <- g
+          (y, z) = yz
+        } yield List(x, y, z)
+      )).flatten shouldBe Vector((42, 42), (43, 43), (44, 44))
+    }
+    "timedPeek1" in {
+      runLog(Scheduler[IO](1).flatMap { scheduler =>
+        Stream.eval(
+          for {
+            q <- async.unboundedQueue[IO,Int]
+            x <- q.timedPeek1(100.millis, scheduler)
+            _ <- q.enqueue1(42)
+            y <- q.timedPeek1(100.millis, scheduler)
+            _ <- q.enqueue1(43)
+            z <- q.timedPeek1(100.millis, scheduler)
+          } yield List(x, y, z)
+        )
+      }).flatten shouldBe Vector(None, Some(42), Some(42))
+    }
+    "peek1 bounded queue" in {
+      runLog(Stream.eval(
+        for {
+          q <- async.boundedQueue[IO, Int](maxSize = 1)
+          f <- async.start(q.peek1)
+          g <- async.start(q.peek1)
+          _ <- q.enqueue1(42)
+          b <- q.offer1(43)
+          x <- f
+          y <- g
+          z <- q.dequeue1
+        } yield List(b, x, y, z)
+      )).flatten shouldBe Vector(false, 42, 42, 42)
+    }
+    "peek1 circular buffer" in {
+      runLog(Stream.eval(
+        for {
+          q <- async.circularBuffer[IO, Int](maxSize = 1)
+          f <- async.start(q.peek1)
+          g <- async.start(q.peek1)
+          _ <- q.enqueue1(42)
+          b <- q.offer1(43)
+          x <- f
+          y <- g
+          z <- q.peek1
+        } yield List(b, x, y, z)
+      )).flatten shouldBe Vector(true, 42, 42, 43)
+    }
+    "peek1 synchronous queue" in {
+      runLog(Stream.eval(
+        for {
+          q <- async.synchronousQueue[IO, Int]
+          f <- async.start(q.peek1)
+          g <- async.start(q.peek1)
+          _ <- async.start(q.enqueue1(42))
+          x <- q.dequeue1
+          y <- f
+          z <- g
+        } yield List(x, y, z)
+      )).flatten shouldBe Vector(42, 42, 42)
+    }
+    "timedPeek1 synchronous queue" in {
+      runLog(Scheduler[IO](1).flatMap { scheduler =>
+        Stream.eval(
+          for {
+            q <- async.synchronousQueue[IO, Int]
+            none1 <- q.timedPeek1(100.millis, scheduler)
+            _ <- async.start(q.enqueue1(42))
+            f <- async.start(q.timedPeek1(1000.millis, scheduler))
+            x <- q.dequeue1
+            y <- f
+            none2 <- q.timedPeek1(100.millis, scheduler)
+          } yield List(none1, x, y, none2)
+        )
+      }).flatten shouldBe Vector(None, 42, Some(42), None)
+    }
+    "peek1 synchronous None-terminated queue" in {
+      runLog(Stream.eval(
+        for {
+          q <- async.mutable.Queue.synchronousNoneTerminated[IO, Int]
+          f <- async.start(q.peek1)
+          g <- async.start(q.peek1)
+          _ <- q.enqueue1(None)
+          y <- f
+          z <- g
+          x <- q.dequeue1
+        } yield List(x, y, z)
+      )).flatten shouldBe Vector(None, None, None)
     }
   }
 }

--- a/core/shared/src/main/scala/fs2/async/mutable/Queue.scala
+++ b/core/shared/src/main/scala/fs2/async/mutable/Queue.scala
@@ -221,7 +221,7 @@ object Queue {
             else state
           }.map { change =>
             if (change.previous.queue.isEmpty) Left(change.now.peek.get)
-            else Right(change.now.queue.head)
+            else Right(change.previous.queue.head)
           }
         }
 

--- a/core/shared/src/main/scala/fs2/async/mutable/Queue.scala
+++ b/core/shared/src/main/scala/fs2/async/mutable/Queue.scala
@@ -52,11 +52,24 @@ abstract class Queue[F[_], A] { self =>
   def dequeue1: F[A]
 
   /**
+   * Returns the element which would be dequeued next,
+   * but without removing it. Completes when such an
+   * element is available.
+   */
+  def peek1: F[A]
+
+  /**
    * Like [[dequeue1]] but limits the amount of time spent waiting for an element
    * to be dequeued. If the element is dequeued before the timeout is reached, the
    * element is returned wrapped in `Some`. Otherwise, `None` is returned.
    */
   def timedDequeue1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[A]]
+
+  /**
+   * Like [[peek1]] but returns `None` if waiting for the
+   * element would need longer time than `timeout`.
+   */
+  def timedPeek1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[A]]
 
   /** Like `dequeue1` but provides a way to cancel the dequeue. */
   def cancellableDequeue1: F[(F[A], F[Unit])]
@@ -122,8 +135,11 @@ abstract class Queue[F[_], A] { self =>
         self.timedEnqueue1(g(a), timeout, scheduler)
       def offer1(a: B): F[Boolean] = self.offer1(g(a))
       def dequeue1: F[B] = self.dequeue1.map(f)
+      def peek1: F[B] = self.peek1.map(f)
       def timedDequeue1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[B]] =
         self.timedDequeue1(timeout, scheduler).map(_.map(f))
+      def timedPeek1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[B]] =
+        self.timedPeek1(timeout, scheduler).map(_.map(f))
       def cancellableDequeue1: F[(F[B],F[Unit])] =
         self.cancellableDequeue1.map(bu => bu._1.map(f) -> bu._2)
       def dequeueBatch1(batchSize: Int): F[Chunk[B]] =
@@ -144,10 +160,14 @@ object Queue {
       * @param queue    Queue, expressed as vector for fast cons/uncons from head/tail
       * @param deq      A list of waiting dequeuers, added to when queue is empty
       */
-    final case class State(queue: Vector[A], deq: Vector[Ref[F,Chunk[A]]])
+    final case class State(
+      queue: Vector[A],
+      deq: Vector[Ref[F,Chunk[A]]],
+      peek: Option[Ref[F, A]]
+    )
 
     Signal(0).flatMap { szSignal =>
-    async.refOf[F,State](State(Vector.empty,Vector.empty)).map { qref =>
+    async.refOf[F,State](State(Vector.empty, Vector.empty, None)).map { qref =>
       // Signals size change of queue, if that has changed
       def signalSize(s: State, ns: State) : F[Unit] = {
         if (s.queue.size != ns.queue.size) szSignal.set(ns.queue.size)
@@ -160,19 +180,55 @@ object Queue {
         def timedEnqueue1(a: A, timeout: FiniteDuration, scheduler: Scheduler): F[Boolean] = offer1(a)
         def offer1(a: A): F[Boolean] =
           qref.modify { s =>
-            if (s.deq.isEmpty) s.copy(queue = s.queue :+ a)
-            else s.copy(deq = s.deq.tail)
+            if (s.deq.isEmpty) s.copy(queue = s.queue :+ a, peek = None)
+            else s.copy(deq = s.deq.tail, peek = None)
           }.flatMap { c =>
-            if (c.previous.deq.isEmpty) // we enqueued a value to the queue
-              signalSize(c.previous, c.now).as(true)
-            else // queue was empty, we had waiting dequeuers
-              c.previous.deq.head.setAsyncPure(Chunk.singleton(a)).as(true)
+            val dq = if (c.previous.deq.isEmpty) {
+              // we enqueued a value to the queue
+              signalSize(c.previous, c.now)
+            } else {
+              // queue was empty, we had waiting dequeuers
+              c.previous.deq.head.setAsyncPure(Chunk.singleton(a))
+            }
+            val pk = if (c.previous.peek.isEmpty) {
+              // no peeker to notify
+              F.unit
+            } else {
+              // notify peekers
+              c.previous.peek.get.setAsyncPure(a)
+            }
+            (dq *> pk).as(true)
           }
 
         def dequeue1: F[A] = cancellableDequeue1.flatMap { _._1 }
 
+        def peek1: F[A] = peek1Impl.flatMap {
+          case Left(ref) => ref.get
+          case Right(a) => F.pure(a)
+        }
+
         def timedDequeue1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[A]] =
           timedDequeueBatch1(1, timeout, scheduler).map(_.map(_.strict.head))
+
+        def timedPeek1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[A]] = {
+          peek1Impl.flatMap {
+            case Left(ref) => ref.timedGet(timeout, scheduler)
+            case Right(a) => F.pure(Some(a))
+          }
+        }
+
+        private def peek1Impl: F[Either[Ref[F, A], A]] = ref[F, A].flatMap { ref =>
+          qref.modify2 { state =>
+            if (state.queue.isEmpty) {
+              state.peek match {
+                case None => (state.copy(peek = Some(ref)), Left(ref))
+                case Some(r) => (state, Left(r))
+              }
+            } else {
+              (state, Right(state.queue.head))
+            }
+          }.map(_._2)
+        }
 
         def cancellableDequeue1: F[(F[A],F[Unit])] =
           cancellableDequeueBatch1(1).map { case (deq,cancel) => (deq.map(_.strict.head),cancel) }
@@ -236,8 +292,11 @@ object Queue {
         def offer1(a: A): F[Boolean] =
           permits.tryDecrement.flatMap { b => if (b) q.offer1(a) else F.pure(false) }
         def dequeue1: F[A] = cancellableDequeue1.flatMap { _._1 }
+        def peek1: F[A] = q.peek1
         def timedDequeue1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[A]] =
           timedDequeueBatch1(1, timeout, scheduler).map(_.map(_.strict.head))
+        def timedPeek1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[A]] =
+          q.timedPeek1(timeout, scheduler)
         override def cancellableDequeue1: F[(F[A], F[Unit])] =
           cancellableDequeueBatch1(1).map { case (deq,cancel) => (deq.map(_.strict.head),cancel) }
         override def dequeueBatch1(batchSize: Int): F[Chunk[A]] = cancellableDequeueBatch1(batchSize).flatMap { _._1 }
@@ -266,8 +325,11 @@ object Queue {
         def offer1(a: A): F[Boolean] =
           enqueue1(a).as(true)
         def dequeue1: F[A] = cancellableDequeue1.flatMap { _._1 }
+        def peek1: F[A] = q.peek1
         def timedDequeue1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[A]] =
           timedDequeueBatch1(1, timeout, scheduler).map(_.map(_.strict.head))
+        def timedPeek1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[A]] =
+          q.timedPeek1(timeout, scheduler)
         def dequeueBatch1(batchSize: Int): F[Chunk[A]] = cancellableDequeueBatch1(batchSize).flatMap { _._1 }
         def timedDequeueBatch1(batchSize: Int, timeout: FiniteDuration, scheduler: Scheduler): F[Option[Chunk[A]]] =
           q.timedDequeueBatch1(batchSize, timeout, scheduler).flatMap {
@@ -296,8 +358,11 @@ object Queue {
         def offer1(a: A): F[Boolean] =
           permits.tryDecrement.flatMap { b => if (b) q.offer1(a) else F.pure(false) }
         def dequeue1: F[A] = cancellableDequeue1.flatMap { _._1 }
+        def peek1: F[A] = q.peek1
         def timedDequeue1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[A]] =
           timedDequeueBatch1(1, timeout, scheduler).map(_.map(_.strict.head))
+        def timedPeek1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[A]] =
+          q.timedPeek1(timeout, scheduler)
         def cancellableDequeue1: F[(F[A],F[Unit])] =
           permits.increment *> q.cancellableDequeue1
         override def dequeueBatch1(batchSize: Int): F[Chunk[A]] = q.dequeueBatch1(batchSize)
@@ -335,8 +400,11 @@ object Queue {
           }
         }
         def dequeue1: F[Option[A]] = cancellableDequeue1.flatMap { _._1 }
+        def peek1: F[Option[A]] = q.peek1
         def timedDequeue1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[Option[A]]] =
           timedDequeueBatch1(1, timeout, scheduler).map(_.map(_.strict.head))
+        def timedPeek1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[Option[A]]] =
+          q.timedPeek1(timeout, scheduler)
         def cancellableDequeue1: F[(F[Option[A]],F[Unit])] =
           permits.increment *> q.cancellableDequeue1
         override def dequeueBatch1(batchSize: Int): F[Chunk[Option[A]]] =


### PR DESCRIPTION
`Queue#peek1` and `timedPeek1` (fixes #983).

I'm unsure about the semantics for `synchronous` (and consequently for `synchronousNoneTerminated`). If I understand correctly, that queue is (conceptually) always empty. That would suggest, that `peek1` should never finish. However, it is in fact possible (sometimes) to dequeue an element from such a queue. Thus, peek could also work. This seems more useful, so this is what this PR currently implements.