### PR TITLE
Segment/Chunk usability

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/ConcurrentBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/ConcurrentBenchmark.scala
@@ -11,7 +11,7 @@ class ConcurrentBenchmark {
   @GenerateN(1, 2, 4, 7, 16, 32, 64, 128, 256)
   @Benchmark
   def join(N: Int): Int = {
-    val each = Stream.segment(Chunk.seq(0 to 1000).map(i => Stream.eval(IO.pure(i)))).covary[IO]
+    val each = Stream.segment(Segment.seq(0 to 1000).map(i => Stream.eval(IO.pure(i)))).covary[IO]
     each.join(N).runLast.unsafeRunSync.get
   }
 }

--- a/core/jvm/src/main/scala/fs2/compress.scala
+++ b/core/jvm/src/main/scala/fs2/compress.scala
@@ -34,13 +34,13 @@ object compress {
       case Some((hd,tl)) =>
         deflater.setInput(hd.toArray)
         val result = _deflate_collect(deflater, buffer, ArrayBuffer.empty, false).toArray
-        Pull.output(Chunk.bytes(result)) >> _deflate_stream(deflater, buffer)(tl)
+        Pull.outputChunk(Chunk.bytes(result)) >> _deflate_stream(deflater, buffer)(tl)
       case None =>
         deflater.setInput(Array.empty)
         deflater.finish()
         val result = _deflate_collect(deflater, buffer, ArrayBuffer.empty, true).toArray
         deflater.end()
-        Pull.output(Chunk.bytes(result))
+        Pull.outputChunk(Chunk.bytes(result))
     }
 
   @tailrec
@@ -68,7 +68,7 @@ object compress {
         val buffer = new Array[Byte](bufferSize)
         inflater.setInput(hd.toArray)
         val result = _inflate_collect(inflater, buffer, ArrayBuffer.empty).toArray
-        Pull.output(Chunk.bytes(result)) >> _inflate_stream(inflater, buffer)(tl)
+        Pull.outputChunk(Chunk.bytes(result)) >> _inflate_stream(inflater, buffer)(tl)
     }.stream
   }
 
