### PR TITLE
Remove Throwable from Ref

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2510,7 +2510,7 @@ object Stream {
               , None : UO
             ){ (_, uo) => uo.asInstanceOf[UO] } map { _ map { case (hd, tl) => (hd, fromFreeC(tl)) }}
 
-          Algebra.eval(ref.setAsync(F.attempt(runStep))) map { _ => AsyncPull.readAttemptRef(ref) }
+          Algebra.eval(async.fork(F.flatMap(F.attempt(runStep))(ref.setAsyncPure))) map { _ => AsyncPull.readAttemptRef(ref) }
         }
       }
     }

--- a/core/shared/src/main/scala/fs2/async/Ref.scala
+++ b/core/shared/src/main/scala/fs2/async/Ref.scala
@@ -15,9 +15,9 @@ import Ref._
 /** An asynchronous, concurrent mutable reference. */
 final class Ref[F[_],A] private[fs2] (implicit F: Effect[F], ec: ExecutionContext) extends RefOps[F,A] { self =>
 
-  private var result: Either[Throwable,A] = null
+  private var result: Box[A] = null
   // any waiting calls to `access` before first `set`
-  private var waiting: LinkedMap[MsgId, Either[Throwable,(A, Long)] => Unit] = LinkedMap.empty
+  private var waiting: LinkedMap[MsgId, ((A, Long)) => Unit] = LinkedMap.empty
   // id which increases with each `set` or successful `modify`
   private var nonce: Long = 0
 
@@ -26,9 +26,9 @@ final class Ref[F[_],A] private[fs2] (implicit F: Effect[F], ec: ExecutionContex
       if (result eq null) {
         waiting = waiting.updated(idf, cb)
       } else {
-        val r = result
+        val r = result.value
         val id = nonce
-        ec.execute { () => cb((r: Either[Throwable, A]).map((_,id))) }
+        ec.execute { () => cb(r -> id) }
       }
 
     case Msg.Set(r, cb) =>
@@ -36,29 +36,29 @@ final class Ref[F[_],A] private[fs2] (implicit F: Effect[F], ec: ExecutionContex
       if (result eq null) {
         val id = nonce
         waiting.values.foreach { cb =>
-          ec.execute { () => cb((r: Either[Throwable, A]).map((_,id))) }
+          ec.execute { () => cb(r -> id) }
         }
         waiting = LinkedMap.empty
       }
-      result = r
+      result = new Box(r)
       cb()
 
     case Msg.TrySet(id, r, cb) =>
       if (id == nonce) {
         nonce += 1L; val id2 = nonce
         waiting.values.foreach { cb =>
-          ec.execute { () => cb((r: Either[Throwable, A]).map((_,id2))) }
+          ec.execute { () => cb(r -> id2) }
         }
         waiting = LinkedMap.empty
-        result = r
-        cb(Right(true))
+        result = new Box(r)
+        cb(true)
       }
-      else cb(Right(false))
+      else cb(false)
 
     case Msg.Nevermind(id, cb) =>
       val interrupted = waiting.get(id).isDefined
       waiting = waiting - id
-      ec.execute { () => cb(Right(interrupted)) }
+      ec.execute { () => cb(interrupted) }
   }
 
   /**
@@ -68,11 +68,11 @@ final class Ref[F[_],A] private[fs2] (implicit F: Effect[F], ec: ExecutionContex
    * setter first. Once it has noop'd or been used once, a setter
    * never succeeds again.
    */
-  def access: F[(A, Either[Throwable,A] => F[Boolean])] =
+  def access: F[(A, A => F[Boolean])] =
     F.flatMap(F.delay(new MsgId)) { mid =>
       F.map(getStamped(mid)) { case (a, id) =>
-        val set = (a: Either[Throwable,A]) =>
-          F.async[Boolean] { cb => actor ! Msg.TrySet(id, a, cb) }
+        val set = (a: A) =>
+          F.async[Boolean] { cb => actor ! Msg.TrySet(id, a, x => cb(Right(x))) }
         (a, set)
       }
     }
@@ -84,7 +84,7 @@ final class Ref[F[_],A] private[fs2] (implicit F: Effect[F], ec: ExecutionContex
     val id = new MsgId
     val get = F.map(getStamped(id))(_._1)
     val cancel = F.async[Unit] {
-      cb => actor ! Msg.Nevermind(id, r => cb((r: Either[Throwable, Boolean]).map(_ => ())))
+      cb => actor ! Msg.Nevermind(id, r => cb(Right(()))) // do we need the Nevermind callback to take a boolean?
     }
     (get, cancel)
   }
@@ -103,7 +103,7 @@ final class Ref[F[_],A] private[fs2] (implicit F: Effect[F], ec: ExecutionContex
   override def tryModify(f: A => A): F[Option[Change[A]]] =
     access.flatMap { case (previous,set) =>
       val now = f(previous)
-      set(Right(now)).map { b =>
+      set(now).map { b =>
         if (b) Some(Change(previous, now))
         else None
       }
@@ -112,7 +112,7 @@ final class Ref[F[_],A] private[fs2] (implicit F: Effect[F], ec: ExecutionContex
   override def tryModify2[B](f: A => (A,B)): F[Option[(Change[A], B)]] =
     access.flatMap { case (previous,set) =>
       val (now,b0) = f(previous)
-      set(Right(now)).map { b =>
+      set(now).map { b =>
         if (b) Some(Change(previous, now) -> b0)
         else None
       }
@@ -131,10 +131,10 @@ final class Ref[F[_],A] private[fs2] (implicit F: Effect[F], ec: ExecutionContex
     }
 
   override def setAsyncPure(a: A): F[Unit] =
-    F.delay { actor ! Msg.Set(Right(a), () => ()) }
+    F.delay { actor ! Msg.Set(a, () => ()) }
 
   override def setSyncPure(a: A): F[Unit] =
-    F.async[Unit](cb => actor ! Msg.Set(Right(a), () => cb(Right(())))) *> F.shift
+    F.async[Unit](cb => actor ! Msg.Set(a, () => cb(Right(())))) *> F.shift
 
   /**
    * Runs `f1` and `f2` simultaneously, but only the winner gets to
@@ -158,7 +158,7 @@ final class Ref[F[_],A] private[fs2] (implicit F: Effect[F], ec: ExecutionContex
           case Right(v) =>
             val actor = ref.get
             ref.set(null)
-            actor ! Msg.Set(Right(v), () => ())
+            actor ! Msg.Set(v, () => ())
         }
       }
     }
@@ -167,7 +167,7 @@ final class Ref[F[_],A] private[fs2] (implicit F: Effect[F], ec: ExecutionContex
   }
 
   private def getStamped(msg: MsgId): F[(A,Long)] =
-    F.async[(A,Long)] { cb => actor ! Msg.Read(cb, msg) }
+    F.async[(A,Long)] { cb => actor ! Msg.Read(x => cb(Right(x)), msg) }
 }
 
 object Ref {
@@ -181,11 +181,12 @@ object Ref {
     uninitialized[F, A].flatMap(r => r.setSyncPure(a).as(r))
 
   private final class MsgId
+  private final class Box[A](val value: A)
   private sealed abstract class Msg[A]
   private object Msg {
-    final case class Read[A](cb: Either[Throwable,(A, Long)] => Unit, id: MsgId) extends Msg[A]
-    final case class Nevermind[A](id: MsgId, cb: Either[Throwable,Boolean] => Unit) extends Msg[A]
-    final case class Set[A](r: Either[Throwable,A], cb: () => Unit) extends Msg[A]
-    final case class TrySet[A](id: Long, r: Either[Throwable,A], cb: Either[Throwable,Boolean] => Unit) extends Msg[A]
+    final case class Read[A](cb: ((A, Long)) => Unit, id: MsgId) extends Msg[A]
+    final case class Nevermind[A](id: MsgId, cb: Boolean => Unit) extends Msg[A]
+    final case class Set[A](r: A, cb: () => Unit) extends Msg[A]
+    final case class TrySet[A](id: Long, r: A, cb: Boolean => Unit) extends Msg[A]
   }
 }

--- a/core/shared/src/main/scala/fs2/async/Ref.scala
+++ b/core/shared/src/main/scala/fs2/async/Ref.scala
@@ -130,19 +130,6 @@ final class Ref[F[_],A] private[fs2] (implicit F: Effect[F], ec: ExecutionContex
       case Some(changeAndB) => F.pure(changeAndB)
     }
 
-  /**
-   * *Asynchronously* sets the current value to the value computed by `fa`.
-   *
-   * After the returned `F[Unit]` is bound, an update will eventually occur, setting the current value to
-   * the value computed by `fa`.
-   *
-   * Note: upon binding the returned action, `fa` is shifted to the execution context of this `Ref`
-   * and then forked. Because the evaluation of `fa` is shifted, any errors that occur while evaluating
-   * `fa` are propagated through subsequent calls to `get` (the returned action completes successfully).
-   */
-  def setAsync(fa: F[A]): F[Unit] =
-    F.liftIO(F.runAsync(F.shift(ec) *> fa) { r => IO(actor ! Msg.Set(r, () => ())) })
-
   override def setAsyncPure(a: A): F[Unit] =
     F.delay { actor ! Msg.Set(Right(a), () => ()) }
 

--- a/core/shared/src/main/scala/fs2/async/Ref.scala
+++ b/core/shared/src/main/scala/fs2/async/Ref.scala
@@ -153,12 +153,12 @@ final class Ref[F[_],A] private[fs2] (implicit F: Effect[F], ec: ExecutionContex
       // or the actor directly, and the winner destroys any
       // references behind it!
       if (won.compareAndSet(false, true)) {
+        val actor = ref.get
+        ref.set(null)
+
         res match {
           case Left(e) => throw e
-          case Right(v) =>
-            val actor = ref.get
-            ref.set(null)
-            actor ! Msg.Set(v, () => ())
+          case Right(v) => actor ! Msg.Set(v, () => ())
         }
       }
     }

--- a/core/shared/src/main/scala/fs2/async/mutable/Queue.scala
+++ b/core/shared/src/main/scala/fs2/async/mutable/Queue.scala
@@ -381,7 +381,7 @@ object Queue {
         def enqueue1(a: Option[A]): F[Unit] = doneRef.access.flatMap { case (done, update) =>
           if (done) F.pure(())
           else a match {
-            case None => update(Right(true)).flatMap { successful => if (successful) q.enqueue1(None) else enqueue1(None) }
+            case None => update(true).flatMap { successful => if (successful) q.enqueue1(None) else enqueue1(None) }
             case _ => permits.decrement *> q.enqueue1(a)
           }
         }
@@ -390,7 +390,7 @@ object Queue {
         def offer1(a: Option[A]): F[Boolean] = doneRef.access.flatMap { case (done, update) =>
           if (done) F.pure(true)
           else a match {
-            case None => update(Right(true)).flatMap { successful => if (successful) q.offer1(None) else offer1(None) }
+            case None => update(true).flatMap { successful => if (successful) q.offer1(None) else offer1(None) }
             case _ => permits.decrement *> q.offer1(a)
           }
         }

--- a/core/shared/src/test/scala/fs2/async/RefSpec.scala
+++ b/core/shared/src/test/scala/fs2/async/RefSpec.scala
@@ -19,7 +19,7 @@ class RefSpec extends Fs2Spec {
           ref.access.flatMap{ case ((_, set)) =>
             ref.setAsyncPure(2).flatMap { _ =>
               mkScheduler.runLast.map(_.get).flatMap { scheduler =>
-                IO.shift(scheduler.delayedExecutionContext(100.millis)) *> set(Right(3))
+                IO.shift(scheduler.delayedExecutionContext(100.millis)) *> set(3)
               }
             }
           }

--- a/core/shared/src/test/scala/fs2/async/RefSpec.scala
+++ b/core/shared/src/test/scala/fs2/async/RefSpec.scala
@@ -27,10 +27,26 @@ class RefSpec extends Fs2Spec {
       }.unsafeToFuture.map { _ shouldBe false }
     }
 
-    "setSync" in {
+    "setSyncPure" in {
       ref[IO, Int].flatMap { ref =>
-        ref.setSyncPure(0) *> ref.setSync(IO(1)) *> ref.get
-      }.unsafeToFuture.map { _ shouldBe 1 }
+        ref.setSyncPure(0) *> ref.get
+      }.unsafeToFuture.map { _ shouldBe 0 }
+    }
+
+    "Successful race" in {
+      mkScheduler.runLast.map(_.get).flatMap { s =>
+          val fast = s.effect.sleep[IO](20.millis) *> true.pure[IO]
+          val slow = s.effect.sleep[IO](200.millis) *> false.pure[IO]
+          ref[IO, Boolean].flatMap(r => r.race(fast, slow) *> r.get)
+      }.unsafeToFuture.map { _ shouldBe true}
+    }
+
+    "Unsuccessful race" in {
+      mkScheduler.runLast.map(_.get).flatMap { s =>
+          val fast = s.effect.sleep[IO](20.millis) *> IO.raiseError[Boolean](new Exception)
+          val slow = s.effect.sleep[IO](200.millis) *> false.pure[IO]
+          ref[IO, Boolean].flatMap(r => r.race(fast, slow))
+      }.attempt.unsafeToFuture.map { _ should be ('left)}
     }
 
     "timedGet" in {


### PR DESCRIPTION
As per the title, it partially addresses #993 .
 Note that the behaviour of all code that depends on Ref within fs2 has _not_ been changed, e.g. I haven't experimented with changing on what EC anything runs, or switching async to sync or anything like that.
This is a sheer refactor, that shouldn't affect the behaviour of the rest of fs2 at all. The semantics of Ref have slightly changed though (hopefully for the best), and the implementation should be a bit clearer without Throwable. 
The commits are self-contained if you prefer to look at them them individually.
Let me know what you think.