### PR TITLE
Edited documentation of new scope/lease management

### DIFF
--- a/core/shared/src/main/scala/fs2/CompositeFailure.scala
+++ b/core/shared/src/main/scala/fs2/CompositeFailure.scala
@@ -2,13 +2,19 @@ package fs2
 
 import cats.data.NonEmptyList
 
-/**
-  * Certain implementation in fs2 may cause multiple failures from the different part of the code to be thrown and collected.
-  * In these scenarios, COmposite failure assures that user won't lose any intermediate failures.
-  */
-class CompositeFailure(
-  failures: NonEmptyList[Throwable]
-) extends Throwable({
-  if (failures.size == 1) failures.head.getMessage
-  else s"Multiple exceptions were thrown (${failures.size}), first ${failures.head.getClass.getName}: ${failures.head.getMessage}"
-}, failures.head)
+/** Represents multiple (>1) exceptions were thrown. */
+final class CompositeFailure(
+  head: Throwable,
+  tail: NonEmptyList[Throwable]
+) extends Throwable(s"Multiple exceptions were thrown (${1 + tail.size}), first ${head.getClass.getName}: ${head.getMessage}", head)
+
+object CompositeFailure {
+  def apply(first: Throwable, second: Throwable, rest: List[Throwable]): CompositeFailure =
+    new CompositeFailure(first, NonEmptyList(second, rest))
+
+  def fromList(errors: List[Throwable]): Option[Throwable] = errors match {
+    case Nil => None
+    case hd :: Nil => Some(hd)
+    case first :: second :: rest => Some(apply(first, second, rest))
+  }
+}

--- a/core/shared/src/main/scala/fs2/Lease.scala
+++ b/core/shared/src/main/scala/fs2/Lease.scala
@@ -1,0 +1,16 @@
+  package fs2
+
+/**
+ * Represents one or more resources that were leased from a scope, causing their
+ * lifetimes to be extended until `cancel` is invoked on this lease.
+ */
+abstract class Lease[F[_]] {
+
+  /**
+   * Cancels the lease of all resources tracked by this lease.
+   *
+   * This may run finalizers on some of the resources (depending on the state of their owning scopes).
+   * If one or more finalizers fail, the returned action completes with a `Left(t)`, providing the failure.
+   */
+  def cancel: F[Either[Throwable, Unit]]
+}

--- a/core/shared/src/main/scala/fs2/Pipe.scala
+++ b/core/shared/src/main/scala/fs2/Pipe.scala
@@ -4,7 +4,7 @@ import scala.concurrent.ExecutionContext
 import cats.effect.Effect
 import cats.implicits._
 import fs2.async.mutable.Queue