@@ -77,7 +77,7 @@ object compress {
       case Some((hd,tl)) =>
         inflater.setInput(hd.toArray)
         val result = _inflate_collect(inflater, buffer, ArrayBuffer.empty).toArray
-        Pull.output(Chunk.bytes(result)) >> _inflate_stream(inflater, buffer)(tl)
+        Pull.outputChunk(Chunk.bytes(result)) >> _inflate_stream(inflater, buffer)(tl)
       case None =>
         if (!inflater.finished) Pull.raiseError(new DataFormatException("Insufficient data"))
         else { inflater.end(); Pull.done }

--- a/core/jvm/src/test/scala/fs2/PipeSpec.scala
+++ b/core/jvm/src/test/scala/fs2/PipeSpec.scala
@@ -154,19 +154,19 @@ class PipeSpec extends Fs2Spec {
 
     "filter (2)" in forAll { (s: PureStream[Double]) =>
       val predicate = (i: Double) => i - i.floor < 0.5
-      val s2 = s.get.mapSegments(s => Chunk.doubles(s.force.toArray))
+      val s2 = s.get.mapSegments(s => Chunk.doubles(s.force.toArray).toSegment)
       runLog(s2.filter(predicate)) shouldBe runLog(s2).filter(predicate)
     }
 
     "filter (3)" in forAll { (s: PureStream[Byte]) =>
       val predicate = (b: Byte) => b < 0
-      val s2 = s.get.mapSegments(s => Chunk.bytes(s.force.toArray))
+      val s2 = s.get.mapSegments(s => Chunk.bytes(s.force.toArray).toSegment)
       runLog(s2.filter(predicate)) shouldBe runLog(s2).filter(predicate)
     }
 
     "filter (4)" in forAll { (s: PureStream[Boolean]) =>
       val predicate = (b: Boolean) => !b
-      val s2 = s.get.mapSegments(s => Chunk.booleans(s.force.toArray))
+      val s2 = s.get.mapSegments(s => Chunk.booleans(s.force.toArray).toSegment)
       runLog(s2.filter(predicate)) shouldBe runLog(s2).filter(predicate)
     }
 
@@ -492,7 +492,7 @@ class PipeSpec extends Fs2Spec {
                 }
               case Stepper.Await(receive) =>
                 s.pull.uncons1.flatMap {
-                  case Some(((i,a),s)) => go(Some(a), receive(Some(Chunk.singleton(i))), s)
+                  case Some(((i,a),s)) => go(Some(a), receive(Some(Segment.singleton(i))), s)
                   case None => go(last, receive(None), s)
                 }
             }

--- a/core/jvm/src/test/scala/fs2/PipeSpec.scala
+++ b/core/jvm/src/test/scala/fs2/PipeSpec.scala
@@ -57,11 +57,11 @@ class PipeSpec extends Fs2Spec {
       val unsegmentedV = s.get.toVector
       assert {
         // All but last list have n0 values
-        segmentedV.dropRight(1).forall(_.toChunk.size == n0.get) &&
+        segmentedV.dropRight(1).forall(_.force.toChunk.size == n0.get) &&
         // Last list has at most n0 values
-        segmentedV.lastOption.fold(true)(_.toChunk.size <= n0.get) &&
+        segmentedV.lastOption.fold(true)(_.force.toChunk.size <= n0.get) &&
         // Flattened sequence is equal to vector without segmenting
-        segmentedV.foldLeft(Vector.empty[Int])((v, l) => v ++ l.toVector) == unsegmentedV
+        segmentedV.foldLeft(Vector.empty[Int])((v, l) => v ++ l.force.toVector) == unsegmentedV
       }
     }
 
@@ -71,9 +71,9 @@ class PipeSpec extends Fs2Spec {
       val expectedSize = unsegmentedV.size - (unsegmentedV.size % n0.get)
       assert {
         // All lists have n0 values
-        segmentedV.forall(_.toChunk.size == n0.get) &&
+        segmentedV.forall(_.force.toChunk.size == n0.get) &&
         // Flattened sequence is equal to vector without segmenting, minus "left over" values that could not fit in a segment
-        segmentedV.foldLeft(Vector.empty[Int])((v, l) => v ++ l.toVector) == unsegmentedV.take(expectedSize)
+        segmentedV.foldLeft(Vector.empty[Int])((v, l) => v ++ l.force.toVector) == unsegmentedV.take(expectedSize)
       }
     }
 
@@ -154,19 +154,19 @@ class PipeSpec extends Fs2Spec {
 
     "filter (2)" in forAll { (s: PureStream[Double]) =>
       val predicate = (i: Double) => i - i.floor < 0.5
-      val s2 = s.get.mapSegments(s => Chunk.doubles(s.toVector.toArray))
+      val s2 = s.get.mapSegments(s => Chunk.doubles(s.force.toArray))
       runLog(s2.filter(predicate)) shouldBe runLog(s2).filter(predicate)
     }
 
     "filter (3)" in forAll { (s: PureStream[Byte]) =>
       val predicate = (b: Byte) => b < 0
-      val s2 = s.get.mapSegments(s => Chunk.bytes(s.toVector.toArray))
+      val s2 = s.get.mapSegments(s => Chunk.bytes(s.force.toArray))
       runLog(s2.filter(predicate)) shouldBe runLog(s2).filter(predicate)
     }
 
     "filter (4)" in forAll { (s: PureStream[Boolean]) =>
       val predicate = (b: Boolean) => !b
-      val s2 = s.get.mapSegments(s => Chunk.booleans(s.toVector.toArray))
+      val s2 = s.get.mapSegments(s => Chunk.booleans(s.force.toArray))
       runLog(s2.filter(predicate)) shouldBe runLog(s2).filter(predicate)
     }
 
@@ -208,9 +208,9 @@ class PipeSpec extends Fs2Spec {
       val f = (i: Int) => i % n.get
       val s1 = s.get.groupAdjacentBy(f)
       val s2 = s.get.map(f).changes
-      runLog(s1.map(_._2)).flatMap(_.toVector) shouldBe runLog(s.get)
+      runLog(s1.map(_._2)).flatMap(_.force.toVector) shouldBe runLog(s.get)
       runLog(s1.map(_._1)) shouldBe runLog(s2)
-      runLog(s1.map { case (k, vs) => vs.toVector.forall(f(_) == k) }) shouldBe runLog(s2.map(_ => true))
+      runLog(s1.map { case (k, vs) => vs.force.toVector.forall(f(_) == k) }) shouldBe runLog(s2.map(_ => true))
     }
 
     "head" in forAll { (s: PureStream[Int]) =>
@@ -277,15 +277,15 @@ class PipeSpec extends Fs2Spec {
     "split" in forAll { (s: PureStream[Int], n: SmallPositive) =>
       val s2 = s.get.map(x => if (x == Int.MinValue) x + 1 else x).map(_.abs).filter(_ != 0)
       withClue(s"n = $n, s = ${s.get.toList}, s2 = " + s2.toList) {
-      runLog { s2.chunkLimit(n.get).intersperse(Chunk.singleton(0)).flatMap(Stream.chunk).split(_ == 0).map(_.toVector).filter(_.nonEmpty) } shouldBe
+      runLog { s2.chunkLimit(n.get).intersperse(Chunk.singleton(0)).flatMap(Stream.chunk).split(_ == 0).map(_.force.toVector).filter(_.nonEmpty) } shouldBe
         s2.chunkLimit(n.get).filter(_.nonEmpty).map(_.toVector).toVector
       }
     }
 
     "split (2)" in {
-      Stream(1, 2, 0, 0, 3, 0, 4).split(_ == 0).toVector.map(_.toVector) shouldBe Vector(Vector(1, 2), Vector(), Vector(3), Vector(4))
-      Stream(1, 2, 0, 0, 3, 0).split(_ == 0).toVector.map(_.toVector) shouldBe Vector(Vector(1, 2), Vector(), Vector(3))
-      Stream(1, 2, 0, 0, 3, 0, 0).split(_ == 0).toVector.map(_.toVector) shouldBe Vector(Vector(1, 2), Vector(), Vector(3), Vector())
+      Stream(1, 2, 0, 0, 3, 0, 4).split(_ == 0).toVector.map(_.force.toVector) shouldBe Vector(Vector(1, 2), Vector(), Vector(3), Vector(4))
+      Stream(1, 2, 0, 0, 3, 0).split(_ == 0).toVector.map(_.force.toVector) shouldBe Vector(Vector(1, 2), Vector(), Vector(3))
+      Stream(1, 2, 0, 0, 3, 0, 0).split(_ == 0).toVector.map(_.force.toVector) shouldBe Vector(Vector(1, 2), Vector(), Vector(3), Vector())
     }
 
     "take" in forAll { (s: PureStream[Int], negate: Boolean, n0: SmallNonnegative) =>
@@ -350,7 +350,7 @@ class PipeSpec extends Fs2Spec {
 
     "take.segments" in {
       val s = Stream(1, 2) ++ Stream(3, 4)
-      runLog(s.take(3).segments.map(_.toVector)) shouldBe Vector(Vector(1, 2), Vector(3))
+      runLog(s.take(3).segments.map(_.force.toVector)) shouldBe Vector(Vector(1, 2), Vector(3))
     }
 
     "unNone" in forAll { (s: PureStream[Option[Int]]) =>

--- a/core/jvm/src/test/scala/fs2/StreamSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamSpec.scala
@@ -149,7 +149,7 @@ class StreamSpec extends Fs2Spec with Inside {
 
     "unfoldSegment" in {
       Stream.unfoldSegment(4L) { s =>
-        if(s > 0) Some((Chunk.longs(Array[Long](s,s)), s-1)) else None
+        if(s > 0) Some((Chunk.longs(Array[Long](s,s)).toSegment, s-1)) else None
       }.toList shouldBe List[Long](4,4,3,3,2,2,1,1)
     }
 

--- a/core/jvm/src/test/scala/fs2/StreamSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamSpec.scala
@@ -125,7 +125,7 @@ class StreamSpec extends Fs2Spec with Inside {
 
       Stream(1, 2, 3, 4, 5).repartition(i => Chunk(i, i)).toList shouldBe List(1, 3, 6, 10, 15, 15)
 
-      Stream(1, 10, 100).repartition(i => Segment.from(i).map(_.toInt).take(1000).toChunk).take(4).toList shouldBe List(1, 2, 3, 4)
+      Stream(1, 10, 100).repartition(i => Segment.from(i).map(_.toInt).take(1000).force.toChunk).take(4).toList shouldBe List(1, 2, 3, 4)
     }
 
     "translate" in forAll { (s: PureStream[Int]) =>

--- a/core/jvm/src/test/scala/fs2/async/QueueSpec.scala
+++ b/core/jvm/src/test/scala/fs2/async/QueueSpec.scala
@@ -32,7 +32,7 @@ class QueueSpec extends Fs2Spec {
             s.get.noneTerminate.evalMap(q.enqueue1).drain ++ q.dequeueAvailable.unNoneTerminate.segments
           })
           result.size should be < 2
-          result.flatMap(_.toVector) shouldBe s.get.toVector
+          result.flatMap(_.force.toVector) shouldBe s.get.toVector
         }
       }
     }

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -439,11 +439,11 @@ object Chunk {
    */
   final class StrictOps[+O](private val self: Chunk[O]) extends AnyVal {
 
-    /** Gets the first element of this chunk or throws if the chunk is empty. */
-    def head: O = self(0)
+    /** Gets the first element of this chunk. */
+    def head: Option[O] = if (self.isEmpty) None else Some(self(0))
 
-    /** Gets the last element of this chunk or throws if the chunk is empty. */
-    def last: O = self(self.size - 1)
+    /** Gets the last element of this chunk. */
+    def last: Option[O] = if (self.isEmpty) None else Some(self(self.size - 1))
 
     /** Splits this chunk in to two chunks at the specified index. */
     def splitAt(n: Int): (Chunk[O], Chunk[O]) = {

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -1,40 +1,18 @@
 package fs2
 
-import cats.Eval
 import scala.reflect.ClassTag
 import java.nio.ByteBuffer
 
 /**
- * Segment with a known size and that allows index-based random access of elements.
+ * Strict, finite sequence of values that allows index-based random access of elements.
  *
- * `Chunk`s can be created for a variety of collection types using methods on the `Chunk` companion
+ * `Chunk`s can be created from a variety of collection types using methods on the `Chunk` companion
  * (e.g., `Chunk.vector`, `Chunk.seq`, `Chunk.array`). Additionally, the `Chunk` companion
  * defines a subtype of `Chunk` for each primitive type, using an unboxed primitive array.
  * To work with unboxed arrays, use methods like `toBytes` to convert a `Chunk[Byte]` to a `Chunk.Bytes`
  * and then access the array directly.
- *
- * This type intentionally has a very limited API. Most operations are defined on `Segment` in a lazy/fusable
- * fashion. In general, better performance comes from fusing as many operations as possible. As such, the
- * chunk API is minimal, to encourage use of the fusable operations.
- *
- * Some operations have a lazy/fusable definition (on `Segment`) and a strict definition
- * on `Chunk`. To call such operations, use the `.strict` method -- e.g., `c.strict.splitAt(3)`.
  */
-abstract class Chunk[+O] extends Segment[O,Unit] { self =>
-
-  private[fs2]
-  def stage0(depth: Segment.Depth, defer: Segment.Defer, emit: O => Unit, emits: Chunk[O] => Unit, done: Unit => Unit) = {
-    var emitted = false
-    Eval.now {
-      Segment.step(if (emitted) Segment.empty else this) {
-        if (!emitted) {
-          emitted = true
-          emits(this)
-        }
-        done(())
-      }
-    }
-  }
+abstract class Chunk[+O] {
 
   /** Returns the number of elements in this chunk. */
   def size: Int
@@ -47,6 +25,23 @@ abstract class Chunk[+O] extends Segment[O,Unit] { self =>
 
   /** False if size is zero, true otherwise. */
   final def nonEmpty: Boolean = size > 0
+
+  /** Drops the first `n` elements of this chunk. */
+  def drop(n: Int): Chunk[O] = splitAt(n)._2
+
+  /** Left-folds the elements of this chunk. */
+  def foldLeft[A](init: A)(f: (A, O) => A): A = {
+    var i = 0
+    var acc = init
+    while (i < size) {
+      acc = f(acc, apply(i))
+      i += 1
+    }
+    acc
+  }
+
+  /** Gets the first element of this chunk. */
+  def head: Option[O] = if (isEmpty) None else Some(apply(0))
 
   /**
    * Returns the index of the first element which passes the specified predicate (i.e., `p(i) == true`)
@@ -61,6 +56,25 @@ abstract class Chunk[+O] extends Segment[O,Unit] { self =>
     }
     if (result == -1) None else Some(result)
   }
+
+  /** Gets the last element of this chunk. */
+  def last: Option[O] = if (isEmpty) None else Some(apply(size - 1))
+
+  /** Creates a new chunk by applying `f` to each element in this chunk. */
+  def map[O2](f: O => O2): Chunk[O2]
+
+  /** Splits this chunk in to two chunks at the specified index. */
+  def splitAt(n: Int): (Chunk[O], Chunk[O]) = {
+    if (n <= 0) (Chunk.empty, this)
+    else if (n >= size) (this, Chunk.empty)
+    else splitAtChunk_(n)
+  }
+
+  /** Splits this chunk in to two chunks at the specified index `n`, which is guaranteed to be in-bounds. */
+  protected def splitAtChunk_(n: Int): (Chunk[O], Chunk[O])
+
+  /** Takes the first `n` elements of this chunk. */
+  def take(n: Int): Chunk[O] = splitAt(n)._1
 
   /** Copies the elements of this chunk to an array. */
   def toArray[O2 >: O: ClassTag]: Array[O2] = {
@@ -161,6 +175,7 @@ abstract class Chunk[+O] extends Segment[O,Unit] { self =>
     }
   }
 
+  /** Invokes the supplied function for each element of this chunk. */
   def foreach(f: O => Unit): Unit = {
     var i = 0
     while (i < size) {
@@ -169,6 +184,7 @@ abstract class Chunk[+O] extends Segment[O,Unit] { self =>
     }
   }
 
+  /** Converts this chunk to a list. */
   def toList: List[O] = {
     if (isEmpty) Nil
     else {
@@ -182,6 +198,10 @@ abstract class Chunk[+O] extends Segment[O,Unit] { self =>
     }
   }
 
+  /** Converts this chunk to a segment. */
+  def toSegment: Segment[O,Unit] = Segment.chunk(this)
+
+  /** Converts this chunk to a vector. */
   def toVector: Vector[O] = {
     if (isEmpty) Vector.empty
     else {
@@ -196,14 +216,12 @@ abstract class Chunk[+O] extends Segment[O,Unit] { self =>
     }
   }
 
-  /** Strict version of `splitAt` - `n` is guaranteed to be within bounds so implementations do not need to do bounds checking. */
-  protected def splitAtChunk_(n: Int): (Chunk[O], Chunk[O])
+  override def hashCode: Int = toVector.hashCode
 
-  /** Strict version of `map`. */
-  protected def mapStrict[O2](f: O => O2): Chunk[O2]
-
-  /** Provides access to strict equivalent methods defined lazily on `Segment`. */
-  final def strict: Chunk.StrictOps[O] = new Chunk.StrictOps(this)
+  override def equals(a: Any): Boolean = a match {
+    case c: Chunk[O] => toVector == c.toVector
+    case _ => false
+  }
 
   override def toString = {
     val vs = (0 until size).view.map(i => apply(i)).mkString(", ")
@@ -216,10 +234,8 @@ object Chunk {
   private val empty_ : Chunk[Nothing] = new Chunk[Nothing] {
     def size = 0
     def apply(i: Int) = sys.error(s"Chunk.empty.apply($i)")
-    override def stage0(depth: Segment.Depth, defer: Segment.Defer, emit: Nothing => Unit, emits: Chunk[Nothing] => Unit, done: Unit => Unit) =
-      Eval.now(Segment.step(empty_)(done(())))
     protected def splitAtChunk_(n: Int): (Chunk[Nothing], Chunk[Nothing]) = sys.error("impossible")
-    protected def mapStrict[O2](f: Nothing => O2): Chunk[O2] = empty
+    override def map[O2](f: Nothing => O2): Chunk[O2] = empty
     override def toString = "empty"
   }
 
@@ -231,7 +247,7 @@ object Chunk {
     def size = 1
     def apply(i: Int) = { if (i == 0) o else throw new IndexOutOfBoundsException() }
     protected def splitAtChunk_(n: Int): (Chunk[O], Chunk[O]) = sys.error("impossible")
-    protected def mapStrict[O2](f: O => O2): Chunk[O2] = singleton(f(o))
+    override def map[O2](f: O => O2): Chunk[O2] = singleton(f(o))
   }
 
   /** Creates a chunk backed by a vector. */
@@ -245,7 +261,7 @@ object Chunk {
         val (fst,snd) = v.splitAt(n)
         vector(fst) -> vector(snd)
       }
-      protected def mapStrict[O2](f: O => O2): Chunk[O2] = vector(v.map(f))
+      override def map[O2](f: O => O2): Chunk[O2] = vector(v.map(f))
     }
   }
 
@@ -260,7 +276,7 @@ object Chunk {
         val (fst,snd) = s.splitAt(n)
         indexedSeq(fst) -> indexedSeq(snd)
       }
-      protected def mapStrict[O2](f: O => O2): Chunk[O2] = indexedSeq(s.map(f))
+      override def map[O2](f: O => O2): Chunk[O2] = indexedSeq(s.map(f))
     }
   }
 
@@ -301,7 +317,7 @@ object Chunk {
     def apply(i: Int) = values(offset + i)
     protected def splitAtChunk_(n: Int): (Chunk[O], Chunk[O]) =
       Boxed(values, offset, n) -> Boxed(values, offset + n, length - n)
-    protected def mapStrict[O2](f: O => O2): Chunk[O2] = seq(values.map(f))
+    override def map[O2](f: O => O2): Chunk[O2] = seq(values.map(f))
     override def toArray[O2 >: O: ClassTag]: Array[O2] = values.slice(offset, offset + length).asInstanceOf[Array[O2]]
   }
   object Boxed { def apply[O](values: Array[O]): Boxed[O] = Boxed(values, 0, values.length) }
@@ -319,7 +335,7 @@ object Chunk {
     def at(i: Int) = values(offset + i)
     protected def splitAtChunk_(n: Int): (Chunk[Boolean], Chunk[Boolean]) =
       Booleans(values, offset, n) -> Booleans(values, offset + n, length - n)
-    protected def mapStrict[O2](f: Boolean => O2): Chunk[O2] = seq(values.map(f))
+    override def map[O2](f: Boolean => O2): Chunk[O2] = seq(values.map(f))
     override def toArray[O2 >: Boolean: ClassTag]: Array[O2] = values.slice(offset, offset + length).asInstanceOf[Array[O2]]
   }
   object Booleans { def apply(values: Array[Boolean]): Booleans = Booleans(values, 0, values.length) }
@@ -337,7 +353,7 @@ object Chunk {
     def at(i: Int) = values(offset + i)
     protected def splitAtChunk_(n: Int): (Chunk[Byte], Chunk[Byte]) =
       Bytes(values, offset, n) -> Bytes(values, offset + n, length - n)
-    protected def mapStrict[O2](f: Byte => O2): Chunk[O2] = seq(values.map(f))
+    override def map[O2](f: Byte => O2): Chunk[O2] = seq(values.map(f))
     override def toArray[O2 >: Byte: ClassTag]: Array[O2] = values.slice(offset, offset + length).asInstanceOf[Array[O2]]
     def toByteBuffer: ByteBuffer = ByteBuffer.wrap(values, offset, length)
   }
@@ -356,7 +372,7 @@ object Chunk {
     def at(i: Int) = values(offset + i)
     protected def splitAtChunk_(n: Int): (Chunk[Short], Chunk[Short]) =
       Shorts(values, offset, n) -> Shorts(values, offset + n, length - n)
-    protected def mapStrict[O2](f: Short => O2): Chunk[O2] = seq(values.map(f))
+    override def map[O2](f: Short => O2): Chunk[O2] = seq(values.map(f))
     override def toArray[O2 >: Short: ClassTag]: Array[O2] = values.slice(offset, offset + length).asInstanceOf[Array[O2]]
   }
   object Shorts { def apply(values: Array[Short]): Shorts = Shorts(values, 0, values.length) }
@@ -374,7 +390,7 @@ object Chunk {
     def at(i: Int) = values(offset + i)
     protected def splitAtChunk_(n: Int): (Chunk[Int], Chunk[Int]) =
       Ints(values, offset, n) -> Ints(values, offset + n, length - n)
-    protected def mapStrict[O2](f: Int => O2): Chunk[O2] = seq(values.map(f))
+    override def map[O2](f: Int => O2): Chunk[O2] = seq(values.map(f))
     override def toArray[O2 >: Int: ClassTag]: Array[O2] = values.slice(offset, offset + length).asInstanceOf[Array[O2]]
   }
   object Ints { def apply(values: Array[Int]): Ints = Ints(values, 0, values.length) }
@@ -392,7 +408,7 @@ object Chunk {
     def at(i: Int) = values(offset + i)
     protected def splitAtChunk_(n: Int): (Chunk[Long], Chunk[Long]) =
       Longs(values, offset, n) -> Longs(values, offset + n, length - n)
-    protected def mapStrict[O2](f: Long => O2): Chunk[O2] = seq(values.map(f))
+    override def map[O2](f: Long => O2): Chunk[O2] = seq(values.map(f))
     override def toArray[O2 >: Long: ClassTag]: Array[O2] = values.slice(offset, offset + length).asInstanceOf[Array[O2]]
   }
   object Longs { def apply(values: Array[Long]): Longs = Longs(values, 0, values.length) }
@@ -410,7 +426,7 @@ object Chunk {
     def at(i: Int) = values(offset + i)
     protected def splitAtChunk_(n: Int): (Chunk[Float], Chunk[Float]) =
       Floats(values, offset, n) -> Floats(values, offset + n, length - n)
-    protected def mapStrict[O2](f: Float => O2): Chunk[O2] = seq(values.map(f))
+    override def map[O2](f: Float => O2): Chunk[O2] = seq(values.map(f))
     override def toArray[O2 >: Float: ClassTag]: Array[O2] = values.slice(offset, offset + length).asInstanceOf[Array[O2]]
   }
   object Floats { def apply(values: Array[Float]): Floats = Floats(values, 0, values.length) }
@@ -428,37 +444,8 @@ object Chunk {
     def at(i: Int) = values(offset + i)
     protected def splitAtChunk_(n: Int): (Chunk[Double], Chunk[Double]) =
       Doubles(values, offset, n) -> Doubles(values, offset + n, length - n)
-    protected def mapStrict[O2](f: Double => O2): Chunk[O2] = seq(values.map(f))
+    override def map[O2](f: Double => O2): Chunk[O2] = seq(values.map(f))
     override def toArray[O2 >: Double: ClassTag]: Array[O2] = values.slice(offset, offset + length).asInstanceOf[Array[O2]]
   }
   object Doubles { def apply(values: Array[Double]): Doubles = Doubles(values, 0, values.length) }
-
-  /**
-   * Defines operations on a `Chunk` that return a `Chunk` and that might otherwise conflict
-   * with lazy implementations defined on `Segment`.
-   */
-  final class StrictOps[+O](private val self: Chunk[O]) extends AnyVal {
-
-    /** Gets the first element of this chunk. */
-    def head: Option[O] = if (self.isEmpty) None else Some(self(0))
-
-    /** Gets the last element of this chunk. */
-    def last: Option[O] = if (self.isEmpty) None else Some(self(self.size - 1))
-
-    /** Splits this chunk in to two chunks at the specified index. */
-    def splitAt(n: Int): (Chunk[O], Chunk[O]) = {
-      if (n <= 0) (Chunk.empty, self)
-      else if (n >= self.size) (self, Chunk.empty)
-      else self.splitAtChunk_(n)
-    }
-
-    /** Takes the first `n` elements of this chunk. */
-    def take(n: Int): Chunk[O] = splitAt(n)._1
-
-    /** Drops the first `n` elements of this chunk. */
-    def drop(n: Int): Chunk[O] = splitAt(n)._2
-
-    /** Strict version of `map`. */
-    def map[O2](f: O => O2): Chunk[O2] = self.mapStrict(f)
-  }
 }

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -11,6 +11,10 @@ import java.nio.ByteBuffer
  * defines a subtype of `Chunk` for each primitive type, using an unboxed primitive array.
  * To work with unboxed arrays, use methods like `toBytes` to convert a `Chunk[Byte]` to a `Chunk.Bytes`
  * and then access the array directly.
+ *
+ * The operations on `Chunk` are all defined strictly. For example, `c.map(f).map(g).map(h)` results in
+ * intermediate chunks being created (1 per call to `map`). In contrast, a chunk can be lifted to a segment
+ * (via `toSegment`) to get arbitrary operator fusion.
  */
 abstract class Chunk[+O] {
 

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -150,6 +150,10 @@ object Pull {
   def output1[F[_],O](o: O): Pull[F,O,Unit] =
     fromFreeC(Algebra.output1[F,O](o))
 
+  /** Ouptuts a chunk of values. */
+  def outputChunk[F[_],O](os: Chunk[O]): Pull[F,O,Unit] =
+    output(Segment.chunk(os))
+
   /** Ouptuts a segment of values. */
   def output[F[_],O](os: Segment[O,Unit]): Pull[F,O,Unit] =
     fromFreeC(Algebra.output[F,O](os))

--- a/core/shared/src/main/scala/fs2/Segment.scala
+++ b/core/shared/src/main/scala/fs2/Segment.scala
@@ -20,6 +20,8 @@ import Segment._
  * Stack safety of fused operations is ensured by tracking a fusion depth. If the depth
  * reaches the limit, the computation is trampolined using `cats.Eval`.
  *
+ * The `equals` and `hashCode` methods are not defined for `Segment`.
+ *
  * Implementation notes:
  *  - Some operators ask for a segment remainder from within a callback (e.g., `emits`). As such,
  *    segments should update state before invoking callbacks so that remainders can be computed
@@ -746,13 +748,6 @@ abstract class Segment[+O,+R] { self =>
       }
       override def toString = s"($self).zipWith($that)(<f1>)"
     }
-
-  // TODO I don't think hashCode and equals should convert to vectors...
-  override def hashCode: Int = force.toVector.hashCode
-  override def equals(a: Any): Boolean = a match {
-    case s: Segment[O,R] => this.force.toVector == s.force.toVector
-    case _ => false
-  }
 }
 
 object Segment {

--- a/core/shared/src/main/scala/fs2/Segment.scala
+++ b/core/shared/src/main/scala/fs2/Segment.scala
@@ -8,13 +8,17 @@ import Segment._
 /**
  * Potentially infinite, pure sequence of values of type `O` and a result of type `R`.
  *
- * All methods which return a `Segment` support fusion with other arbitrary methods that
+ * All methods on `Segment` support fusion with other arbitrary methods that
  * return `Segment`s. This is similar to the staging approach described in
  * [[https://arxiv.org/pdf/1612.06668v1.pdf Stream Fusion, to Completeness]], but without
  * code generation in staging.
  *
- * Stack safety is ensured by tracking a fusion depth. If the depth reaches the
- * limit, the computation is trampolined using `cats.Eval`.
+ * To force evaluation of one or more values of a segment, call `.force` followed by one
+ * of the operations on the returned `Segment.Force` type. For example, to convert a
+ * segment to a vector, call `s.force.toVector`.
+ *
+ * Stack safety of fused operations is ensured by tracking a fusion depth. If the depth
+ * reaches the limit, the computation is trampolined using `cats.Eval`.
  *
  * Implementation notes:
  *  - Some operators ask for a segment remainder from within a callback (e.g., `emits`). As such,

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2060,8 +2060,8 @@ object Stream {
           val o2: O = carry.fold(o)(S.combine(_, o))
           val partitions: Chunk[O] = f(o2)
           if (partitions.isEmpty) partitions -> None
-          else if (partitions.size == 1) Chunk.empty -> Some(partitions.strict.last)
-          else partitions.take(partitions.size - 1).voidResult -> Some(partitions.strict.last)
+          else if (partitions.size == 1) Chunk.empty -> partitions.strict.last
+          else partitions.take(partitions.size - 1).voidResult -> partitions.strict.last
         }.flatMap { case (out, carry) => out }.mapResult { case ((out, carry), unit) => carry }
       }.flatMap { case Some(carry) => Pull.output1(carry); case None => Pull.done }.stream
     }

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -165,7 +165,7 @@ final class Stream[+F[_],+O] private(private val free: FreeC[Algebra[Nothing,Not
               val cur = f(i)
               if (!cur && last) (out :+ Chunk.vector(buf :+ i), Vector.empty, cur)
               else (out, buf :+ i, cur)
-            }.run
+            }.force.run
           }
           if (out.isEmpty) {
             go(buffer :+ Chunk.vector(buf), newLast, tl)
@@ -218,7 +218,7 @@ final class Stream[+F[_],+O] private(private val free: FreeC[Algebra[Nothing,Not
   def chunkLimit(n: Int): Stream[F,Chunk[O]] =
     this repeatPull { _.unconsLimit(n) flatMap {
       case None => Pull.pure(None)
-      case Some((hd,tl)) => Pull.output1(hd.toChunk).as(Some(tl))
+      case Some((hd,tl)) => Pull.output1(hd.force.toChunk).as(Some(tl))
     }}
 
   /**
@@ -387,7 +387,7 @@ final class Stream[+F[_],+O] private(private val free: FreeC[Algebra[Nothing,Not
         s.pull.uncons.flatMap {
           case None => Pull.pure(None)
           case Some((hd,tl)) =>
-            val all = acc ++ hd.toVector
+            val all = acc ++ hd.force.toVector
             Pull.output(Chunk.vector(all.dropRight(n))) >> go(all.takeRight(n), tl)
         }
       }
@@ -542,7 +542,7 @@ final class Stream[+F[_],+O] private(private val free: FreeC[Algebra[Nothing,Not
    *
    * @example {{{
    * scala> import cats.implicits._
-   * scala> Stream("Hello", "Hi", "Greetings", "Hey").groupAdjacentBy(_.head).toList.map { case (k,vs) => k -> vs.toList }
+   * scala> Stream("Hello", "Hi", "Greetings", "Hey").groupAdjacentBy(_.head).toList.map { case (k,vs) => k -> vs.force.toList }
    * res0: List[(Char,List[String])] = List((H,List(Hello, Hi)), (G,List(Greetings)), (H,List(Hey)))
    * }}}
    */
@@ -576,7 +576,7 @@ final class Stream[+F[_],+O] private(private val free: FreeC[Algebra[Nothing,Not
         // split the chunk into the bit where the keys match and the bit where they don't
         val matching = chunk.take(differsAt)
         val newOut: Segment[O,Unit] = out ++ matching.voidResult
-        val nonMatching = chunk.drop(differsAt).fold(_ => Chunk.empty, identity).toChunk
+        val nonMatching = chunk.strict.drop(differsAt)
         // nonMatching is guaranteed to be non-empty here, because we know the last element of the chunk doesn't have
         // the same key as the first
         val k2 = f(nonMatching(0))
@@ -614,7 +614,7 @@ final class Stream[+F[_],+O] private(private val free: FreeC[Algebra[Nothing,Not
           case Some((hd,tl)) =>
             val interspersed = {
               val bldr = Vector.newBuilder[O2]
-              hd.toVector.foreach { o => bldr += separator; bldr += o }
+              hd.force.toVector.foreach { o => bldr += separator; bldr += o }
               Chunk.vector(bldr.result)
             }
             Pull.output(interspersed) >> Pull.pure(Some(tl))
@@ -744,7 +744,7 @@ final class Stream[+F[_],+O] private(private val free: FreeC[Algebra[Nothing,Not
     val _ = ev // Convince scalac that ev is used
     this.asInstanceOf[Stream[F,Either[Throwable,O2]]].segments.flatMap { s =>
       val errs = s.collect { case Left(e) => e }
-      errs.uncons1 match {
+      errs.force.uncons1 match {
         case Left(()) => Stream.segment(s.collect { case Right(i) => i })
         case Right((hd,tl)) => Stream.raiseError(hd)
       }
@@ -775,7 +775,7 @@ final class Stream[+F[_],+O] private(private val free: FreeC[Algebra[Nothing,Not
     this.pull.uncons.flatMap {
       case None => Pull.done
       case Some((hd,tl)) =>
-        hd.scan(z)(f).uncons1 match {
+        hd.scan(z)(f).force.uncons1 match {
           case Left(acc) => tl.scan_(acc)(f)
           case Right((_, out)) => Pull.segment(out).flatMap{acc => tl.scan_(acc)(f)}
         }
@@ -866,7 +866,7 @@ final class Stream[+F[_],+O] private(private val free: FreeC[Algebra[Nothing,Not
       s.pull.uncons.flatMap {
         case None => Pull.done
         case Some((hd,tl)) =>
-          hd.scan(window)((w, i) => w.dequeue._2.enqueue(i)).drop(1) match {
+          hd.scan(window)((w, i) => w.dequeue._2.enqueue(i)).force.drop(1) match {
             case Left((w2,_)) => go(w2, tl)
             case Right(out) => Pull.segment(out).flatMap { window => go(window, tl) }
           }
@@ -875,7 +875,7 @@ final class Stream[+F[_],+O] private(private val free: FreeC[Algebra[Nothing,Not
     this.pull.unconsN(n, true).flatMap {
       case None => Pull.done
       case Some((hd, tl)) =>
-        val window = hd.fold(collection.immutable.Queue.empty[O])(_.enqueue(_)).run
+        val window = hd.fold(collection.immutable.Queue.empty[O])(_.enqueue(_)).force.run
         Pull.output1(window) >> go(window, tl)
     }.stream
   }
@@ -894,14 +894,14 @@ final class Stream[+F[_],+O] private(private val free: FreeC[Algebra[Nothing,Not
     def go(buffer: Catenable[Segment[O,Unit]], s: Stream[F,O]): Pull[F,Segment[O,Unit],Unit] = {
       s.pull.uncons.flatMap {
         case Some((hd,tl)) =>
-          hd.splitWhile(o => !(f(o))) match {
+          hd.force.splitWhile(o => !(f(o))) match {
             case Left((_,out)) =>
               if (out.isEmpty) go(buffer, tl)
               else go(buffer ++ out, tl)
             case Right((out,tl2)) =>
               val b2 = if (out.nonEmpty) buffer ++ out else buffer
               (if (b2.nonEmpty) Pull.output1(Segment.catenated(b2)) else Pull.pure(())) >>
-                go(Catenable.empty, tl.cons(tl2.drop(1).fold(_ => Segment.empty, identity)))
+                go(Catenable.empty, tl.cons(tl2.force.drop(1).fold(_ => Segment.empty, identity)))
           }
         case None =>
           if (buffer.nonEmpty) Pull.output1(Segment.catenated(buffer)) else Pull.done
@@ -1658,7 +1658,7 @@ object Stream {
           // This allows recursive infinite streams of the form `def s: Stream[Pure,O] = Stream(o).flatMap { _ => s }`
           val only: Option[O] = tl match {
             case FreeC.Pure(_) =>
-              hd.uncons1.toOption.flatMap { case (o, tl) => tl.uncons1.fold(_ => Some(o), _ => None) }
+              hd.force.uncons1.toOption.flatMap { case (o, tl) => tl.force.uncons1.fold(_ => Some(o), _ => None) }
             case _ => None
           }
           only match {
@@ -2473,7 +2473,7 @@ object Stream {
     def unconsChunk: Pull[F,Nothing,Option[(Chunk[O],Stream[F,O])]] =
       uncons.flatMap {
         case None => Pull.pure(None)
-        case Some((hd,tl)) => hd.unconsChunk match {
+        case Some((hd,tl)) => hd.force.unconsChunk match {
           case Left(()) => tl.pull.unconsChunk
           case Right((c,tl2)) => Pull.pure(Some((c, tl.cons(tl2))))
         }
@@ -2483,7 +2483,7 @@ object Stream {
     def uncons1: Pull[F,Nothing,Option[(O,Stream[F,O])]] =
       uncons flatMap {
         case None => Pull.pure(None)
-        case Some((hd, tl)) => hd.uncons1 match {
+        case Some((hd, tl)) => hd.force.uncons1 match {
           case Left(_) => tl.pull.uncons1
           case Right((hd,tl2)) => Pull.pure(Some(hd -> tl.cons(tl2)))
         }
@@ -2528,7 +2528,7 @@ object Stream {
       require(n > 0)
       uncons.flatMap {
         case Some((hd,tl)) =>
-          hd.splitAt(n) match {
+          hd.force.splitAt(n) match {
             case Left((_,segments,rem)) => Pull.pure(Some(Segment.catenated(segments) -> tl))
             case Right((segments,tl2)) => Pull.pure(Some(Segment.catenated(segments) -> tl.cons(tl2)))
           }
@@ -2548,7 +2548,7 @@ object Stream {
             if (allowFewer && acc.nonEmpty) Pull.pure(Some((Segment.catenated(acc), Stream.empty)))
             else Pull.pure(None)
           case Some((hd,tl)) =>
-            hd.splitAt(n) match {
+            hd.force.splitAt(n) match {
               case Left((_,segments,rem)) =>
                 if (rem > 0) go(acc ++ segments, rem, tl)
                 else Pull.pure(Some(Segment.catenated(acc ++ segments) -> tl))
@@ -2567,7 +2567,7 @@ object Stream {
       else uncons.flatMap {
         case None => Pull.pure(None)
         case Some((hd,tl)) =>
-          hd.drop(n) match {
+          hd.force.drop(n) match {
             case Left((_,rem)) =>
               if (rem > 0) tl.pull.drop(rem)
               else Pull.pure(Some(tl))
@@ -2591,7 +2591,7 @@ object Stream {
       uncons.flatMap {
         case None => Pull.pure(None)
         case Some((hd, tl)) =>
-          hd.dropWhile(p, dropFailure) match {
+          hd.force.dropWhile(p, dropFailure) match {
             case Left(_) => tl.pull.dropWhile_(p, dropFailure)
             case Right(tl2) => Pull.pure(Some(tl.cons(tl2)))
           }
@@ -2619,7 +2619,7 @@ object Stream {
         case Some((hd, tl)) =>
           hd.indexWhere(f) match {
             case None => tl.pull.find(f)
-            case Some(idx) if idx + 1 < hd.size => Pull.pure(Some((hd(idx), hd.drop(idx + 1).fold(_ => tl, hd => tl.cons(hd)))))
+            case Some(idx) if idx + 1 < hd.size => Pull.pure(Some((hd(idx), hd.force.drop(idx + 1).fold(_ => tl, hd => tl.cons(hd)))))
             case Some(idx) => Pull.pure(Some((hd(idx), tl)))
           }
       }
@@ -2730,7 +2730,7 @@ object Stream {
         s.pull.unconsN(n, true).flatMap {
           case None => Pull.pure(Chunk.vector(acc))
           case Some((hd, tl)) =>
-            val vector = hd.toVector
+            val vector = hd.force.toVector
             go(acc.drop(vector.length) ++ vector, tl)
         }
       }

--- a/core/shared/src/main/scala/fs2/async/mutable/Queue.scala
+++ b/core/shared/src/main/scala/fs2/async/mutable/Queue.scala
@@ -207,7 +207,7 @@ object Queue {
         def peek1: F[A] = peek1Impl.flatMap(_.fold(_.get, F.pure))
 
         def timedDequeue1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[A]] =
-          timedDequeueBatch1(1, timeout, scheduler).map(_.map(_.strict.head))
+          timedDequeueBatch1(1, timeout, scheduler).map(_.map(_.strict.head.get))
 
         def timedPeek1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[A]] = {
           peek1Impl.flatMap {
@@ -227,7 +227,7 @@ object Queue {
         }
 
         def cancellableDequeue1: F[(F[A],F[Unit])] =
-          cancellableDequeueBatch1(1).map { case (deq,cancel) => (deq.map(_.strict.head),cancel) }
+          cancellableDequeueBatch1(1).map { case (deq,cancel) => (deq.map(_.strict.head.get),cancel) }
 
         def dequeueBatch1(batchSize: Int): F[Chunk[A]] =
           cancellableDequeueBatch1(batchSize).flatMap { _._1 }
@@ -290,11 +290,11 @@ object Queue {
         def dequeue1: F[A] = cancellableDequeue1.flatMap { _._1 }
         def peek1: F[A] = q.peek1
         def timedDequeue1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[A]] =
-          timedDequeueBatch1(1, timeout, scheduler).map(_.map(_.strict.head))
+          timedDequeueBatch1(1, timeout, scheduler).map(_.map(_.strict.head.get))
         def timedPeek1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[A]] =
           q.timedPeek1(timeout, scheduler)
         override def cancellableDequeue1: F[(F[A], F[Unit])] =
-          cancellableDequeueBatch1(1).map { case (deq,cancel) => (deq.map(_.strict.head),cancel) }
+          cancellableDequeueBatch1(1).map { case (deq,cancel) => (deq.map(_.strict.head.get),cancel) }
         override def dequeueBatch1(batchSize: Int): F[Chunk[A]] = cancellableDequeueBatch1(batchSize).flatMap { _._1 }
         def timedDequeueBatch1(batchSize: Int, timeout: FiniteDuration, scheduler: Scheduler): F[Option[Chunk[A]]] =
           q.timedDequeueBatch1(batchSize, timeout, scheduler).flatMap {
@@ -323,7 +323,7 @@ object Queue {
         def dequeue1: F[A] = cancellableDequeue1.flatMap { _._1 }
         def peek1: F[A] = q.peek1
         def timedDequeue1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[A]] =
-          timedDequeueBatch1(1, timeout, scheduler).map(_.map(_.strict.head))
+          timedDequeueBatch1(1, timeout, scheduler).map(_.map(_.strict.head.get))
         def timedPeek1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[A]] =
           q.timedPeek1(timeout, scheduler)
         def dequeueBatch1(batchSize: Int): F[Chunk[A]] = cancellableDequeueBatch1(batchSize).flatMap { _._1 }
@@ -332,7 +332,7 @@ object Queue {
             case Some(c) => permits.incrementBy(c.size).as(Some(c))
             case None => F.pure(None)
           }
-        def cancellableDequeue1: F[(F[A], F[Unit])] = cancellableDequeueBatch1(1).map { case (deq,cancel) => (deq.map(_.strict.head),cancel) }
+        def cancellableDequeue1: F[(F[A], F[Unit])] = cancellableDequeueBatch1(1).map { case (deq,cancel) => (deq.map(_.strict.head.get),cancel) }
         def cancellableDequeueBatch1(batchSize: Int): F[(F[Chunk[A]],F[Unit])] =
           q.cancellableDequeueBatch1(batchSize).map { case (deq,cancel) => (deq.flatMap(a => permits.incrementBy(a.size).as(a)), cancel) }
         def size = q.size
@@ -356,7 +356,7 @@ object Queue {
         def dequeue1: F[A] = cancellableDequeue1.flatMap { _._1 }
         def peek1: F[A] = q.peek1
         def timedDequeue1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[A]] =
-          timedDequeueBatch1(1, timeout, scheduler).map(_.map(_.strict.head))
+          timedDequeueBatch1(1, timeout, scheduler).map(_.map(_.strict.head.get))
         def timedPeek1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[A]] =
           q.timedPeek1(timeout, scheduler)
         def cancellableDequeue1: F[(F[A],F[Unit])] =
@@ -398,7 +398,7 @@ object Queue {
         def dequeue1: F[Option[A]] = cancellableDequeue1.flatMap { _._1 }
         def peek1: F[Option[A]] = q.peek1
         def timedDequeue1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[Option[A]]] =
-          timedDequeueBatch1(1, timeout, scheduler).map(_.map(_.strict.head))
+          timedDequeueBatch1(1, timeout, scheduler).map(_.map(_.strict.head.get))
         def timedPeek1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[Option[A]]] =
           q.timedPeek1(timeout, scheduler)
         def cancellableDequeue1: F[(F[Option[A]],F[Unit])] =

--- a/core/shared/src/main/scala/fs2/async/mutable/Queue.scala
+++ b/core/shared/src/main/scala/fs2/async/mutable/Queue.scala
@@ -143,11 +143,11 @@ abstract class Queue[F[_], A] { self =>
       def cancellableDequeue1: F[(F[B],F[Unit])] =
         self.cancellableDequeue1.map(bu => bu._1.map(f) -> bu._2)
       def dequeueBatch1(batchSize: Int): F[Chunk[B]] =
-        self.dequeueBatch1(batchSize).map(_.strict.map(f))
+        self.dequeueBatch1(batchSize).map(_.map(f))
       def timedDequeueBatch1(batchSize: Int, timeout: FiniteDuration, scheduler: Scheduler): F[Option[Chunk[B]]] =
-        self.timedDequeueBatch1(batchSize, timeout, scheduler).map(_.map(_.strict.map(f)))
+        self.timedDequeueBatch1(batchSize, timeout, scheduler).map(_.map(_.map(f)))
       def cancellableDequeueBatch1(batchSize: Int): F[(F[Chunk[B]],F[Unit])] =
-        self.cancellableDequeueBatch1(batchSize).map(bu => bu._1.map(_.strict.map(f)) -> bu._2)
+        self.cancellableDequeueBatch1(batchSize).map(bu => bu._1.map(_.map(f)) -> bu._2)
     }
 }
 
@@ -207,7 +207,7 @@ object Queue {
         def peek1: F[A] = peek1Impl.flatMap(_.fold(_.get, F.pure))
 
         def timedDequeue1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[A]] =
-          timedDequeueBatch1(1, timeout, scheduler).map(_.map(_.strict.head.get))
+          timedDequeueBatch1(1, timeout, scheduler).map(_.map(_.head.get))
 
         def timedPeek1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[A]] = {
           peek1Impl.flatMap {
@@ -227,7 +227,7 @@ object Queue {
         }
 
         def cancellableDequeue1: F[(F[A],F[Unit])] =
-          cancellableDequeueBatch1(1).map { case (deq,cancel) => (deq.map(_.strict.head.get),cancel) }
+          cancellableDequeueBatch1(1).map { case (deq,cancel) => (deq.map(_.head.get),cancel) }
 
         def dequeueBatch1(batchSize: Int): F[Chunk[A]] =
           cancellableDequeueBatch1(batchSize).flatMap { _._1 }
@@ -290,11 +290,11 @@ object Queue {
         def dequeue1: F[A] = cancellableDequeue1.flatMap { _._1 }
         def peek1: F[A] = q.peek1
         def timedDequeue1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[A]] =
-          timedDequeueBatch1(1, timeout, scheduler).map(_.map(_.strict.head.get))
+          timedDequeueBatch1(1, timeout, scheduler).map(_.map(_.head.get))
         def timedPeek1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[A]] =
           q.timedPeek1(timeout, scheduler)
         override def cancellableDequeue1: F[(F[A], F[Unit])] =
-          cancellableDequeueBatch1(1).map { case (deq,cancel) => (deq.map(_.strict.head.get),cancel) }
+          cancellableDequeueBatch1(1).map { case (deq,cancel) => (deq.map(_.head.get),cancel) }
         override def dequeueBatch1(batchSize: Int): F[Chunk[A]] = cancellableDequeueBatch1(batchSize).flatMap { _._1 }
         def timedDequeueBatch1(batchSize: Int, timeout: FiniteDuration, scheduler: Scheduler): F[Option[Chunk[A]]] =
           q.timedDequeueBatch1(batchSize, timeout, scheduler).flatMap {
@@ -323,7 +323,7 @@ object Queue {
         def dequeue1: F[A] = cancellableDequeue1.flatMap { _._1 }
         def peek1: F[A] = q.peek1
         def timedDequeue1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[A]] =
-          timedDequeueBatch1(1, timeout, scheduler).map(_.map(_.strict.head.get))
+          timedDequeueBatch1(1, timeout, scheduler).map(_.map(_.head.get))
         def timedPeek1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[A]] =
           q.timedPeek1(timeout, scheduler)
         def dequeueBatch1(batchSize: Int): F[Chunk[A]] = cancellableDequeueBatch1(batchSize).flatMap { _._1 }
@@ -332,7 +332,7 @@ object Queue {
             case Some(c) => permits.incrementBy(c.size).as(Some(c))
             case None => F.pure(None)
           }
-        def cancellableDequeue1: F[(F[A], F[Unit])] = cancellableDequeueBatch1(1).map { case (deq,cancel) => (deq.map(_.strict.head.get),cancel) }
+        def cancellableDequeue1: F[(F[A], F[Unit])] = cancellableDequeueBatch1(1).map { case (deq,cancel) => (deq.map(_.head.get),cancel) }
         def cancellableDequeueBatch1(batchSize: Int): F[(F[Chunk[A]],F[Unit])] =
           q.cancellableDequeueBatch1(batchSize).map { case (deq,cancel) => (deq.flatMap(a => permits.incrementBy(a.size).as(a)), cancel) }
         def size = q.size
@@ -356,7 +356,7 @@ object Queue {
         def dequeue1: F[A] = cancellableDequeue1.flatMap { _._1 }
         def peek1: F[A] = q.peek1
         def timedDequeue1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[A]] =
-          timedDequeueBatch1(1, timeout, scheduler).map(_.map(_.strict.head.get))
+          timedDequeueBatch1(1, timeout, scheduler).map(_.map(_.head.get))
         def timedPeek1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[A]] =
           q.timedPeek1(timeout, scheduler)
         def cancellableDequeue1: F[(F[A],F[Unit])] =
@@ -398,7 +398,7 @@ object Queue {
         def dequeue1: F[Option[A]] = cancellableDequeue1.flatMap { _._1 }
         def peek1: F[Option[A]] = q.peek1
         def timedDequeue1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[Option[A]]] =
-          timedDequeueBatch1(1, timeout, scheduler).map(_.map(_.strict.head.get))
+          timedDequeueBatch1(1, timeout, scheduler).map(_.map(_.head.get))
         def timedPeek1(timeout: FiniteDuration, scheduler: Scheduler): F[Option[Option[A]]] =
           q.timedPeek1(timeout, scheduler)
         def cancellableDequeue1: F[(F[Option[A]],F[Unit])] =

--- a/core/shared/src/main/scala/fs2/internal/Algebra.scala
+++ b/core/shared/src/main/scala/fs2/internal/Algebra.scala
@@ -78,7 +78,7 @@ private[fs2] object Algebra {
             try {
               def asSegment(c: Catenable[Segment[O,Unit]]): Segment[O,Unit] =
                 c.uncons.flatMap { case (h1,t1) => t1.uncons.map(_ => Segment.catenated(c)).orElse(Some(h1)) }.getOrElse(Segment.empty)
-              os.values.splitAt(chunkSize, Some(maxSteps)) match {
+              os.values.force.splitAt(chunkSize, Some(maxSteps)) match {
                 case Left((r,segments,rem)) =>
                   pure[F,X,Option[(Segment[O,Unit], FreeC[Algebra[F,O,?],Unit])]](Some(asSegment(segments) -> f(Right(r))))
                 case Right((segments,tl)) =>
@@ -120,7 +120,7 @@ private[fs2] object Algebra {
         case None => F.pure(acc)
         case Some((hd, tl)) =>
           F.suspend {
-            try runFoldLoop[F,O,B](scope, hd.fold(acc)(g).run, g, uncons(tl).viewL)
+            try runFoldLoop[F,O,B](scope, hd.fold(acc)(g).force.run, g, uncons(tl).viewL)
             catch { case NonFatal(e) => runFoldLoop[F,O,B](scope, acc, g, uncons(tl.asHandler(e)).viewL) }
           }
       }

--- a/core/shared/src/main/scala/fs2/internal/RunFoldScope.scala
+++ b/core/shared/src/main/scala/fs2/internal/RunFoldScope.scala
@@ -127,7 +127,7 @@ private[internal] final class RunFoldScope[F[_]] private (val id: Token, private
    * Returns failure with collected failures, or `Unit` on successful traversal.
    */
   private def traverseError[A](ca: Catenable[A], f: A => F[Either[Throwable,Unit]]) : F[Either[Throwable, Unit]] = {
-    F.map(Catenable.traverseInstance.traverse(ca)(f)) { results =>
+    F.map(Catenable.instance.traverse(ca)(f)) { results =>
       CompositeFailure.fromList(results.collect { case Left(err) => err }.toList).toLeft(())
     }
   }
@@ -180,7 +180,7 @@ private[internal] final class RunFoldScope[F[_]] private (val id: Token, private
 
   // See docs on [[Scope#lease]]
   def lease: F[Option[Lease[F]]] = {
-    val T = Catenable.traverseInstance
+    val T = Catenable.instance
     F.flatMap(state.get) { s =>
       if (!s.open) F.pure(None)
       else {

--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -55,7 +55,7 @@ object text {
       s.pull.unconsChunk.flatMap {
         case Some((byteChunks, tail)) =>
           val (output, nextBuffer) = byteChunks.toList.foldLeft((Nil: List[String], buf))(processSingleChunk)
-          Pull.output(Chunk.seq(output.reverse)) >> doPull(nextBuffer, tail)
+          Pull.output(Segment.seq(output.reverse)) >> doPull(nextBuffer, tail)
         case None if !buf.isEmpty =>
           Pull.output1(new String(buf.toArray, utf8Charset)) >> Pull.pure(None)
         case None =>
@@ -131,7 +131,7 @@ object text {
       s.pull.unconsChunk.flatMap {
         case Some((chunk, s)) =>
           val (toOutput, newBuffer, newPendingLineFeed) = extractLines(buffer, chunk, pendingLineFeed)
-          Pull.output(toOutput) >> go(newBuffer, newPendingLineFeed, s)
+          Pull.outputChunk(toOutput) >> go(newBuffer, newPendingLineFeed, s)
         case None if buffer.nonEmpty => Pull.output1(buffer.mkString) >> Pull.pure(None)
         case None => Pull.pure(None)
       }

--- a/core/shared/src/test/scala/fs2/SegmentSpec.scala
+++ b/core/shared/src/test/scala/fs2/SegmentSpec.scala
@@ -15,7 +15,7 @@ class SegmentSpec extends Fs2Spec {
     Gen.chooseNum(0, 3).flatMap(n => Gen.listOfN(n, Gen.listOf(genO)).flatMap { oss => Segment.unfoldChunk(0)(i => if (i < oss.size) Some(Chunk.seq(oss(i)) -> (i + 1)) else None) }),
     Gen.listOf(genO).map(_.foldLeft(Segment.empty[O])((acc, o) => acc ++ Segment.singleton(o))),
     Gen.delay(for { lhs <- genSegment(genO); rhs <- genSegment(genO) } yield lhs ++ rhs),
-    Gen.delay(for { seg <- genSegment(genO); c <- Gen.listOf(genO).map(Chunk.seq) } yield seg.prepend(c))
+    Gen.delay(for { seg <- genSegment(genO); c <- Gen.listOf(genO).map(Segment.seq) } yield seg.prepend(c))
   )
 
   implicit def arbSegment[O: Arbitrary]: Arbitrary[Segment[O,Unit]] =
@@ -101,7 +101,7 @@ class SegmentSpec extends Fs2Spec {
     "last" in {
       forAll { (s: Segment[Int,Unit]) =>
         val (out, (r, l)) = s.last.force.unconsAll
-        val flattenedOutput = out.toList.flatMap(_.force.toList)
+        val flattenedOutput = out.toList.flatMap(_.toList)
         val sList = s.force.toList
         flattenedOutput shouldBe (if (sList.isEmpty) Nil else sList.init)
         l shouldBe sList.lastOption
@@ -125,12 +125,12 @@ class SegmentSpec extends Fs2Spec {
         val result = s.force.splitAt(n)
         val v = s.force.toVector
         if (n == 0 || n < v.size) {
-          val Right((segments, rest)) = result
-          segments.toVector.flatMap(_.force.toVector) shouldBe v.take(n)
+          val Right((chunks, rest)) = result
+          chunks.toVector.flatMap(_.toVector) shouldBe v.take(n)
           rest.force.toVector shouldBe v.drop(n)
         } else {
-          val Left((_, segments, rem)) = result
-          segments.toVector.flatMap(_.force.toVector) shouldBe v.take(n)
+          val Left((_, chunks, rem)) = result
+          chunks.toVector.flatMap(_.toVector) shouldBe v.take(n)
           rem shouldBe (n - v.size)
         }
       }
@@ -138,11 +138,11 @@ class SegmentSpec extends Fs2Spec {
 
     "splitWhile" in {
       forAll { (s: Segment[Int,Unit], f: Int => Boolean) =>
-        val (segments, unfinished, tail) = s.force.splitWhile(f) match {
-          case Left((_,segments)) => (segments, true, Segment.empty)
-          case Right((segments,tail)) => (segments, false, tail)
+        val (chunks, unfinished, tail) = s.force.splitWhile(f) match {
+          case Left((_,chunks)) => (chunks, true, Segment.empty)
+          case Right((chunks,tail)) => (chunks, false, tail)
         }
-        Segment.catenated(segments).force.toVector shouldBe s.force.toVector.takeWhile(f)
+        Segment.catenatedChunks(chunks).force.toVector shouldBe s.force.toVector.takeWhile(f)
         unfinished shouldBe (s.force.toVector.takeWhile(f).size == s.force.toVector.size)
         val remainder = s.force.toVector.dropWhile(f)
         if (remainder.isEmpty) tail shouldBe Segment.empty
@@ -152,12 +152,12 @@ class SegmentSpec extends Fs2Spec {
 
     "splitWhile (2)" in {
       forAll { (s: Segment[Int,Unit], f: Int => Boolean) =>
-        val (segments, unfinished, tail) = s.force.splitWhile(f, emitFailure = true) match {
-          case Left((_,segments)) => (segments, true, Segment.empty)
-          case Right((segments,tail)) => (segments, false, tail)
+        val (chunks, unfinished, tail) = s.force.splitWhile(f, emitFailure = true) match {
+          case Left((_,chunks)) => (chunks, true, Segment.empty)
+          case Right((chunks,tail)) => (chunks, false, tail)
         }
         val svec = s.force.toVector
-        Segment.catenated(segments).force.toVector shouldBe (svec.takeWhile(f) ++ svec.dropWhile(f).headOption)
+        Segment.catenatedChunks(chunks).force.toVector shouldBe (svec.takeWhile(f) ++ svec.dropWhile(f).headOption)
         unfinished shouldBe (svec.takeWhile(f).size == svec.size)
         val remainder = svec.dropWhile(f).drop(1)
         if (remainder.isEmpty) tail shouldBe Segment.empty
@@ -167,7 +167,7 @@ class SegmentSpec extends Fs2Spec {
 
     "splitWhile (3)" in {
       val (prefix, suffix) = Segment.seq(List.range(1,10)).map(_ - 1).force.splitWhile(_ < 5).toOption.get
-      Segment.catenated(prefix).force.toVector shouldBe Vector(0, 1, 2, 3, 4)
+      Segment.catenatedChunks(prefix).force.toVector shouldBe Vector(0, 1, 2, 3, 4)
       suffix.force.toVector shouldBe Vector(5, 6, 7, 8)
     }
 
@@ -203,9 +203,9 @@ class SegmentSpec extends Fs2Spec {
 
     "unconsChunk" in {
       forAll { (xss: List[List[Int]]) =>
-        val seg = xss.foldRight(Segment.empty[Int])((xs, acc) => Chunk.array(xs.toArray) ++ acc)
+        val seg = xss.foldRight(Segment.empty[Int])((xs, acc) => Segment.array(xs.toArray) ++ acc)
         // Consecutive empty chunks are collapsed to a single empty chunk
-        seg.force.unconsAll._1.toList.map(_.force.toList).filter(_.nonEmpty) shouldBe xss.filter(_.nonEmpty)
+        seg.force.unconsAll._1.toList.map(_.toList).filter(_.nonEmpty) shouldBe xss.filter(_.nonEmpty)
       }
     }
 
@@ -227,7 +227,7 @@ class SegmentSpec extends Fs2Spec {
         val ysv = ys.force.toVector
         val f: (Int,Int) => (Int,Int) = (_,_)
         val (segments, leftover) = xs.zipWith(ys)(f).force.unconsAll
-        segments.toVector.flatMap(_.force.toVector) shouldBe xsv.zip(ysv).map { case (x,y) => f(x,y) }
+        segments.toVector.flatMap(_.toVector) shouldBe xsv.zip(ysv).map { case (x,y) => f(x,y) }
         leftover match {
           case Left((_,leftoverYs)) => withClue("leftover ys")(leftoverYs.force.toVector shouldBe ysv.drop(xsv.size))
           case Right((_,leftoverXs)) => withClue("leftover xs")(leftoverXs.force.toVector shouldBe xsv.drop(ysv.size))
@@ -249,7 +249,7 @@ class SegmentSpec extends Fs2Spec {
             case Left(r) => r
             case Right((o, s)) => go(s)
           }
-        go(Chunk.indexedSeq(0 until N))
+        go(Segment.indexedSeq(0 until N))
       }
     }}
   }

--- a/core/shared/src/test/scala/fs2/SegmentSpec.scala
+++ b/core/shared/src/test/scala/fs2/SegmentSpec.scala
@@ -24,56 +24,56 @@ class SegmentSpec extends Fs2Spec {
   "Segment" - {
 
     "++" in {
-      forAll { (xs: List[Int], ys: List[Int]) =>
+      forAll { (xs: Vector[Int], ys: Vector[Int]) =>
         val appended = Segment.seq(xs) ++ Segment.seq(ys)
-        appended.toVector shouldBe (xs.toVector ++ ys.toVector)
+        appended.force.toVector shouldBe (xs ++ ys)
       }
     }
 
     "toChunk" in {
       forAll { (xs: List[Int]) =>
-        Segment.seq(xs).toChunk.toVector shouldBe xs.toVector
+        Segment.seq(xs).force.toChunk shouldBe Chunk.seq(xs)
       }
     }
 
     "collect" in {
       forAll { (s: Segment[Int,Unit], f: Int => Double, defined: Int => Boolean) =>
         val pf: PartialFunction[Int,Double] = { case n if defined(n) => f(n) }
-        s.collect(pf).toVector shouldBe s.toVector.collect(pf)
+        s.collect(pf).force.toVector shouldBe s.force.toVector.collect(pf)
       }
     }
 
     "drop" in {
       forAll { (s: Segment[Int,Unit], n: Int) =>
-        s.drop(n).fold(_ => Segment.empty, identity).toVector shouldBe s.toVector.drop(n)
+        s.force.drop(n).fold(_ => Segment.empty, identity).force.toVector shouldBe s.force.toVector.drop(n)
       }
     }
 
     "dropWhile" in {
       forAll { (s: Segment[Int,Unit], f: Int => Boolean) =>
-        s.dropWhile(f).fold(_ => Vector.empty, _.toVector) shouldBe s.toVector.dropWhile(f)
+        s.force.dropWhile(f).fold(_ => Vector.empty, _.force.toVector) shouldBe s.force.toVector.dropWhile(f)
       }
     }
 
     "dropWhile (2)" in {
       forAll { (s: Segment[Int,Unit], f: Int => Boolean) =>
-        val svec = s.toVector
+        val svec = s.force.toVector
         val svecD = if (svec.isEmpty) svec else svec.dropWhile(f).drop(1)
         val dropping = svec.isEmpty || (svecD.isEmpty && f(svec.last))
-        s.dropWhile(f, true).map(_.toVector) shouldBe (if (dropping) Left(()) else Right(svecD))
+        s.force.dropWhile(f, true).map(_.force.toVector) shouldBe (if (dropping) Left(()) else Right(svecD))
       }
     }
 
     "flatMap" in {
       forAll { (s: Segment[Int,Unit], f: Int => Segment[Int,Unit]) =>
-        s.flatMap(f).toVector shouldBe s.toVector.flatMap(i => f(i).toVector)
+        s.flatMap(f).force.toVector shouldBe s.force.toVector.flatMap(i => f(i).force.toVector)
       }
     }
 
     "flatMap (2)" in {
       forAll { (s: Segment[Int,Unit], f: Int => Segment[Int,Unit], n: Int) =>
-        val s2 = s.flatMap(f).take(n).drain.run.toOption
-        s2.foreach { _.toVector shouldBe s.toVector.flatMap(i => f(i).toVector).drop(n) }
+        val s2 = s.flatMap(f).take(n).drain.force.run.toOption
+        s2.foreach { _.force.toVector shouldBe s.force.toVector.flatMap(i => f(i).force.toVector).drop(n) }
       }
     }
 
@@ -81,28 +81,28 @@ class SegmentSpec extends Fs2Spec {
       forAll { (s: Segment[Int,Unit], init: Double, f: (Double,Int) => (Double,Int)) =>
         val s1 = s.flatMapAccumulate(init) { (s,i) => val (s2,o) = f(s,i); Segment.singleton(o).asResult(s2) }
         val s2 = s.mapAccumulate(init)(f)
-        s1.toVector shouldBe s2.toVector
-        s1.drain.run shouldBe s2.drain.run
+        s1.force.toVector shouldBe s2.force.toVector
+        s1.drain.force.run shouldBe s2.drain.force.run
       }
     }
 
     "flatMapResult" in {
       forAll { (s: Segment[Int,Unit], r: Int, f: Int => Segment[Int, Unit]) =>
-        s.asResult(r).flatMapResult(f).toVector shouldBe (s ++ f(r)).toVector
+        s.asResult(r).flatMapResult(f).force.toVector shouldBe (s ++ f(r)).force.toVector
       }
     }
 
     "fold" in {
       forAll { (s: Segment[Int,Unit], init: Int, f: (Int, Int) => Int) =>
-        s.fold(init)(f).run shouldBe s.toChunk.toVector.foldLeft(init)(f)
+        s.fold(init)(f).force.run shouldBe s.force.toVector.foldLeft(init)(f)
       }
     }
 
     "last" in {
       forAll { (s: Segment[Int,Unit]) =>
-        val (out, (r, l)) = s.last.unconsAll
-        val flattenedOutput = out.toList.flatMap(_.toList)
-        val sList = s.toList
+        val (out, (r, l)) = s.last.force.unconsAll
+        val flattenedOutput = out.toList.flatMap(_.force.toList)
+        val sList = s.force.toList
         flattenedOutput shouldBe (if (sList.isEmpty) Nil else sList.init)
         l shouldBe sList.lastOption
       }
@@ -110,27 +110,27 @@ class SegmentSpec extends Fs2Spec {
 
     "map" in {
       forAll { (s: Segment[Int,Unit], f: Int => Double) =>
-        s.map(f).toChunk shouldBe s.toChunk.map(f)
+        s.map(f).force.toChunk shouldBe s.force.toChunk.map(f)
       }
     }
 
     "scan" in {
       forAll { (s: Segment[Int,Unit], init: Int, f: (Int, Int) => Int) =>
-        s.scan(init)(f).toChunk.toVector shouldBe s.toChunk.toVector.scanLeft(init)(f)
+        s.scan(init)(f).force.toVector shouldBe s.force.toVector.scanLeft(init)(f)
       }
     }
 
     "splitAt" in {
       forAll { (s: Segment[Int,Unit], n: Int) =>
-        val result = s.splitAt(n)
-        val v = s.toVector
+        val result = s.force.splitAt(n)
+        val v = s.force.toVector
         if (n == 0 || n < v.size) {
           val Right((segments, rest)) = result
-          segments.toVector.flatMap(_.toVector) shouldBe v.take(n)
-          rest.toVector shouldBe v.drop(n)
+          segments.toVector.flatMap(_.force.toVector) shouldBe v.take(n)
+          rest.force.toVector shouldBe v.drop(n)
         } else {
           val Left((_, segments, rem)) = result
-          segments.toVector.flatMap(_.toVector) shouldBe v.take(n)
+          segments.toVector.flatMap(_.force.toVector) shouldBe v.take(n)
           rem shouldBe (n - v.size)
         }
       }
@@ -138,66 +138,66 @@ class SegmentSpec extends Fs2Spec {
 
     "splitWhile" in {
       forAll { (s: Segment[Int,Unit], f: Int => Boolean) =>
-        val (segments, unfinished, tail) = s.splitWhile(f) match {
+        val (segments, unfinished, tail) = s.force.splitWhile(f) match {
           case Left((_,segments)) => (segments, true, Segment.empty)
           case Right((segments,tail)) => (segments, false, tail)
         }
-        Segment.catenated(segments).toVector shouldBe s.toVector.takeWhile(f)
-        unfinished shouldBe (s.toVector.takeWhile(f).size == s.toVector.size)
-        val remainder = s.toVector.dropWhile(f)
+        Segment.catenated(segments).force.toVector shouldBe s.force.toVector.takeWhile(f)
+        unfinished shouldBe (s.force.toVector.takeWhile(f).size == s.force.toVector.size)
+        val remainder = s.force.toVector.dropWhile(f)
         if (remainder.isEmpty) tail shouldBe Segment.empty
-        else tail.toVector shouldBe remainder
+        else tail.force.toVector shouldBe remainder
       }
     }
 
     "splitWhile (2)" in {
       forAll { (s: Segment[Int,Unit], f: Int => Boolean) =>
-        val (segments, unfinished, tail) = s.splitWhile(f, emitFailure = true) match {
+        val (segments, unfinished, tail) = s.force.splitWhile(f, emitFailure = true) match {
           case Left((_,segments)) => (segments, true, Segment.empty)
           case Right((segments,tail)) => (segments, false, tail)
         }
-        val svec = s.toVector
-        Segment.catenated(segments).toVector shouldBe (svec.takeWhile(f) ++ svec.dropWhile(f).headOption)
+        val svec = s.force.toVector
+        Segment.catenated(segments).force.toVector shouldBe (svec.takeWhile(f) ++ svec.dropWhile(f).headOption)
         unfinished shouldBe (svec.takeWhile(f).size == svec.size)
         val remainder = svec.dropWhile(f).drop(1)
         if (remainder.isEmpty) tail shouldBe Segment.empty
-        else tail.toVector shouldBe remainder
+        else tail.force.toVector shouldBe remainder
       }
     }
 
     "splitWhile (3)" in {
-      val (prefix, suffix) = Segment.seq(List.range(1,10)).map(_ - 1).splitWhile(_ < 5).toOption.get
-      Segment.catenated(prefix).toVector shouldBe Vector(0, 1, 2, 3, 4)
-      suffix.toVector shouldBe Vector(5, 6, 7, 8)
+      val (prefix, suffix) = Segment.seq(List.range(1,10)).map(_ - 1).force.splitWhile(_ < 5).toOption.get
+      Segment.catenated(prefix).force.toVector shouldBe Vector(0, 1, 2, 3, 4)
+      suffix.force.toVector shouldBe Vector(5, 6, 7, 8)
     }
 
     "sum" in {
       forAll { (s: Segment[Int,Unit]) =>
-        s.sum.run shouldBe s.toVector.sum
+        s.sum.force.run shouldBe s.force.toVector.sum
       }
     }
 
     "take" in {
       forAll { (s: Segment[Int,Unit], n: Int) =>
-        val v = s.toVector
-        s.take(n).toVector shouldBe v.take(n)
+        val v = s.force.toVector
+        s.take(n).force.toVector shouldBe v.take(n)
         if (n > 0 && n >= v.size) {
-          s.take(n).drain.run shouldBe Left(((), n - v.size))
+          s.take(n).drain.force.run shouldBe Left(((), n - v.size))
         } else {
-          s.take(n).drain.run shouldBe Right(Segment.vector(v.drop(n)))
+          s.take(n).drain.force.run shouldBe Right(Segment.vector(v.drop(n)))
         }
       }
     }
 
     "takeWhile" in {
       forAll { (s: Segment[Int,Unit], f: Int => Boolean) =>
-        s.takeWhile(f).toVector shouldBe s.toVector.takeWhile(f)
+        s.takeWhile(f).force.toVector shouldBe s.force.toVector.takeWhile(f)
       }
     }
 
     "takeWhile (2)" in {
       forAll { (s: Segment[Int,Unit], f: Int => Boolean) =>
-        s.takeWhile(f, true).toVector shouldBe (s.toVector.takeWhile(f) ++ s.toVector.dropWhile(f).headOption)
+        s.takeWhile(f, true).force.toVector shouldBe (s.force.toVector.takeWhile(f) ++ s.force.toVector.dropWhile(f).headOption)
       }
     }
 
@@ -205,7 +205,7 @@ class SegmentSpec extends Fs2Spec {
       forAll { (xss: List[List[Int]]) =>
         val seg = xss.foldRight(Segment.empty[Int])((xs, acc) => Chunk.array(xs.toArray) ++ acc)
         // Consecutive empty chunks are collapsed to a single empty chunk
-        seg.unconsAll._1.toList.map(_.toVector.toList).filter(_.nonEmpty) shouldBe xss.filter(_.nonEmpty)
+        seg.force.unconsAll._1.toList.map(_.force.toList).filter(_.nonEmpty) shouldBe xss.filter(_.nonEmpty)
       }
     }
 
@@ -213,7 +213,7 @@ class SegmentSpec extends Fs2Spec {
       val Ns = List(2,3,100,200,400,800,1600,3200,6400,12800,25600,51200,102400)
       Ns.foreach { N => N.toString in {
         val s = Segment.from(0).take(N).voidResult
-        def go(s: Segment[Long,Unit]): Unit = s.uncons1 match {
+        def go(s: Segment[Long,Unit]): Unit = s.force.uncons1 match {
           case Right((hd,tl)) => go(tl)
           case Left(_) => ()
         }
@@ -223,14 +223,14 @@ class SegmentSpec extends Fs2Spec {
 
     "zipWith" in {
       forAll { (xs: Segment[Int,Unit], ys: Segment[Int,Unit]) =>
-        val xsv = xs.toVector
-        val ysv = ys.toVector
+        val xsv = xs.force.toVector
+        val ysv = ys.force.toVector
         val f: (Int,Int) => (Int,Int) = (_,_)
-        val (segments, leftover) = xs.zipWith(ys)(f).unconsAll
-        segments.toVector.flatMap(_.toVector) shouldBe xsv.zip(ysv).map { case (x,y) => f(x,y) }
+        val (segments, leftover) = xs.zipWith(ys)(f).force.unconsAll
+        segments.toVector.flatMap(_.force.toVector) shouldBe xsv.zip(ysv).map { case (x,y) => f(x,y) }
         leftover match {
-          case Left((_,leftoverYs)) => withClue("leftover ys")(leftoverYs.toVector shouldBe ysv.drop(xsv.size))
-          case Right((_,leftoverXs)) => withClue("leftover xs")(leftoverXs.toVector shouldBe xsv.drop(ysv.size))
+          case Left((_,leftoverYs)) => withClue("leftover ys")(leftoverYs.force.toVector shouldBe ysv.drop(xsv.size))
+          case Right((_,leftoverXs)) => withClue("leftover xs")(leftoverXs.force.toVector shouldBe xsv.drop(ysv.size))
         }
       }
     }
@@ -238,14 +238,14 @@ class SegmentSpec extends Fs2Spec {
     "staging stack safety" in {
       val N = 100000
       val s = (0 until N).foldLeft(Segment.singleton(0))((s,i) => s map (_ + i))
-      s.sum.run shouldBe (0 until N).sum
+      s.sum.force.run shouldBe (0 until N).sum
     }
 
     val Ns = List(2,3,100,200,400,800,1600,3200,6400,12800,25600,51200,102400)
     "uncons1 is O(1)" - { Ns.foreach { N =>
       N.toString in {
         def go[O,R](s: Segment[O,R]): R =
-          s.uncons1 match {
+          s.force.uncons1 match {
             case Left(r) => r
             case Right((o, s)) => go(s)
           }

--- a/core/shared/src/test/scala/fs2/SegmentSpec.scala
+++ b/core/shared/src/test/scala/fs2/SegmentSpec.scala
@@ -160,7 +160,7 @@ class SegmentSpec extends Fs2Spec {
         Segment.catenatedChunks(chunks).force.toVector shouldBe (svec.takeWhile(f) ++ svec.dropWhile(f).headOption)
         unfinished shouldBe (svec.takeWhile(f).size == svec.size)
         val remainder = svec.dropWhile(f).drop(1)
-        if (remainder.isEmpty) tail shouldBe Segment.empty
+        if (remainder.isEmpty) tail.force.toVector shouldBe Vector.empty
         else tail.force.toVector shouldBe remainder
       }
     }
@@ -184,7 +184,7 @@ class SegmentSpec extends Fs2Spec {
         if (n > 0 && n >= v.size) {
           s.take(n).drain.force.run shouldBe Left(((), n - v.size))
         } else {
-          s.take(n).drain.force.run shouldBe Right(Segment.vector(v.drop(n)))
+          s.take(n).drain.force.run.map(_.force.toVector) shouldBe Right(Segment.vector(v.drop(n)).force.toVector)
         }
       }
     }

--- a/docs/ReadmeExample.md
+++ b/docs/ReadmeExample.md
@@ -98,7 +98,7 @@ There are a number of ways of interpreting the stream. In this case, we call `ru
 
 ```scala
 scala> val task: IO[Unit] = written.run
-task: cats.effect.IO[Unit] = IO$2027047179
+task: cats.effect.IO[Unit] = IO$952127193
 ```
 
 We still haven't *done* anything yet. Effects only occur when we run the resulting task. We can run a `IO` by calling `unsafeRunSync()` -- the name is telling us that calling it performs effects and hence, it is not referentially transparent.

--- a/docs/migration-guide-0.10.md
+++ b/docs/migration-guide-0.10.md
@@ -50,7 +50,7 @@ As a result `fs2.Task` has been removed. Porting from `Task` to `IO` is relative
 
 Performance is significantly better thanks to the introduction of `fs2.Segment`. A `Segment` is a potentially infinite, lazy, pure data structure which supports a variety of fused operations. This is coincidentally similar to the approach taken in [Stream Fusion, to Completeness](https://arxiv.org/pdf/1612.06668v1.pdf), though using a novel approach that does not require code generation.
 
-Instead of a `Stream` being made up of `Chunk`s like in 0.9, it is now made up of `Segment`s. `Chunk[O]` is a subtype of `Segment[O,Unit]`. Many of the operations which operated in terms of chunks now operate in terms of segments. Occassionally, there are operations that are specialized for chunks -- typically when index based access to the underlying elements is more performant than the benefits of operator fusion.
+Instead of a `Stream` being made up of `Chunk`s like in 0.9, it is now made up of `Segment`s. A `Segment[O,Unit]` can wrap a `Chunk[O]` (via `Segment.chunk(c)`) but can also be formed in a lot of other ways. Many of the operations which operated in terms of chunks now operate in terms of segments. Occasionally, there are operations that are specialized for chunks -- typically when index based access to the underlying elements is more performant than the benefits of operator fusion.
 
 ### API Simplification
 

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -126,7 +126,7 @@ _Note:_ The various `run*` functions aren't specialized to `IO` and work for any
 
 FS2 streams are segmented internally for performance. You can construct an individual stream segment using `Stream.segment`, which accepts an `fs2.Segment` and lots of functions in the library are segment-aware and/or try to preserve segments when possible.
 
-Segments are potentially infinite and support lazy, fused operations. A `Chunk` is a specialized segment that's finite and supports efficient indexed based lookup of elements.
+Segments are potentially infinite and support lazy, fused operations. A `Chunk` is a strict, finite sequence of values that supports efficient indexed based lookup of elements. A chunk can be lifted to a segment via `Segment.chunk(c)` or `c.toSegment`.
 
 ```tut
 import fs2.Chunk
@@ -136,7 +136,7 @@ val s1c = Stream.chunk(Chunk.doubles(Array(1.0, 2.0, 3.0)))
 s1c.mapChunks { ds =>
   val doubles = ds.toDoubles
   /* do things unboxed using doubles.{values,size} */
- doubles
+ doubles.toSegment
 }
 ```
 

--- a/io/src/main/scala/fs2/io/JavaInputOutputStream.scala
+++ b/io/src/main/scala/fs2/io/JavaInputOutputStream.scala
@@ -171,7 +171,7 @@ private[io] object JavaInputOutputStream {
           val cloned = Chunk.Bytes(bytes.toArray)
           if (bytes.size <= len) Ready(None) -> Some(cloned)
           else {
-            val (out,rem) = cloned.strict.splitAt(len)
+            val (out,rem) = cloned.splitAt(len)
             Ready(Some(rem.toBytes)) -> Some(out.toBytes)
           }
       }
@@ -203,7 +203,7 @@ private[io] object JavaInputOutputStream {
                   val (copy,maybeKeep) =
                     if (bytes.size <= len) bytes -> None
                     else {
-                      val (out,rem) = bytes.strict.splitAt(len)
+                      val (out,rem) = bytes.splitAt(len)
                       out.toBytes -> Some(rem.toBytes)
                     }
                   F.flatMap(F.delay {

--- a/io/src/main/scala/fs2/io/file/file.scala
+++ b/io/src/main/scala/fs2/io/file/file.scala
@@ -75,7 +75,7 @@ package object file {
       if (written >= buf.size)
         Pull.pure(())
       else
-        _writeAll1(buf.drop(written).toOption.get.toChunk, out, offset + written)
+        _writeAll1(buf.strict.drop(written), out, offset + written)
     }
 
   /**

--- a/io/src/main/scala/fs2/io/file/file.scala
+++ b/io/src/main/scala/fs2/io/file/file.scala
@@ -75,7 +75,7 @@ package object file {
       if (written >= buf.size)
         Pull.pure(())
       else
-        _writeAll1(buf.strict.drop(written), out, offset + written)
+        _writeAll1(buf.drop(written), out, offset + written)
     }
 
   /**

--- a/io/src/main/scala/fs2/io/file/pulls.scala
+++ b/io/src/main/scala/fs2/io/file/pulls.scala
@@ -43,7 +43,7 @@ object pulls {
       if (written >= buf.size)
         Pull.pure(())
       else
-        _writeAllToFileHandle2(buf.drop(written).toOption.get.toChunk, out, offset + written)
+        _writeAllToFileHandle2(buf.strict.drop(written), out, offset + written)
     }
 
   /**

--- a/io/src/main/scala/fs2/io/file/pulls.scala
+++ b/io/src/main/scala/fs2/io/file/pulls.scala
@@ -21,7 +21,7 @@ object pulls {
 
   private def _readAllFromFileHandle0[F[_]](chunkSize: Int, offset: Long)(h: FileHandle[F]): Pull[F, Byte, Unit] =
     Pull.eval(h.read(chunkSize, offset)).flatMap {
-      case Some(o) => Pull.output(o) >> _readAllFromFileHandle0(chunkSize, offset + o.size)(h)
+      case Some(o) => Pull.outputChunk(o) >> _readAllFromFileHandle0(chunkSize, offset + o.size)(h)
       case None => Pull.done
     }
 

--- a/io/src/main/scala/fs2/io/file/pulls.scala
+++ b/io/src/main/scala/fs2/io/file/pulls.scala
@@ -43,7 +43,7 @@ object pulls {
       if (written >= buf.size)
         Pull.pure(())
       else
-        _writeAllToFileHandle2(buf.strict.drop(written), out, offset + written)
+        _writeAllToFileHandle2(buf.drop(written), out, offset + written)
     }
 
   /**

--- a/scodec/shared/src/main/scala/fs2/interop/scodec/ByteVectorChunk.scala
+++ b/scodec/shared/src/main/scala/fs2/interop/scodec/ByteVectorChunk.scala
@@ -15,7 +15,7 @@ final class ByteVectorChunk private (val toByteVector: ByteVector) extends Chunk
     (ByteVectorChunk(before), ByteVectorChunk(after))
   }
 
-  protected def mapStrict[O2](f: Byte => O2): Chunk[O2] =
+  override def map[O2](f: Byte => O2): Chunk[O2] =
     Chunk.indexedSeq(toByteVector.toIndexedSeq.map(f))
 }
 


### PR DESCRIPTION
This PR includes:
 - `Segment` operations which force evaluation of any elements have been moved to `Segment.Force`, resulting in syntax like `s.force.toVector`, `s.force.run`, `s.force.unconsChunk`. The primary motivation here is to be clear when evaluation occurs.
 - `Segment` no longer overrides `equals` and `hashCode` as computing these values necessarily forces the segment, which may hang if the segment is infinite.
 - `Chunk` is no longer a subtype of `Segment`. A chunk can be lifted to a segment via `Segment.chunk(c)` or `c.toSegment`. By avoiding subtyping, users know that chunk operations are *always* strict. This is a significant improvement over the old API where an operation on a `Chunk` may be strict (if defined directly on `Chunk`), lazy, or partially eager and partially lazy.
 - `Chunk#{head,last}` were changed to return `Option[O]` -- the only unsafe operation on `Chunk` is `apply` now.