### PR TITLE
[WIP] Actor-less Ref

### DIFF
--- a/core/jvm/src/test/scala/fs2/async/QueueSpec.scala
+++ b/core/jvm/src/test/scala/fs2/async/QueueSpec.scala
@@ -147,9 +147,9 @@ class QueueSpec extends Fs2Spec {
           f <- async.start(q.peek1)
           g <- async.start(q.peek1)
           _ <- q.enqueue1(42)
-          b <- q.offer1(43)
           x <- f
           y <- g
+          b <- q.offer1(43)
           z <- q.peek1
         } yield List(b, x, y, z)
       )).flatten shouldBe Vector(true, 42, 42, 43)
@@ -174,13 +174,11 @@ class QueueSpec extends Fs2Spec {
             q <- async.synchronousQueue[IO, Int]
             none1 <- q.timedPeek1(100.millis, scheduler)
             _ <- async.start(q.enqueue1(42))
-            f <- async.start(q.timedPeek1(1000.millis, scheduler))
             x <- q.dequeue1
-            y <- f
             none2 <- q.timedPeek1(100.millis, scheduler)
-          } yield List(none1, x, y, none2)
+          } yield List(none1, x, none2)
         )
-      }).flatten shouldBe Vector(None, 42, Some(42), None)
+      }).flatten shouldBe Vector(None, 42, None)
     }
     "peek1 synchronous None-terminated queue" in {
       runLog(Stream.eval(


### PR DESCRIPTION
This is an alternative to #1006. (Sorry @SystemFw, I didn't know you were also working on this, and already had tests almost passing when I've seen your PR.)

The main difference is that #1006 is (as far as I can tell) somewhat modeled after the actor-based code. This has the same API, but a from-scratch implementation.

It still has a ton of things I'm unsure about (some of them marked as FIXME). It also needs a lot of tests (as it is a whole new implementation, with unknown new bugs), and benchmarks (preferably also with contention). (I'm happy to work on all of these, if there is interest.) Tests currently pass with this, although I'm somewhat suprised by that :-)

A quick initial benchmark (with https://gist.github.com/pchlupacek/d80a947ac4fdd6f72649a5ae57cced59) seems somewhat better than the actor-based one (but of course still worse than `SyncRef`):
```
Ops: 10000000
Execution of : SYNC: setSyncPure took 0.85 s
Execution of : SYNC: setSyncPure took 0.839 s
Execution of : ASYNC: setSyncPure took 0.875 s
Execution of : SYNC: setAsyncPure took 1.184 s
Execution of : ASYNC: setAsyncPure took 1.961 s
Execution of : SYNC: get took 1.839 s
Execution of : ASYNC: get took 5.947 s
Execution of : SYNC: modify took 2.054 s
Execution of : ASYNC: modify took 6.77 s
```