-import fs2.internal.{Algebra, FreeC, NonFatal, RunFoldScope}
+import fs2.internal.{Algebra, FreeC, NonFatal}
 
 object Pipe {
 
@@ -22,8 +22,7 @@ object Pipe {
 
     // Steps `s` without overhead of resource tracking
     def stepf(s: Stream[Read,O]): Read[UO] = {
-      Algebra.runFoldScope(
-        RunFoldScope.newRoot[Read],
+      Algebra.runFold(
         Algebra.uncons(s.get).flatMap {
           case Some((hd,tl)) => Algebra.output1[Read,UO](Some((hd,Stream.fromFreeC(tl))))
           case None => Algebra.pure[Read,UO,Unit](())

--- a/core/shared/src/main/scala/fs2/Pipe2.scala
+++ b/core/shared/src/main/scala/fs2/Pipe2.scala
@@ -1,6 +1,6 @@
 package fs2
 
-import fs2.internal.{Algebra, FreeC, NonFatal, RunFoldScope}
+import fs2.internal.{Algebra, FreeC, NonFatal}
 
 object Pipe2 {
   /** Creates a [[Stepper]], which allows incrementally stepping a pure `Pipe2`. */
@@ -20,8 +20,7 @@ object Pipe2 {
 
     // Steps `s` without overhead of resource tracking
     def stepf(s: Stream[Read,O]): Read[UO] = {
-      Algebra.runFoldScope(
-        RunFoldScope.newRoot[Read],
+      Algebra.runFold(
         Algebra.uncons(s.get).flatMap {
           case Some((hd,tl)) => Algebra.output1[Read,UO](Some((hd,Stream.fromFreeC(tl))))
           case None => Algebra.pure[Read,UO,Unit](())

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -1,7 +1,7 @@
 package fs2
 
 import cats.effect.Sync
-import fs2.internal.{ Algebra, FreeC }
+import fs2.internal.{ Algebra, FreeC, Token }
 
 /**
  * A `p: Pull[F,O,R]` reads values from one or more streams, returns a
@@ -176,7 +176,7 @@ object Pull {
   def suspend[F[_],O,R](p: => Pull[F,O,R]): Pull[F,O,R] =
     fromFreeC(Algebra.suspend(p.get))
 
-  private def release[F[_]](token: Algebra.Token): Pull[F,Nothing,Unit] =
+  private def release[F[_]](token: Token): Pull[F,Nothing,Unit] =
     fromFreeC[F,Nothing,Unit](Algebra.release(token))
 
   /** Implicitly covaries a pull. */

--- a/core/shared/src/main/scala/fs2/Scope.scala
+++ b/core/shared/src/main/scala/fs2/Scope.scala
@@ -1,58 +1,29 @@
 package fs2
 
-import fs2.Scope.Lease
-
-
 /**
-  * Scope represents a controlled block of execution of the stream to track resources acquired and released during
-  * the interpretation of the Stream.
-  *
-  * Scope's methods are used to perform low-level actions on stream interpretation, such as leasing the resources.
-  */
-trait Scope[F[_]] {
-
+ * Represents a period of stream execution in which resources are acquired and released.
+ *
+ * Note: this type is generally used to implement low-level actions that manipulate
+ * resource lifetimes and hence, isn't generally used by user-level code.
+ */
+abstract class Scope[F[_]] {
 
   /**
-    * Allows to lease resources of the current scope.
-    *
-    * Note that this will lease all the resources, and resources of all parents and children of this scope.
-    *
-    * If this scope is closed already, this will yield to None. Otherwise this returns `F` that when evaluated
-    * will cancelLease of the leased resources, possibly invoking their finalization.
-    *
-    * Resource may be finalized during this being executed, but before `lease` is acquired on the resource.
-    * In that case the already finalized resource won't be leased.
-    *
-    * As such this is important to be run only when all resources are known to be not finalized or not being
-    * about to be finalized yet.
-    *
-    * Wehn this completes all resources available at that time have been successfully leased.
-    *
-    */
+   * Leases the resources of this scope until the returned lease is cancelled.
+   *
+   * Note that this leases all resources in this scope, resources in all parent scopes (up to root)
+   * and resources of all child scopes.
+   *
+   * `None` is returned if this scope is already closed. Otherwise a lease is returned,
+   * which must be cancelled. Upon cancellation, resource finalizers may be run, depending on the
+   * state of the owning scopes.
+   *
+   * Resources may be finalized during the execution of this method and before the lease has been acquired
+   * for a resource. In such an event, the already finalized resource won't be leased. As such, it is
+   * important to call `lease` only when all resources are known to be non-finalized / non-finalizing.
+   *
+   * When the lease is returned, all resources available at the time `lease` was called have been
+   * successfully leased.
+   */
   def lease: F[Option[Lease[F]]]
-
-
 }
-
-object Scope {
-
-  /**
-    * Wraps leased resources from the scope of the other Stream.
-    */
-  trait Lease[F[_]] {
-
-    /**
-      * Cancels lease of the previously leased resources. This may actually run finalizers on some of the resources,
-      * and if these fails, tresulting `F` will be evaluated to left side.
-      * @return
-      */
-    def cancel: F[Either[Throwable, Unit]]
-
-  }
-
-
-}
-
-
-
-

--- a/core/shared/src/main/scala/fs2/internal/RunFoldScope.scala
+++ b/core/shared/src/main/scala/fs2/internal/RunFoldScope.scala
@@ -1,72 +1,67 @@
 package fs2.internal
 
-import java.util.concurrent.atomic.AtomicReference
-
-import fs2._
-import Algebra.Token
-import cats.data.NonEmptyList
-import cats.effect.Sync
-import fs2.Scope.Lease
-import fs2.async.SyncRef
-
 import scala.annotation.tailrec
 
+import java.util.concurrent.atomic.AtomicReference
 
+import fs2.{ Catenable, CompositeFailure, Lease, Scope }
+import fs2.async.SyncRef
+import cats.effect.Sync
 
 /**
-  * Scope represents a controlled block of execution of the stream to track resources acquired and released during
-  * the interpretation of the Stream.
-  *
-  * Scope may have associated resources with it and cleanups, that are evaluated when the scope closes.
-  *
-  * Scope lifetime:
-  *
-  * When stream interpretation starts, one `root` scope is created. Then Scopes are created and closed based on the
-  * stream structure, but as a rule of thumb every time when you convert Stream to `Pull` and back to Stream you are
-  * creating one scope (opening and closing) the scope.
-  *
-  * So for example `s.chunks` is defined with `s.repeatPull` which in turn is defined with `Pull.loop(...).stream`. In this
-  * case you always open and close single Scope.
-  *
-  * Scopes may be as well opened and closed manually with Stream#scope. Given `s.scope` that will open the scope before
-  * the stream `s` to be evaluated and will close the scope once the stream finishes its evaluation.
-  *
-  * Scope organization
-  *
-  * Scopes are organized in tree structure, with each scope having at max one parent (root has no parent)
-  * with Nil or more child scopes.
-  *
-  * Every time a new scope is created, it is inheriting parent from the current scope and it is adding itself to be
-  * child scope of that parent.
-  *
-  * During the interpretation of nondeterministic stream (i.e. merge) there may be multiple scopes attached to single parent
-  * and these scopes may be created and closed in nondeterministic order.
-  *
-  * Parent scope never outlives the child scopes. That means when parent scope is closed for whatever reason, the child
-  * scopes are closed too.
-  *
-  * Resources
-  *
-  * Primary role of the scope is track resource allocation and release. The Stream interpreter guarantees, that
-  * resources allocated in the scope are released always when the scope closes.
-  *
-  * Resource allocation
-  *
-  * Resource is allocated when interpreter interprets `Acquire` algebra. That is result of the Stream#bracket construct.
-  * Please see `Resource` for details how this is done.
-  *
-  * @param id           Unique identification of the scope
-  * @param parent       If empty indicates root scope. If nonemtpy, indicates parent of this scope
-  */
-final class RunFoldScope[F[_]]  private (val id: Token, private val parent: Option[RunFoldScope[F]])(implicit F: Sync[F]) extends Scope[F]{ self =>
+ * Implementation of [[Scope]] for the internal stream interpreter.
+ *
+ * Represents a period of stream execution in which resources are acquired and released.
+ * A scope has a state, consisting of resources (with associated finalizers) acquired in this scope
+ * and child scopes spawned from this scope.
+ *
+ * === Scope lifetime ===
+ *
+ * When stream interpretation starts, one `root` scope is created. Scopes are then created and closed based on the
+ * stream structure. Every time a `Pull` is converted to a `Stream`, a scope is created.
+ *
+ * For example, `s.chunks` is defined with `s.repeatPull` which in turn is defined with `Pull.loop(...).stream`.
+ * In this case, a single scope is created as a result of the call to `.stream`.
+ *
+ * Scopes may also be opened and closed manually with `Stream#scope`. For the stream `s.scope`, a scope
+ * is opened before evaluation of `s` and closed once `s` finishes evaluation.
+ *
+ * === Scope organization ===
+ *
+ * Scopes are organized in tree structure, with each scope having at max one parent (a root scope has no parent)
+ * with 0 or more child scopes.
+ *
+ * Every time a new scope is created, it inherits parent from the current scope and adds itself as a child
+ * of that parent.
+ *
+ * During the interpretation of nondeterministic streams (i.e. merge), there may be multiple scopes attached
+ * to a single parent and these scopes may be created and closed in a nondeterministic order.
+ *
+ * A child scope never outlives its parent scope. I.e., when a parent scope is closed for whatever reason,
+ * the child scopes are closed too.
+ *
+ * === Resources ===
+ *
+ * The primary role of a scope is tracking resource allocation and release. The stream interpreter guarantees that
+ * resources allocated in a scope are always released when the scope closes.
+ *
+ * === Resource allocation ===
+ *
+ * Resources are allocated when the interpreter interprets the `Acquire` element, which is typically constructed
+ * via `Stream.bracket` or `Pull.acquire`. See [[Resource]] docs for more information.
+ *
+ * @param id           Unique identification of the scope
+ * @param parent       If empty indicates root scope. If non-emtpy, indicates parent of this scope.
+ */
+private[internal] final class RunFoldScope[F[_]] private (val id: Token, private val parent: Option[RunFoldScope[F]])(implicit F: Sync[F]) extends Scope[F] { self =>
 
   private val state: SyncRef[F, RunFoldScope.State[F]] = new SyncRef(new AtomicReference(RunFoldScope.State.initial))
 
   /**
-    * Registers new resource in this scope.
-    * Yields to false, if the resource may not be registered because scope is closed already.
-    */
-  private[internal] def register(resource: Resource[F]): F[Boolean] =
+   * Registers supplied resource in this scope.
+   * Returns false if the resource may not be registered because scope is closed already.
+   */
+  def register(resource: Resource[F]): F[Boolean] =
     F.map(state.modify { s =>
       if (!s.open) s
       else s.copy(resources = resource +: s.resources)
@@ -74,11 +69,13 @@ final class RunFoldScope[F[_]]  private (val id: Token, private val parent: Opti
 
 
   /**
-    * When resource is released during the Scope lifetime, this is invoked.
-    * When this returns, the resource may not be actually released yet, as it may have been `leased` to other scopes,
-    * but this scope will lose reference to that resource always when this finishes evaluation.
-    */
-  private[internal] def releaseResource(id: Token): F[Either[Throwable, Unit]] =
+   * Releases the resource identified by the supplied token.
+   *
+   * Invoked when a resource is released during the scope's lifetime.
+   * When the action returns, the resource may not be released yet, as
+   * it may have been `leased` to other scopes.
+   */
+  def releaseResource(id: Token): F[Either[Throwable, Unit]] =
     F.flatMap(state.modify2 {  _.unregisterResource(id) }) { case (c, mr) => mr match {
       case Some(resource) => resource.release
       case None => F.pure(Right(()))// resource does not exist in scope any more.
@@ -86,13 +83,12 @@ final class RunFoldScope[F[_]]  private (val id: Token, private val parent: Opti
 
 
   /**
-    * Open child scope of this scope.
-    *
-    * If this scope is currently closed, then this will search any known parent scope of this scope
-    * and attaches newly creates scope to that scope.
-    *
-    */
-  private[internal] def open: F[RunFoldScope[F]] = {
+   * Opens a child scope.
+   *
+   * If this scope is currently closed, then the child scope is opened on the first
+   * open ancestor of this scope.
+   */
+  def open: F[RunFoldScope[F]] = {
     F.flatMap(state.modify2 { s =>
       if (! s.open) (s, None)
       else {
@@ -112,63 +108,56 @@ final class RunFoldScope[F[_]]  private (val id: Token, private val parent: Opti
   }
 
   /**
-    * When the child scope is closed, this signals to parent scope that it is not anymore responsible
-    * for the children scope and its resources.
-    */
-  private def releaseChildScope(id: Token): F[Unit] =
+   * Unregisters the child scope identified by the supplied id.
+   *
+   * As a result of unregistering a child scope, its resources are no longer
+   * reachable from its parent.
+   */
+  def releaseChildScope(id: Token): F[Unit] =
     F.map(state.modify2 { _.unregisterChild(id) }){ _ => () }
 
 
-  /** returns all resources of this scope **/
-  private def resources: F[Catenable[Resource[F]]] = {
+  /** Returns all direct resources of this scope (does not return resources in ancestor scopes or child scopes). **/
+  def resources: F[Catenable[Resource[F]]] = {
     F.map(state.get) { _.resources }
   }
 
   /**
-    * Traverses supplied Catenable with `f` that may produce failure, and collects theses failures.
-    * Returns failure with collected failures, or Unit on successful traversal.
-    */
+   * Traverses supplied `Catenable` with `f` that may produce a failure, and collects these failures.
+   * Returns failure with collected failures, or `Unit` on successful traversal.
+   */
   private def traverseError[A](ca: Catenable[A], f: A => F[Either[Throwable,Unit]]) : F[Either[Throwable, Unit]] = {
     F.map(Catenable.traverseInstance.traverse(ca)(f)) { results =>
-      results.collect { case Left(err) => err }.uncons match {
-        case None => Right(())
-        case Some((first, others)) => Left(new CompositeFailure(NonEmptyList(first, others.toList)))
-      }
+      CompositeFailure.fromList(results.collect { case Left(err) => err }.toList).toLeft(())
     }
   }
 
   /**
-    * Closes current scope.
-    *
-    * All resources of this scope are released when this is evaluated.
-    *
-    * Also this will close the children scopes (if any) and release their resources.
-    *
-    * If this scope is child of the parent scope, this will unregister this scope from the parent scope.
-    *
-    * Note that if there were leased or not yet acquired resources, that may cause that these resource will not be
-    * yet finalized even after this scope will be closed, but they will get finalized in near future. See Resource for
-    * more details.
-    *
-    */
-  private[internal] def close: F[Either[Throwable, Unit]] = {
+   * Closes this scope.
+   *
+   * All resources of this scope are released when this is evaluated.
+   *
+   * Also this will close the child scopes (if any) and release their resources.
+   *
+   * If this scope has a parent scope, this scope will be unregistered from its parent.
+   *
+   * Note that if there were leased or not yet acquired resources, these resource will not yet be
+   * finalized after this scope is closed, but they will get finalized shortly after. See [[Resource]] for
+   * more details.
+   */
+  def close: F[Either[Throwable, Unit]] = {
     F.flatMap(state.modify{ _.close }) { c =>
     F.flatMap(traverseError[RunFoldScope[F]](c.previous.children, _.close)) { resultChildren =>
     F.flatMap(traverseError[Resource[F]](c.previous.resources, _.release)) { resultResources =>
     F.map(self.parent.fold(F.unit)(_.releaseChildScope(self.id))) { _ =>
       val results = resultChildren.left.toSeq ++ resultResources.left.toSeq
-      results.headOption match {
-       case None => Right(())
-       case Some(h) => Left(new CompositeFailure(NonEmptyList(h, results.tail.toList)))
-     }
+      CompositeFailure.fromList(results.toList).toLeft(())
     }}}}
   }
 
 
-  /**
-    * Returns closes open parent scope or root.
-    */
-  private[internal] def openAncestor: F[RunFoldScope[F]] = {
+  /** Returns closest open parent scope or root. */
+  def openAncestor: F[RunFoldScope[F]] = {
     self.parent.fold(F.pure(self)) { parent =>
       F.flatMap(parent.state.get) { s =>
         if (s.open) F.pure(parent)
@@ -177,7 +166,7 @@ final class RunFoldScope[F[_]]  private (val id: Token, private val parent: Opti
     }
   }
 
-  /** gets all ancestors of this scope, inclusive root scope **/
+  /** Gets all ancestors of this scope, inclusive of root scope. **/
   private def ancestors: F[Catenable[RunFoldScope[F]]] = {
     @tailrec
     def go(curr: RunFoldScope[F], acc: Catenable[RunFoldScope[F]]): F[Catenable[RunFoldScope[F]]] = {
@@ -189,24 +178,7 @@ final class RunFoldScope[F[_]]  private (val id: Token, private val parent: Opti
     go(self, Catenable.empty)
   }
 
-
-  /**
-    * Allows to lease resources of the current scope.
-    *
-    * Note that this will lease all the resources, and resources of all parents and children of this scope.
-    *
-    * If this scope is closed already, this will yield to None. Otherwise this returns `F` that when evaluated
-    * will cancelLease of the leased resources, possibly invoking their finalization.
-    *
-    * Resource may be finalized during this being executed, but before `lease` is acquired on the resource.
-    * In that case the already finalized resource won't be leased.
-    *
-    * As such this is important to be run only when all resources are known to be not finalized or not being
-    * about to be finalized yet.
-    *
-    * When this completes all resources available at that time have been successfully leased.
-    *
-    */
+  // See docs on [[Scope#lease]]
   def lease: F[Option[Lease[F]]] = {
     val T = Catenable.traverseInstance
     F.flatMap(state.get) { s =>
@@ -226,20 +198,15 @@ final class RunFoldScope[F[_]]  private (val id: Token, private val parent: Opti
         }}}
       }
     }
-
   }
-
-
-
 }
 
-object RunFoldScope {
+private[internal] object RunFoldScope {
+  /** Creates a new root scope. */
   def newRoot[F[_]: Sync]: RunFoldScope[F] = new RunFoldScope[F](new Token(), None)
 
-
-
   /**
-    * State of the scope
+    * State of a scope.
     *
     * @param open               Yields to true if the scope is open
     *
@@ -250,14 +217,9 @@ object RunFoldScope {
     * @param children           Children of this scope. Children may appear during the parallel pulls where one scope may
     *                           split to multiple asynchronously acquired scopes and resources.
     *                           Still, likewise for resources they are released in reverse order.
-    *
-    *
-    * @tparam F
     */
-  final private[RunFoldScope] case class State[F[_]](
-    open: Boolean
-    , resources: Catenable[Resource[F]]
-    , children: Catenable[RunFoldScope[F]]
+  final private case class State[F[_]](
+    open: Boolean, resources: Catenable[Resource[F]], children: Catenable[RunFoldScope[F]]
   ) { self =>
 
     def unregisterResource(id: Token): (State[F], Option[Resource[F]]) = {
@@ -273,19 +235,13 @@ object RunFoldScope {
     }
 
     def close: State[F] = RunFoldScope.State.closed
-
   }
 
-
-  private[RunFoldScope] object State {
+  private object State {
     private val initial_ = State[Nothing](open = true, resources = Catenable.empty, children = Catenable.empty)
     def initial[F[_]]: State[F] = initial_.asInstanceOf[State[F]]
 
     private val closed_ = State[Nothing](open = false, resources = Catenable.empty, children = Catenable.empty)
     def closed[F[_]]: State[F] = closed_.asInstanceOf[State[F]]
-
   }
-
-
-
 }

--- a/core/shared/src/main/scala/fs2/internal/Token.scala
+++ b/core/shared/src/main/scala/fs2/internal/Token.scala
@@ -1,0 +1,6 @@
+package fs2.internal
+
+/** Represents a unique identifier (using object equality). */
+private[fs2] final class Token {
+  override def toString: String = s"Token(${hashCode.toHexString})"
+}


### PR DESCRIPTION
Non-doc changes include:
 - Moving `Lease` back to a type-level type since it's used by both `Scope` and `Resource`
 - Changing `CompositeFailure` so that it always represents at least 2 exceptions
 - Moving `Algebra.Token` to top level of `internal` package since it's used by `Resource` and `Scope`