### PR TITLE
Deprecated run methods and...

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,15 @@ def converter[F[_]](implicit F: Sync[F]): F[Unit] =
     .intersperse("\n")
     .through(text.utf8Encode)
     .through(io.file.writeAll(Paths.get("testdata/celsius.txt")))
-    .run
+    .compile.drain
 
 // at the end of the universe...
 val u: Unit = converter[IO].unsafeRunSync()
 ```
 
-This will construct a `F[Unit]`, `converter`, which reads lines incrementally from `testdata/fahrenheit.txt`, skipping blanklines and commented lines. It then parses temperatures in degrees Fahrenheit, converts these to Celsius, UTF-8 encodes the output, and writes incrementally to `testdata/celsius.txt`, using constant memory. The input and output files will be closed upon normal termination or if exceptions occur.
+This will construct a `F[Unit]`, `converter`, which reads lines incrementally from `testdata/fahrenheit.txt`, skipping blank lines and commented lines. It then parses temperatures in degrees Fahrenheit, converts these to Celsius, UTF-8 encodes the output, and writes incrementally to `testdata/celsius.txt`, using constant memory. The input and output files will be closed upon normal termination or if exceptions occur.
 
-At the end it's saying that the effect `F` will be of type `cats.effect.IO` and then it's possible to invoke `unsafeRunSync()`. You can choose a different effect type or your own as long as it implements `cats.effect.Sync` for this case. In some other cases the constraints might require to implement interfaces like `cats.effect.MonadError[?, Throwable]`, `cats.effect.Async` and / or `cats.effect.Effect`.
+At the end it's saying that the effect `F` will be of type `cats.effect.IO` and then it's possible to invoke `unsafeRunSync()`. You can choose a different effect type or your own as long as it implements `cats.effect.Sync`.
 
 The library supports a number of other interesting use cases:
 
@@ -66,10 +66,10 @@ The 0.10 release is almost complete and will be released when Cats 1.0 is releas
 
 ```
 // available for Scala 2.11, 2.12
-libraryDependencies += "co.fs2" %% "fs2-core" % "0.10.0-M8" // For cats 1.0.0-RC1 and cats-effect 0.5
+libraryDependencies += "co.fs2" %% "fs2-core" % "0.10.0-M10" // For cats 1.0.0-RC2 and cats-effect 0.6
 
 // optional I/O library
-libraryDependencies += "co.fs2" %% "fs2-io" % "0.10.0-M8"
+libraryDependencies += "co.fs2" %% "fs2-io" % "0.10.0-M10"
 ```
 
 The 0.9 release is out and we recommend upgrading. You may want to first [read the 0.9 migration guide](docs/migration-guide-0.9.md) if you are upgrading from 0.8 or earlier. To get 0.9, add the following to your SBT build:

--- a/benchmark/src/main/scala/fs2/benchmark/ConcurrentBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/ConcurrentBenchmark.scala
@@ -12,6 +12,6 @@ class ConcurrentBenchmark {
   @Benchmark
   def join(N: Int): Int = {
     val each = Stream.segment(Segment.seq(0 to 1000).map(i => Stream.eval(IO.pure(i)))).covary[IO]
-    each.join(N).runLast.unsafeRunSync.get
+    each.join(N).compile.last.unsafeRunSync.get
   }
 }

--- a/benchmark/src/main/scala/fs2/benchmark/StreamBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/StreamBenchmark.scala
@@ -11,37 +11,37 @@ class StreamBenchmark {
   @GenerateN(2, 3, 100, 200, 400, 800, 1600, 3200, 6400, 12800, 25600, 51200, 102400)
   @Benchmark
   def leftAssocConcat(N: Int): Int = {
-    (1 until N).map(Stream.emit).foldRight(Stream.empty.covaryOutput[Int])(_ ++ _).covary[IO].runLast.unsafeRunSync.get
+    (1 until N).map(Stream.emit).foldRight(Stream.empty.covaryOutput[Int])(_ ++ _).covary[IO].compile.last.unsafeRunSync.get
   }
 
   @GenerateN(2, 3, 100, 200, 400, 800, 1600, 3200, 6400, 12800, 25600, 51200, 102400)
   @Benchmark
   def rightAssocConcat(N: Int): Int = {
-    (0 until N).map(Stream.emit).foldRight(Stream.empty.covaryOutput[Int])(_ ++ _).covary[IO].runLast.unsafeRunSync.get
+    (0 until N).map(Stream.emit).foldRight(Stream.empty.covaryOutput[Int])(_ ++ _).covary[IO].compile.last.unsafeRunSync.get
   }
 
   @GenerateN(2, 3, 100, 200, 400, 800, 1600, 3200, 6400, 12800, 25600, 51200, 102400)
   @Benchmark
   def leftAssocFlatMap(N: Int): Int = {
-    (1 until N).map(Stream.emit).foldLeft(Stream.emit(0))((acc,a) => acc.flatMap(_ => a)).covary[IO].runLast.unsafeRunSync.get
+    (1 until N).map(Stream.emit).foldLeft(Stream.emit(0))((acc,a) => acc.flatMap(_ => a)).covary[IO].compile.last.unsafeRunSync.get
   }
 
   @GenerateN(2, 3, 100, 200, 400, 800, 1600, 3200, 6400, 12800, 25600, 51200, 102400)
   @Benchmark
   def rightAssocFlatMap(N: Int): Int = {
-    (1 until N).map(Stream.emit).reverse.foldLeft(Stream.emit(0))((acc, a) => a.flatMap( _ => acc)).covary[IO].runLast.unsafeRunSync.get
+    (1 until N).map(Stream.emit).reverse.foldLeft(Stream.emit(0))((acc, a) => a.flatMap( _ => acc)).covary[IO].compile.last.unsafeRunSync.get
   }
 
   @GenerateN(2, 3, 100, 200, 400, 800, 1600, 3200, 6400, 12800, 25600, 51200, 102400)
   @Benchmark
   def eval(N: Int): Unit = {
-    Stream.repeatEval(IO(())).take(N).runLast.unsafeRunSync.get
+    Stream.repeatEval(IO(())).take(N).compile.last.unsafeRunSync.get
   }
 
   @GenerateN(0, 2, 3, 6, 12, 25, 50, 100, 200, 400, 800, 1600, 3200, 6400, 12800, 25600, 51200, 102400)
   @Benchmark
-  def runLog(N: Int): Vector[Int] = {
-    Stream.emits(0 until N).covary[IO].runLog.unsafeRunSync
+  def toVector(N: Int): Vector[Int] = {
+    Stream.emits(0 until N).covary[IO].compile.toVector.unsafeRunSync
   }
 
   @GenerateN(1, 2, 4, 8, 16, 32, 64, 128, 256)
@@ -52,7 +52,7 @@ class StreamBenchmark {
         case Some((h,t)) => Pull.output(h).as(Some(t))
         case None => Pull.pure(None)
       }
-    }.covary[IO].runLast.unsafeRunSync.get
+    }.covary[IO].compile.last.unsafeRunSync.get
   }
 
   @GenerateN(1, 10, 100, 1000, 10000)

--- a/core/jvm/src/test/scala/fs2/ConcurrentlySpec.scala
+++ b/core/jvm/src/test/scala/fs2/ConcurrentlySpec.scala
@@ -13,7 +13,7 @@ class ConcurrentlySpec extends Fs2Spec {
 
     "when background stream fails, overall stream fails" in forAll { (s: PureStream[Int], f: Failure) =>
       val prg = Scheduler[IO](1).flatMap(scheduler => (scheduler.sleep_[IO](25.millis) ++ s.get).concurrently(f.get))
-      val throws = f.get.drain.run.attempt.unsafeRunSync.isLeft
+      val throws = f.get.drain.compile.toVector.attempt.unsafeRunSync.isLeft
       if (throws) an[Err.type] should be thrownBy runLog(prg)
       else runLog(prg)
     }

--- a/core/jvm/src/test/scala/fs2/ConcurrentlySpec.scala
+++ b/core/jvm/src/test/scala/fs2/ConcurrentlySpec.scala
@@ -13,7 +13,7 @@ class ConcurrentlySpec extends Fs2Spec {
 
     "when background stream fails, overall stream fails" in forAll { (s: PureStream[Int], f: Failure) =>
       val prg = Scheduler[IO](1).flatMap(scheduler => (scheduler.sleep_[IO](25.millis) ++ s.get).concurrently(f.get))
-      val throws = f.get.drain.compile.toVector.attempt.unsafeRunSync.isLeft
+      val throws = f.get.drain.compile.drain.attempt.unsafeRunSync.isLeft
       if (throws) an[Err.type] should be thrownBy runLog(prg)
       else runLog(prg)
     }

--- a/core/jvm/src/test/scala/fs2/HashSpec.scala
+++ b/core/jvm/src/test/scala/fs2/HashSpec.scala
@@ -43,7 +43,7 @@ class HashSpec extends Fs2Spec {
     // avoid using .par here because it's not source-compatible across 2.12/2.13
     // (2.13 needs an import, but in 2.12 the same import won't compile)
     val vec = collection.parallel.immutable.ParVector.fill(100)(s)
-    val res = s.runLog.unsafeRunSync()
-    vec.map(_.runLog.unsafeRunSync()) shouldBe Vector.fill(100)(res)
+    val res = s.compile.toVector.unsafeRunSync()
+    vec.map(_.compile.toVector.unsafeRunSync()) shouldBe Vector.fill(100)(res)
   }
 }

--- a/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
+++ b/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
@@ -10,12 +10,12 @@ object ResourceTrackerSanityTest extends App {
   val big = Stream.constant(1).flatMap { n =>
     Stream.bracket(IO(()))(_ => Stream.emits(List(1, 2, 3)), _ => IO(()))
   }
-  big.run.unsafeRunSync()
+  big.compile.drain.unsafeRunSync()
 }
 
 object RepeatPullSanityTest extends App {
   def id[A]: Pipe[Pure, A, A] = _ repeatPull { _.uncons1.flatMap { case Some((h, t)) => Pull.output1(h) as Some(t); case None => Pull.pure(None) } }
-  Stream.constant(1).covary[IO].throughPure(id).run.unsafeRunSync()
+  Stream.constant(1).covary[IO].throughPure(id).compile.drain.unsafeRunSync()
 }
 
 object RepeatEvalSanityTest extends App {
@@ -24,29 +24,29 @@ object RepeatEvalSanityTest extends App {
       s.pull.uncons1.flatMap { case Some((h, t)) => Pull.output1(h) >> go(t); case None => Pull.done }
     in => go(in).stream
   }
-  Stream.repeatEval(IO(1)).throughPure(id).run.unsafeRunSync()
+  Stream.repeatEval(IO(1)).throughPure(id).compile.drain.unsafeRunSync()
 }
 
 object AppendSanityTest extends App {
-  (Stream.constant(1).covary[IO] ++ Stream.empty).pull.echo.stream.run.unsafeRunSync()
+  (Stream.constant(1).covary[IO] ++ Stream.empty).pull.echo.stream.compile.drain.unsafeRunSync()
 }
 
 object DrainOnCompleteSanityTest extends App {
   import ExecutionContext.Implicits.global
   val s = Stream.repeatEval(IO(1)).pull.echo.stream.drain ++ Stream.eval_(IO(println("done")))
-  (Stream.empty.covary[IO] merge s).run.unsafeRunSync()
+  (Stream.empty.covary[IO] merge s).compile.drain.unsafeRunSync()
 }
 
 object ConcurrentJoinSanityTest extends App {
   import ExecutionContext.Implicits.global
-  Stream.constant(Stream.empty.covary[IO]).covary[IO].join(5).run.unsafeRunSync
+  Stream.constant(Stream.empty.covary[IO]).covary[IO].join(5).compile.drain.unsafeRunSync
 }
 
 object DanglingDequeueSanityTest extends App {
   import ExecutionContext.Implicits.global
   Stream.eval(async.unboundedQueue[IO,Int]).flatMap { q =>
     Stream.constant(1).flatMap { _ => Stream.empty mergeHaltBoth q.dequeue }
-  }.run.unsafeRunSync
+  }.compile.drain.unsafeRunSync
 }
 
 object AwakeEverySanityTest extends App {
@@ -54,21 +54,21 @@ object AwakeEverySanityTest extends App {
   import ExecutionContext.Implicits.global
   Scheduler[IO](1).flatMap { _.awakeEvery[IO](1.millis) }.flatMap {
     _ => Stream.eval(IO(()))
-  }.run.unsafeRunSync
+  }.compile.drain.unsafeRunSync
 }
 
 object SignalDiscreteSanityTest extends App {
   import ExecutionContext.Implicits.global
   Stream.eval(async.signalOf[IO, Unit](())).flatMap { signal =>
     signal.discrete.evalMap(a => signal.set(a))
-  }.run.unsafeRunSync
+  }.compile.drain.unsafeRunSync
 }
 
 object SignalContinuousSanityTest extends App {
   import ExecutionContext.Implicits.global
   Stream.eval(async.signalOf[IO, Unit](())).flatMap { signal =>
     signal.continuous.evalMap(a => signal.set(a))
-  }.run.unsafeRunSync
+  }.compile.drain.unsafeRunSync
 }
 
 object ConstantEvalSanityTest extends App {
@@ -81,12 +81,12 @@ object ConstantEvalSanityTest extends App {
       println("Elapsed: " + (now - start))
       start = now
     }
-  }) }.run.unsafeRunSync
+  }) }.compile.drain.unsafeRunSync
 }
 
 object RecursiveFlatMapTest extends App {
   def loop: Stream[IO,Unit] = Stream(()).covary[IO].flatMap(_ => loop)
-  loop.run.unsafeRunSync
+  loop.compile.drain.unsafeRunSync
 }
 
 object StepperSanityTest extends App {
@@ -108,7 +108,7 @@ object StepperSanityTest extends App {
     s => go(Pipe.stepper(p), s).stream
   }
   val incr: Pipe[Pure,Int,Int] = _.map(_ + 1)
-  Stream.constant(0).covary[IO].through(id(incr)).run.unsafeRunSync
+  Stream.constant(0).covary[IO].through(id(incr)).compile.drain.unsafeRunSync
 }
 
 object StepperSanityTest2 extends App {
@@ -128,7 +128,7 @@ object EvalFlatMapMapTest extends App {
   Stream.eval(IO(())).
     flatMap(_ => Stream.emits(Seq())).
     map(x => x).
-    repeat.run.unsafeRunSync()
+    repeat.compile.drain.unsafeRunSync()
 }
 
 object QueueTest extends App {
@@ -137,18 +137,18 @@ object QueueTest extends App {
     queue.dequeueAvailable.rethrow.unNoneTerminate.concurrently(
       Stream.constant(1, 128).covary[IO].noneTerminate.attempt.evalMap(queue.enqueue1(_))
     ).evalMap(_ => IO.unit)
-  }.run.unsafeRunSync()
+  }.compile.drain.unsafeRunSync()
 }
 
 object ProgressMerge extends App {
   import ExecutionContext.Implicits.global
   val progress = Stream.constant(1, 128).covary[IO]
-  (progress merge progress).run.unsafeRunSync()
+  (progress merge progress).compile.drain.unsafeRunSync()
 }
 
 object HungMerge extends App {
   import ExecutionContext.Implicits.global
   val hung = Stream.eval(IO.async[Int](_ => ()))
   val progress = Stream.constant(1, 128).covary[IO]
-  (hung merge progress).run.unsafeRunSync()
+  (hung merge progress).compile.drain.unsafeRunSync()
 }

--- a/core/jvm/src/test/scala/fs2/MergeJoinSpec.scala
+++ b/core/jvm/src/test/scala/fs2/MergeJoinSpec.scala
@@ -50,12 +50,12 @@ class MergeJoinSpec extends Fs2Spec {
       val s: Stream[IO,Stream[IO,Unit]] = bracketed.map { b =>
         Stream.eval(IO(b.get)).flatMap(b => if (b) Stream(()) else Stream.raiseError(Err)).repeat.take(10000)
       }
-      s.joinUnbounded.run.unsafeRunSync()
+      s.joinUnbounded.compile.drain.unsafeRunSync()
     }
 
     "merge (left/right failure)" in forAll { (s1: PureStream[Int], f: Failure) =>
       an[Err.type] should be thrownBy {
-        s1.get.merge(f.get).run.unsafeRunSync()
+        s1.get.merge(f.get).compile.drain.unsafeRunSync()
       }
     }
 

--- a/core/jvm/src/test/scala/fs2/Pipe2Spec.scala
+++ b/core/jvm/src/test/scala/fs2/Pipe2Spec.scala
@@ -181,7 +181,7 @@ class Pipe2Spec extends Fs2Spec {
         val pausedStream = Stream.eval(async.signalOf[IO,Boolean](false)).flatMap { pause =>
           mkScheduler.flatMap { scheduler =>
             scheduler.awakeEvery[IO](10.millis).scan(0)((acc, _) => acc + 1).evalMap { n =>
-              if (n % 2 != 0) pause.set(true) *> async.start((scheduler.sleep_[IO](10.millis) ++ Stream.eval(pause.set(false))).run) *> IO.pure(n)
+              if (n % 2 != 0) pause.set(true) *> async.start((scheduler.sleep_[IO](10.millis) ++ Stream.eval(pause.set(false))).compile.drain) *> IO.pure(n)
               else IO.pure(n)
             }.take(5)
           }

--- a/core/jvm/src/test/scala/fs2/SchedulerSpec.scala
+++ b/core/jvm/src/test/scala/fs2/SchedulerSpec.scala
@@ -13,7 +13,7 @@ class SchedulerSpec extends AsyncFs2Spec {
 
       // force a sync up in duration, then measure how long sleep takes
       val emitAndSleep = Stream.emit(()) ++ mkScheduler.flatMap(_.sleep[IO](delay))
-      val t = emitAndSleep zip Stream.duration[IO] drop 1 map { _._2 } runLog
+      val t = emitAndSleep.zip(Stream.duration[IO]).drop(1).map(_._2).compile.toVector
 
       (IO.shift *> t).unsafeToFuture() collect {
         case Vector(d) => assert(d >= delay)
@@ -25,7 +25,7 @@ class SchedulerSpec extends AsyncFs2Spec {
       val t = mkScheduler.flatMap { scheduler =>
         val s1 = Stream(1, 2, 3) ++ scheduler.sleep[IO](delay * 2) ++ Stream() ++ Stream(4, 5) ++ scheduler.sleep[IO](delay / 2) ++ Stream(6)
         s1.through(scheduler.debounce(delay))
-      }.runLog
+      }.compile.toVector
       t.unsafeToFuture() map { r =>
         assert(r == Vector(3, 6))
       }

--- a/core/jvm/src/test/scala/fs2/StreamAppSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamAppSpec.scala
@@ -59,7 +59,7 @@ class StreamAppSpec extends Fs2Spec {
       (for {
         runApp <- async.start(testApp.doMain(List.empty))
         // Wait for app to start
-        _ <- requestShutdown.discrete.takeWhile(_ == IO.unit).run
+        _ <- requestShutdown.discrete.takeWhile(_ == IO.unit).compile.drain
         // Run shutdown task
         _ <- requestShutdown.get.flatten
         result <- runApp

--- a/core/jvm/src/test/scala/fs2/TestUtilPlatform.scala
+++ b/core/jvm/src/test/scala/fs2/TestUtilPlatform.scala
@@ -15,10 +15,10 @@ trait TestUtilPlatform {
   val timeout: FiniteDuration
 
   def runLog[A](s: Stream[IO,A], timeout: FiniteDuration = timeout): Vector[A] =
-    s.runLog.unsafeRunTimed(timeout).getOrElse(throw new TimeoutException("IO run timed out"))
+    s.compile.toVector.unsafeRunTimed(timeout).getOrElse(throw new TimeoutException("IO run timed out"))
 
   def throws[A](err: Throwable)(s: Stream[IO,A]): Boolean =
-    s.runLog.attempt.unsafeRunSync() match {
+    s.compile.toVector.attempt.unsafeRunSync() match {
       case Left(e) if e == err => true
       case _ => false
     }

--- a/core/jvm/src/test/scala/fs2/async/SemaphoreSpec.scala
+++ b/core/jvm/src/test/scala/fs2/async/SemaphoreSpec.scala
@@ -15,7 +15,7 @@ class SemaphoreSpec extends Fs2Spec {
         val n0 = ((n.abs % 20) + 1).abs
         Stream.eval(async.mutable.Semaphore[IO](n0)).flatMap { s =>
           Stream.emits(0 until n0).evalMap { _ => s.decrement }.drain ++ Stream.eval(s.available)
-        }.runLog.unsafeRunSync() shouldBe Vector(0)
+        }.compile.toVector.unsafeRunSync() shouldBe Vector(0)
       }
     }
 

--- a/core/jvm/src/test/scala/fs2/async/SignalSpec.scala
+++ b/core/jvm/src/test/scala/fs2/async/SignalSpec.scala
@@ -12,7 +12,7 @@ class SignalSpec extends Fs2Spec {
         val vs = vs0 map { n => if (n == 0) 1 else n }
         val s = async.signalOf[IO,Long](0L).unsafeRunSync()
         val r = new AtomicLong(0)
-        (IO.shift *> s.discrete.map(r.set).run).unsafeToFuture()
+        (IO.shift *> s.discrete.map(r.set).compile.drain).unsafeToFuture()
         assert(vs.forall { v =>
           s.set(v).unsafeRunSync()
           while (s.get.unsafeRunSync() != v) {} // wait for set to arrive
@@ -31,7 +31,7 @@ class SignalSpec extends Fs2Spec {
         val vs = v0 :: vsTl
         val s = async.signalOf[IO,Long](0L).unsafeRunSync()
         val r = new AtomicLong(0)
-        (IO.shift *> s.discrete.map { i => Thread.sleep(10); r.set(i) }.run).unsafeToFuture()
+        (IO.shift *> s.discrete.map { i => Thread.sleep(10); r.set(i) }.compile.drain).unsafeToFuture()
         vs.foreach { v => s.set(v).unsafeRunSync() }
         val last = vs.last
         while (r.get != last) {}

--- a/core/shared/src/main/scala/fs2/Pipe.scala
+++ b/core/shared/src/main/scala/fs2/Pipe.scala
@@ -22,7 +22,7 @@ object Pipe {
 
     // Steps `s` without overhead of resource tracking
     def stepf(s: Stream[Read,O]): Read[UO] = {
-      Algebra.runFold(
+      Algebra.compile(
         Algebra.uncons(s.get).flatMap {
           case Some((hd,tl)) => Algebra.output1[Read,UO](Some((hd,Stream.fromFreeC(tl))))
           case None => Algebra.pure[Read,UO,Unit](())

--- a/core/shared/src/main/scala/fs2/Pipe.scala
+++ b/core/shared/src/main/scala/fs2/Pipe.scala
@@ -4,7 +4,7 @@ import scala.concurrent.ExecutionContext
 import cats.effect.Effect
 import cats.implicits._
 import fs2.async.mutable.Queue
-import fs2.internal.{Algebra, FreeC, NonFatal}
+import fs2.internal.{FreeC, NonFatal}
 
 object Pipe {
 
@@ -22,11 +22,10 @@ object Pipe {
 
     // Steps `s` without overhead of resource tracking
     def stepf(s: Stream[Read,O]): Read[UO] = {
-      Algebra.compile(
-        Algebra.uncons(s.get).flatMap {
-          case Some((hd,tl)) => Algebra.output1[Read,UO](Some((hd,Stream.fromFreeC(tl))))
-          case None => Algebra.pure[Read,UO,Unit](())
-        }, None: UO)((x,y) => y)
+      s.pull.uncons.flatMap {
+        case Some((hd,tl)) => Pull.output1((hd,tl))
+        case None => Pull.done
+      }.streamNoScope.compile.last
     }
 
     def go(s: Read[UO]): Stepper[I,O] = Stepper.Suspend { () =>

--- a/core/shared/src/main/scala/fs2/Pipe.scala
+++ b/core/shared/src/main/scala/fs2/Pipe.scala
@@ -33,10 +33,9 @@ object Pipe {
         case FreeC.Pure(None) => Stepper.Done
         case FreeC.Pure(Some((hd,tl))) => Stepper.Emits(hd, go(stepf(tl)))
         case FreeC.Fail(t) => Stepper.Fail(t)
-        case bound: FreeC.Bind[ReadSegment,_,UO] =>
-          val f = bound.asInstanceOf[FreeC.Bind[ReadSegment,Any,UO]].f
-          val fx = bound.fx.asInstanceOf[FreeC.Eval[ReadSegment,UO]].fr
-          Stepper.Await(segment => try go(f(Right(fx(segment)))) catch { case NonFatal(t) => go(f(Left(t))) })
+        case bound: FreeC.Bind[ReadSegment,x,UO] =>
+          val fx = bound.fx.asInstanceOf[FreeC.Eval[ReadSegment,x]].fr
+          Stepper.Await(segment => try go(bound.f(Right(fx(segment)))) catch { case NonFatal(t) => go(bound.f(Left(t))) })
         case e => sys.error("FreeC.ViewL structure must be Pure(a), Fail(e), or Bind(Eval(fx),k), was: " + e)
       }
     }

--- a/core/shared/src/main/scala/fs2/Pipe2.scala
+++ b/core/shared/src/main/scala/fs2/Pipe2.scala
@@ -20,7 +20,7 @@ object Pipe2 {
 
     // Steps `s` without overhead of resource tracking
     def stepf(s: Stream[Read,O]): Read[UO] = {
-      Algebra.runFold(
+      Algebra.compile(
         Algebra.uncons(s.get).flatMap {
           case Some((hd,tl)) => Algebra.output1[Read,UO](Some((hd,Stream.fromFreeC(tl))))
           case None => Algebra.pure[Read,UO,Unit](())

--- a/core/shared/src/main/scala/fs2/Scheduler.scala
+++ b/core/shared/src/main/scala/fs2/Scheduler.scala
@@ -196,7 +196,7 @@ abstract class Scheduler {
    *      |   val s = Stream(1, 2, 3) ++ scheduler.sleep_[IO](500.millis) ++ Stream(4, 5) ++ scheduler.sleep_[IO](10.millis) ++ Stream(6)
    *      |   s.through(scheduler.debounce(100.milliseconds))
    *      | }
-   * scala> s2.runLog.unsafeRunSync
+   * scala> s2.compile.toVector.unsafeRunSync
    * res0: Vector[Int] = Vector(3, 6)
    * }}}
    */

--- a/core/shared/src/main/scala/fs2/async/mutable/Topic.scala
+++ b/core/shared/src/main/scala/fs2/async/mutable/Topic.scala
@@ -117,7 +117,7 @@ object Topic {
                 eval(done.get).interruptWhen(q.full.discrete.map(! _ )).last.flatMap {
                   case None => eval(publish(a))
                   case Some(_) => Stream.empty
-                }.run
+                }.compile.drain
               }
             }
 

--- a/core/shared/src/main/scala/fs2/internal/Algebra.scala
+++ b/core/shared/src/main/scala/fs2/internal/Algebra.scala
@@ -68,27 +68,26 @@ private[fs2] object Algebra {
     s.viewL.get match {
       case done: FreeC.Pure[Algebra[F,O,?], Unit] => pure(None)
       case failed: FreeC.Fail[Algebra[F,O,?], _] => raiseError(failed.error)
-      case bound: FreeC.Bind[Algebra[F,O,?],_,Unit] =>
-        val f = bound.f.asInstanceOf[Either[Throwable,Any] => FreeC[Algebra[F,O,?],Unit]]
-        val fx = bound.fx.asInstanceOf[FreeC.Eval[Algebra[F,O,?],_]].fr
+      case bound: FreeC.Bind[Algebra[F,O,?],x,Unit] =>
+        val fx = bound.fx.asInstanceOf[FreeC.Eval[Algebra[F,O,?],x]].fr
         fx match {
-          case os: Algebra.Output[F, O] =>
-            pure[F,X,Option[(Segment[O,Unit], FreeC[Algebra[F,O,?],Unit])]](Some((os.values, f(Right(())))))
-          case os: Algebra.Run[F, O, x] =>
+          case os: Algebra.Output[F,O] =>
+            pure(Some((os.values, bound.f(Right(())))))
+          case os: Algebra.Run[F,O,x] =>
             try {
               def asSegment(c: Catenable[Chunk[O]]): Segment[O,Unit] =
                 c.uncons.flatMap { case (h1,t1) => t1.uncons.map(_ => Segment.catenated(c.map(Segment.chunk))).orElse(Some(Segment.chunk(h1))) }.getOrElse(Segment.empty)
               os.values.force.splitAt(chunkSize, Some(maxSteps)) match {
                 case Left((r,chunks,rem)) =>
-                  pure[F,X,Option[(Segment[O,Unit], FreeC[Algebra[F,O,?],Unit])]](Some(asSegment(chunks) -> f(Right(r))))
+                  pure(Some(asSegment(chunks) -> bound.f(Right(r))))
                 case Right((chunks,tl)) =>
-                  pure[F,X,Option[(Segment[O,Unit], FreeC[Algebra[F,O,?],Unit])]](Some(asSegment(chunks) -> FreeC.Bind[Algebra[F,O,?],x,Unit](segment(tl), f)))
+                  pure(Some(asSegment(chunks) -> FreeC.Bind(segment(tl), bound.f)))
               }
-            } catch { case NonFatal(e) => FreeC.suspend(uncons(f(Left(e)), chunkSize)) }
+            } catch { case NonFatal(e) => FreeC.suspend(uncons(bound.f(Left(e)), chunkSize)) }
           case algebra => // Eval, Acquire, Release, OpenScope, CloseScope, GetScope
-            FreeC.Bind[Algebra[F,X,?],Any,Option[(Segment[O,Unit], FreeC[Algebra[F,O,?],Unit])]](
-              FreeC.Eval[Algebra[F,X,?],Any](algebra.asInstanceOf[Algebra[F,X,Any]]),
-              (x: Either[Throwable,Any]) => uncons[F,X,O](f(x), chunkSize)
+            FreeC.Bind(
+              FreeC.Eval(algebra.asInstanceOf[Algebra[F,X,x]]), // O is phantom in these constructors so it is safe to case O to X
+              (e: Either[Throwable,x]) => uncons[F,X,O](bound.f(e), chunkSize)
             )
         }
       case e => sys.error("FreeC.ViewL structure must be Pure(a), Fail(e), or Bind(Eval(fx),k), was: " + e)
@@ -127,13 +126,11 @@ private[fs2] object Algebra {
 
       case failed: FreeC.Fail[Algebra[F,O,?], _] => F.raiseError(failed.error)
 
-      case bound: FreeC.Bind[Algebra[F,O,?], _, Option[(Segment[O,Unit], FreeC[Algebra[F,O,?],Unit])]] =>
-        val f = bound.f.asInstanceOf[
-          Either[Throwable,Any] => FreeC[Algebra[F,O,?], Option[(Segment[O,Unit], FreeC[Algebra[F,O,?],Unit])]]]
-        val fx = bound.fx.asInstanceOf[FreeC.Eval[Algebra[F,O,?],_]].fr
+      case bound: FreeC.Bind[Algebra[F,O,?],x,Option[(Segment[O,Unit],FreeC[Algebra[F,O,?],Unit])]] =>
+        val fx = bound.fx.asInstanceOf[FreeC.Eval[Algebra[F,O,?],x]].fr
         fx match {
           case wrap: Algebra.Eval[F, O, _] =>
-            F.flatMap(F.attempt(wrap.value)) { e => compileLoop(scope, acc, g, f(e).viewL) }
+            F.flatMap(F.attempt(wrap.value)) { e => compileLoop(scope, acc, g, bound.f(e).viewL) }
 
           case acquire: Algebra.Acquire[F,_,_] =>
             val acquireResource = acquire.resource
@@ -144,16 +141,16 @@ private[fs2] object Algebra {
                   case Right(r) =>
                     val finalizer = F.suspend { acquire.release(r) }
                     F.flatMap(resource.acquired(finalizer)) { result =>
-                      compileLoop(scope, acc, g, f(result.right.map { _ => (r, resource.id) }).viewL)
+                      compileLoop(scope, acc, g, bound.f(result.right.map { _ => (r, resource.id) }).viewL)
                     }
 
                   case Left(err) =>
                     F.flatMap(scope.releaseResource(resource.id)) { result =>
-                      val failedResult: Either[Throwable, Unit] =
+                      val failedResult: Either[Throwable,x] =
                         result.left.toOption.map { err0 =>
                           Left(new CompositeFailure(err, NonEmptyList.of(err0)))
                          }.getOrElse(Left(err))
-                      compileLoop(scope, acc, g, f(failedResult).viewL)
+                      compileLoop(scope, acc, g, bound.f(failedResult).viewL)
                     }
                 }
               } else {
@@ -164,24 +161,24 @@ private[fs2] object Algebra {
 
           case release: Algebra.Release[F,_] =>
             F.flatMap(scope.releaseResource(release.token))  { result =>
-              compileLoop(scope, acc, g, f(result).viewL)
+              compileLoop(scope, acc, g, bound.f(result).viewL)
             }
 
           case c: Algebra.CloseScope[F,_] =>
             F.flatMap(c.toClose.close) { result =>
               F.flatMap(c.toClose.openAncestor) { scopeAfterClose =>
-                compileLoop(scopeAfterClose, acc, g, f(result).viewL)
+                compileLoop(scopeAfterClose, acc, g, bound.f(result).viewL)
               }
             }
 
           case o: Algebra.OpenScope[F,_] =>
             F.flatMap(scope.open) { innerScope =>
-              compileLoop(innerScope, acc, g, f(Right(innerScope)).viewL)
+              compileLoop(innerScope, acc, g, bound.f(Right(innerScope)).viewL)
             }
 
           case e: GetScope[F,_] =>
             F.suspend {
-              compileLoop(scope, acc, g, f(Right(scope)).viewL)
+              compileLoop(scope, acc, g, bound.f(Right(scope)).viewL)
             }
 
           case other => sys.error(s"impossible Segment or Output following uncons: $other")

--- a/core/shared/src/test/scala/fs2/TestUtil.scala
+++ b/core/shared/src/test/scala/fs2/TestUtil.scala
@@ -14,7 +14,7 @@ trait TestUtil extends TestUtilPlatform {
 
   val timeout: FiniteDuration = 60.seconds
 
-  def runLogF[A](s: Stream[IO,A]): Future[Vector[A]] = (IO.shift *> s.runLog).unsafeToFuture
+  def runLogF[A](s: Stream[IO,A]): Future[Vector[A]] = (IO.shift *> s.compile.toVector).unsafeToFuture
 
   def spuriousFail(s: Stream[IO,Int], f: Failure): Stream[IO,Int] =
     s.flatMap { i => if (i % (math.random * 10 + 1).toInt == 0) f.get

--- a/core/shared/src/test/scala/fs2/async/PromiseSpec.scala
+++ b/core/shared/src/test/scala/fs2/async/PromiseSpec.scala
@@ -51,7 +51,7 @@ class PromiseSpec extends AsyncFs2Spec with EitherValues {
             _ <- p.complete(42)
             second <- p.timedGet(100.millis, scheduler)
           } yield List(first, second)
-      }.runLog.unsafeToFuture.map(_.flatten shouldBe Vector(None, Some(42)))
+      }.compile.toVector.unsafeToFuture.map(_.flatten shouldBe Vector(None, Some(42)))
     }
 
     "cancellableGet - cancel before force" in {
@@ -68,7 +68,7 @@ class PromiseSpec extends AsyncFs2Spec with EitherValues {
           _ <- scheduler.effect.sleep[IO](100.millis)
           result <- r.get
         } yield result
-      }.runLast.unsafeToFuture.map(_ shouldBe Some(None))
+      }.compile.last.unsafeToFuture.map(_ shouldBe Some(None))
     }
   }
 }

--- a/docs/ReadmeExample.md
+++ b/docs/ReadmeExample.md
@@ -97,11 +97,8 @@ written: fs2.Stream[cats.effect.IO,Unit] = Stream(..)
 There are a number of ways of interpreting the stream. In this case, we call `compile.drain`, which returns a val value of the effect type, `IO`. The output of the stream is ignored - we compile it solely for its effect.
 
 ```scala
-scala> val task: IO[Unit] = written.run
-<console>:21: warning: method run in class InvariantOps is deprecated (since 0.10.0): Use compile.drain instead
-       val task: IO[Unit] = written.run
-                                    ^
-task: cats.effect.IO[Unit] = IO$1142011553
+scala> val task: IO[Unit] = written.compile.drain
+task: cats.effect.IO[Unit] = IO$129936443
 ```
 
 We still haven't *done* anything yet. Effects only occur when we run the resulting task. We can run a `IO` by calling `unsafeRunSync()` -- the name is telling us that calling it performs effects and hence, it is not referentially transparent.

--- a/docs/ReadmeExample.md
+++ b/docs/ReadmeExample.md
@@ -101,7 +101,7 @@ scala> val task: IO[Unit] = written.run
 <console>:21: warning: method run in class InvariantOps is deprecated (since 0.10.0): Use compile.drain instead
        val task: IO[Unit] = written.run
                                     ^
-task: cats.effect.IO[Unit] = IO$1308901804
+task: cats.effect.IO[Unit] = IO$1142011553
 ```
 
 We still haven't *done* anything yet. Effects only occur when we run the resulting task. We can run a `IO` by calling `unsafeRunSync()` -- the name is telling us that calling it performs effects and hence, it is not referentially transparent.

--- a/docs/ReadmeExample.md
+++ b/docs/ReadmeExample.md
@@ -20,7 +20,7 @@ object Converter {
       .intersperse("\n")
       .through(text.utf8Encode)
       .through(io.file.writeAll(Paths.get("testdata/celsius.txt")))
-      .run
+      .compile.drain
 }
 // defined object Converter
 
@@ -94,11 +94,14 @@ scala> val written: Stream[IO, Unit] = encodedBytes.through(io.file.writeAll(Pat
 written: fs2.Stream[cats.effect.IO,Unit] = Stream(..)
 ```
 
-There are a number of ways of interpreting the stream. In this case, we call `run`, which returns a val value of the effect type, `IO`. The output of the stream is ignored - we run it solely for its effect.
+There are a number of ways of interpreting the stream. In this case, we call `compile.drain`, which returns a val value of the effect type, `IO`. The output of the stream is ignored - we compile it solely for its effect.
 
 ```scala
 scala> val task: IO[Unit] = written.run
-task: cats.effect.IO[Unit] = IO$952127193
+<console>:21: warning: method run in class InvariantOps is deprecated (since 0.10.0): Use compile.drain instead
+       val task: IO[Unit] = written.run
+                                    ^
+task: cats.effect.IO[Unit] = IO$1308901804
 ```
 
 We still haven't *done* anything yet. Effects only occur when we run the resulting task. We can run a `IO` by calling `unsafeRunSync()` -- the name is telling us that calling it performs effects and hence, it is not referentially transparent.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -137,13 +137,13 @@ val eff = Stream.eval(IO { println("TASK BEING RUN!!"); 1 + 1 })
 // eff: fs2.Stream[cats.effect.IO,Int] = Stream(..)
 
 val ra = eff.compile.toVector // gather all output into a Vector
-// ra: cats.effect.IO[Vector[Int]] = IO$1153354928
+// ra: cats.effect.IO[Vector[Int]] = IO$1874296212
 
 val rb = eff.compile.drain // purely for effects
-// rb: cats.effect.IO[Unit] = IO$1263779705
+// rb: cats.effect.IO[Unit] = IO$2100089851
 
 val rc = eff.compile.fold(0)(_ + _) // run and accumulate some result
-// rc: cats.effect.IO[Int] = IO$593410330
+// rc: cats.effect.IO[Int] = IO$440495402
 ```
 
 Notice these all return a `IO` of some sort, but this process of compilation doesn't actually _perform_ any of the effects (nothing gets printed).
@@ -274,10 +274,10 @@ scala> val count = new java.util.concurrent.atomic.AtomicLong(0)
 count: java.util.concurrent.atomic.AtomicLong = 0
 
 scala> val acquire = IO { println("incremented: " + count.incrementAndGet); () }
-acquire: cats.effect.IO[Unit] = IO$778339107
+acquire: cats.effect.IO[Unit] = IO$477876869
 
 scala> val release = IO { println("decremented: " + count.decrementAndGet); () }
-release: cats.effect.IO[Unit] = IO$1666732013
+release: cats.effect.IO[Unit] = IO$1801684415
 ```
 
 ```scala
@@ -554,7 +554,7 @@ import cats.effect.Sync
 // import cats.effect.Sync
 
 val T = Sync[IO]
-// T: cats.effect.Sync[cats.effect.IO] = cats.effect.IOInstances$$anon$1@7254f5ea
+// T: cats.effect.Sync[cats.effect.IO] = cats.effect.IOInstances$$anon$1@3f28af56
 
 val s = Stream.eval_(T.delay { destroyUniverse() }) ++ Stream("...moving on")
 // s: fs2.Stream[cats.effect.IO,String] = Stream(..)
@@ -611,12 +611,12 @@ val c = new Connection {
 
 // Effect extends both Sync and Async
 val T = cats.effect.Effect[IO]
-// T: cats.effect.Effect[cats.effect.IO] = cats.effect.IOInstances$$anon$1@7254f5ea
+// T: cats.effect.Effect[cats.effect.IO] = cats.effect.IOInstances$$anon$1@3f28af56
 
 val bytes = T.async[Array[Byte]] { (cb: Either[Throwable,Array[Byte]] => Unit) =>
   c.readBytesE(cb)
 }
-// bytes: cats.effect.IO[Array[Byte]] = IO$1355451161
+// bytes: cats.effect.IO[Array[Byte]] = IO$795809508
 
 Stream.eval(bytes).map(_.toList).compile.toVector.unsafeRunSync()
 // res42: Vector[List[Byte]] = Vector(List(0, 1, 2))

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -137,13 +137,13 @@ val eff = Stream.eval(IO { println("TASK BEING RUN!!"); 1 + 1 })
 // eff: fs2.Stream[cats.effect.IO,Int] = Stream(..)
 
 val ra = eff.compile.toVector // gather all output into a Vector
-// ra: cats.effect.IO[Vector[Int]] = IO$1473460473
+// ra: cats.effect.IO[Vector[Int]] = IO$1153354928
 
 val rb = eff.compile.drain // purely for effects
-// rb: cats.effect.IO[Unit] = IO$389935702
+// rb: cats.effect.IO[Unit] = IO$1263779705
 
 val rc = eff.compile.fold(0)(_ + _) // run and accumulate some result
-// rc: cats.effect.IO[Int] = IO$387044598
+// rc: cats.effect.IO[Int] = IO$593410330
 ```
 
 Notice these all return a `IO` of some sort, but this process of compilation doesn't actually _perform_ any of the effects (nothing gets printed).
@@ -274,10 +274,10 @@ scala> val count = new java.util.concurrent.atomic.AtomicLong(0)
 count: java.util.concurrent.atomic.AtomicLong = 0
 
 scala> val acquire = IO { println("incremented: " + count.incrementAndGet); () }
-acquire: cats.effect.IO[Unit] = IO$2108369770
+acquire: cats.effect.IO[Unit] = IO$778339107
 
 scala> val release = IO { println("decremented: " + count.decrementAndGet); () }
-release: cats.effect.IO[Unit] = IO$190389079
+release: cats.effect.IO[Unit] = IO$1666732013
 ```
 
 ```scala
@@ -554,7 +554,7 @@ import cats.effect.Sync
 // import cats.effect.Sync
 
 val T = Sync[IO]
-// T: cats.effect.Sync[cats.effect.IO] = cats.effect.IOInstances$$anon$1@70ac78a6
+// T: cats.effect.Sync[cats.effect.IO] = cats.effect.IOInstances$$anon$1@7254f5ea
 
 val s = Stream.eval_(T.delay { destroyUniverse() }) ++ Stream("...moving on")
 // s: fs2.Stream[cats.effect.IO,String] = Stream(..)
@@ -611,12 +611,12 @@ val c = new Connection {
 
 // Effect extends both Sync and Async
 val T = cats.effect.Effect[IO]
-// T: cats.effect.Effect[cats.effect.IO] = cats.effect.IOInstances$$anon$1@70ac78a6
+// T: cats.effect.Effect[cats.effect.IO] = cats.effect.IOInstances$$anon$1@7254f5ea
 
 val bytes = T.async[Array[Byte]] { (cb: Either[Throwable,Array[Byte]] => Unit) =>
   c.readBytesE(cb)
 }
-// bytes: cats.effect.IO[Array[Byte]] = IO$1817661216
+// bytes: cats.effect.IO[Array[Byte]] = IO$1355451161
 
 Stream.eval(bytes).map(_.toList).compile.toVector.unsafeRunSync()
 // res42: Vector[List[Byte]] = Vector(List(0, 1, 2))
@@ -721,10 +721,7 @@ If instead we use `onFinalize`, the code is guaranteed to run, regardless of whe
 Stream(1).covary[IO].
           onFinalize(IO { println("finalized!") }).
           take(1).
-          runLog.unsafeRunSync()
-// <console>:22: warning: method runLog in class InvariantOps is deprecated (since 0.10.0): Use compile.toVector instead
-//                  runLog.unsafeRunSync()
-//                  ^
+          compile.toVector.unsafeRunSync()
 // finalized!
 // res3: Vector[Int] = Vector(1)
 ```

--- a/docs/migration-guide-0.10.md
+++ b/docs/migration-guide-0.10.md
@@ -160,6 +160,17 @@ Given that most usage of merging a drained stream with another stream should be 
 - `NonEmptyChunk` no longer exists (and empty `Chunks` *can* be emitted).
 - The `Attempt` alias no longer exists - replace with `Either[Throwable,A]`.
 
-#### Cats Type Class Instances
+#### Compiling / Interpreting Streams
 
-Note that both `Stream` and `Pull` have type class instances for `cats.effect.Sync`, and hence all super type classes (e.g., `Monad`). These instances are defined in the `Stream` and `Pull` companion objects but they are *NOT* marked implicit. To use them implicitly, they must be manually assigned to an implicit val. This is because the Cats supplied syntax conflicts with `Stream` and `Pull` syntax, resulting in methods which ignore the covariance of `Stream` and `Pull`. Considering this is almost never the right option, these instances are non-implicit.
+In 0.9, a stream was compiled in to an effectful value via one of the `run` methods -- e.g., `run`, `runLog`, `runLast`. In 0.10, all methods which compile a stream in to an effectful value are under the `compile` prefix:
+
+
+|0.9|0.10|
+|---|---|
+|s.run|s.compile.drain|
+|s.runLog|s.compile.toVector|
+| |s.compile.toList|
+|s.runLast|s.compile.last|
+|s.runFold|s.compile.fold|
+| |s.compile.foldSemigroup|
+| |s.compile.foldMonoid|

--- a/docs/src/ReadmeExample.md
+++ b/docs/src/ReadmeExample.md
@@ -20,7 +20,7 @@ object Converter {
       .intersperse("\n")
       .through(text.utf8Encode)
       .through(io.file.writeAll(Paths.get("testdata/celsius.txt")))
-      .run
+      .compile.drain
 }
 
 Converter.converter.unsafeRunSync()
@@ -83,7 +83,7 @@ We then write the encoded bytes to a file. Note that nothing has happened at thi
 val written: Stream[IO, Unit] = encodedBytes.through(io.file.writeAll(Paths.get("testdata/celsius.txt")))
 ```
 
-There are a number of ways of interpreting the stream. In this case, we call `run`, which returns a val value of the effect type, `IO`. The output of the stream is ignored - we run it solely for its effect.
+There are a number of ways of interpreting the stream. In this case, we call `compile.drain`, which returns a val value of the effect type, `IO`. The output of the stream is ignored - we compile it solely for its effect.
 
 ```tut
 val task: IO[Unit] = written.run

--- a/docs/src/ReadmeExample.md
+++ b/docs/src/ReadmeExample.md
@@ -86,7 +86,7 @@ val written: Stream[IO, Unit] = encodedBytes.through(io.file.writeAll(Paths.get(
 There are a number of ways of interpreting the stream. In this case, we call `compile.drain`, which returns a val value of the effect type, `IO`. The output of the stream is ignored - we compile it solely for its effect.
 
 ```tut
-val task: IO[Unit] = written.run
+val task: IO[Unit] = written.compile.drain
 ```
 
 We still haven't *done* anything yet. Effects only occur when we run the resulting task. We can run a `IO` by calling `unsafeRunSync()` -- the name is telling us that calling it performs effects and hence, it is not referentially transparent.

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -94,17 +94,17 @@ eff.toList
 Here's a complete example of running an effectful stream. We'll explain this in a minute:
 
 ```tut
-eff.runLog.unsafeRunSync()
+eff.compile.toVector.unsafeRunSync()
 ```
 
-The first `.runLog` is one of several methods available to 'run' (or perhaps 'compile') the stream to a single effect:
+The first `.compile.toVector` is one of several methods available to 'compile' the stream to a single effect:
 
 ```tut:book
 val eff = Stream.eval(IO { println("TASK BEING RUN!!"); 1 + 1 })
 
-val ra = eff.runLog // gather all output into a Vector
-val rb = eff.run // purely for effects
-val rc = eff.runFold(0)(_ + _) // run and accumulate some result
+val ra = eff.compile.toVector // gather all output into a Vector
+val rb = eff.compile.drain // purely for effects
+val rc = eff.compile.fold(0)(_ + _) // run and accumulate some result
 ```
 
 Notice these all return a `IO` of some sort, but this process of compilation doesn't actually _perform_ any of the effects (nothing gets printed).
@@ -120,7 +120,7 @@ rc.unsafeRunSync()
 
 Here we finally see the tasks being executed. As is shown with `rc`, rerunning a task executes the entire computation again; nothing is cached for you automatically.
 
-_Note:_ The various `run*` functions aren't specialized to `IO` and work for any `F[_]` with an implicit `Effect[F]` (or `Sync[F]` for the `run*Sync` functions) --- FS2 needs to know how to catch errors that occur during evaluation of `F` effects, how to suspend computations, and sometimes how to do asynchronous evaluation.
+_Note:_ The various `run*` functions aren't specialized to `IO` and work for any `F[_]` with an implicit `Sync[F]` --- FS2 needs to know how to catch errors that occur during evaluation of `F` effects, how to suspend computations.
 
 ### Segments & Chunks
 
@@ -149,7 +149,7 @@ val appendEx1 = Stream(1,2,3) ++ Stream.emit(42)
 val appendEx2 = Stream(1,2,3) ++ Stream.eval(IO.pure(4))
 
 appendEx1.toVector
-appendEx2.runLog.unsafeRunSync()
+appendEx2.compile.toVector.unsafeRunSync()
 
 appendEx1.map(_ + 1).toList
 ```
@@ -183,7 +183,7 @@ try err2.toList catch { case e: Exception => println(e) }
 ```
 
 ```tut
-try err3.run.unsafeRunSync() catch { case e: Exception => println(e) }
+try err3.compile.drain.unsafeRunSync() catch { case e: Exception => println(e) }
 ```
 
 The `handleErrorWith` method lets us catch any of these errors:
@@ -205,7 +205,7 @@ val release = IO { println("decremented: " + count.decrementAndGet); () }
 ```
 
 ```tut:fail
-Stream.bracket(acquire)(_ => Stream(1,2,3) ++ err, _ => release).run.unsafeRunSync()
+Stream.bracket(acquire)(_ => Stream(1,2,3) ++ err, _ => release).compile.drain.unsafeRunSync()
 ```
 
 The inner stream fails, but notice the `release` action is still run:
@@ -229,7 +229,7 @@ Implement `repeat`, which repeats a stream indefinitely, `drain`, which strips a
 ```tut
 Stream(1,0).repeat.take(6).toList
 Stream(1,2,3).drain.toList
-Stream.eval_(IO(println("!!"))).runLog.unsafeRunSync()
+Stream.eval_(IO(println("!!"))).compile.toVector.unsafeRunSync()
 (Stream(1,2) ++ (throw new Exception("nooo!!!"))).attempt.toList
 ```
 
@@ -357,7 +357,7 @@ Stream.range(1,10).scan(0)(_ + _).toList // running sum
 FS2 comes with lots of concurrent operations. The `merge` function runs two streams concurrently, combining their outputs. It halts when both inputs have halted:
 
 ```tut:fail
-Stream(1,2,3).merge(Stream.eval(IO { Thread.sleep(200); 4 })).runLog.unsafeRunSync()
+Stream(1,2,3).merge(Stream.eval(IO { Thread.sleep(200); 4 })).compile.toVector.unsafeRunSync()
 ```
 
 Oops, we need a `scala.concurrent.ExecutionContext` in implicit scope. Let's add that:
@@ -365,7 +365,7 @@ Oops, we need a `scala.concurrent.ExecutionContext` in implicit scope. Let's add
 ```tut
 import scala.concurrent.ExecutionContext.Implicits.global
 
-Stream(1,2,3).merge(Stream.eval(IO { Thread.sleep(200); 4 })).runLog.unsafeRunSync()
+Stream(1,2,3).merge(Stream.eval(IO { Thread.sleep(200); 4 })).compile.toVector.unsafeRunSync()
 ```
 
 The `merge` function supports concurrency. FS2 has a number of other useful concurrency functions like `concurrently` (runs another stream concurrently and discards its output), `interrupt` (halts if the left branch produces `false`), `either` (like `merge` but returns an `Either`), `mergeHaltBoth` (halts if either branch halts), and others.
@@ -429,7 +429,7 @@ These are easy to deal with. Just wrap these effects in a `Stream.eval`:
 def destroyUniverse(): Unit = { println("BOOOOM!!!"); } // stub implementation
 
 val s = Stream.eval_(IO { destroyUniverse() }) ++ Stream("...moving on")
-s.runLog.unsafeRunSync()
+s.compile.toVector.unsafeRunSync()
 ```
 
 The way you bring synchronous effects into your effect type may differ. `Sync.delay` can be used for this generally, without committing to a particular effect:
@@ -439,7 +439,7 @@ import cats.effect.Sync
 
 val T = Sync[IO]
 val s = Stream.eval_(T.delay { destroyUniverse() }) ++ Stream("...moving on")
-s.runLog.unsafeRunSync()
+s.compile.toVector.unsafeRunSync()
 ```
 
 When using this approach, be sure the expression you pass to delay doesn't throw exceptions.
@@ -491,7 +491,7 @@ val bytes = T.async[Array[Byte]] { (cb: Either[Throwable,Array[Byte]] => Unit) =
   c.readBytesE(cb)
 }
 
-Stream.eval(bytes).map(_.toList).runLog.unsafeRunSync()
+Stream.eval(bytes).map(_.toList).compile.toVector.unsafeRunSync()
 ```
 
 Be sure to check out the [`fs2.io`](../io) package which has nice FS2 bindings to Java NIO libraries, using exactly this approach.

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -578,7 +578,7 @@ If instead we use `onFinalize`, the code is guaranteed to run, regardless of whe
 Stream(1).covary[IO].
           onFinalize(IO { println("finalized!") }).
           take(1).
-          runLog.unsafeRunSync()
+          compile.toVector.unsafeRunSync()
 ```
 
 That covers synchronous interrupts. Let's look at asynchronous interrupts. Ponder what the result of `merged` will be in this example:

--- a/io/src/main/scala/fs2/io/JavaInputOutputStream.scala
+++ b/io/src/main/scala/fs2/io/JavaInputOutputStream.scala
@@ -85,7 +85,7 @@ private[io] object JavaInputOutputStream {
         source.chunks
         .evalMap(ch => queue.enqueue1(Right(ch.toBytes)))
         .interruptWhen(dnState.discrete.map(_.isDone).filter(identity))
-        .run
+        .compile.drain
       )){ r => markUpstreamDone(r.swap.toOption) }
     }).map(_ => ())
 
@@ -230,7 +230,7 @@ private[io] object JavaInputOutputStream {
       }){ _ =>
         F.flatMap(upState.discrete.collectFirst {
           case UpStreamState(true, maybeErr) => maybeErr // await upStreamDome to yield as true
-        }.runLast){ _.flatten match {
+        }.compile.last){ _.flatten match {
           case None => F.pure(())
           case Some(err) => F.raiseError[Unit](err)
         }}

--- a/io/src/test/scala/fs2/io/IoSpec.scala
+++ b/io/src/test/scala/fs2/io/IoSpec.scala
@@ -6,51 +6,51 @@ import fs2.Fs2Spec
 
 class IoSpec extends Fs2Spec {
   "readInputStream" - {
-    "arbitrary.runLog" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
+    "non-buffered" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
       val is: InputStream = new ByteArrayInputStream(bytes)
       val stream = readInputStream(IO(is), chunkSize.get)
-      val example = stream.runLog.unsafeRunSync.toArray
+      val example = stream.compile.toVector.unsafeRunSync.toArray
       example shouldBe bytes
     }
 
-    "arbitrary.buffer.runLog" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
+    "buffered" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
       val is: InputStream = new ByteArrayInputStream(bytes)
       val stream = readInputStream(IO(is), chunkSize.get)
-      val example = stream.buffer(chunkSize.get * 2).runLog.unsafeRunSync.toArray
+      val example = stream.buffer(chunkSize.get * 2).compile.toVector.unsafeRunSync.toArray
       example shouldBe bytes
     }
   }
 
   "readInputStreamAsync" - {
-    "arbitrary.runLog" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
+    "non-buffered" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
       val is: InputStream = new ByteArrayInputStream(bytes)
       val stream = readInputStreamAsync(IO(is), chunkSize.get)
-      val example = stream.runLog.unsafeRunSync.toArray
+      val example = stream.compile.toVector.unsafeRunSync.toArray
       example shouldBe bytes
     }
 
-    "arbitrary.buffer.runLog" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
+    "buffered" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
       val is: InputStream = new ByteArrayInputStream(bytes)
       val stream = readInputStreamAsync(IO(is), chunkSize.get)
-      val example = stream.buffer(chunkSize.get * 2).runLog.unsafeRunSync.toArray
+      val example = stream.buffer(chunkSize.get * 2).compile.toVector.unsafeRunSync.toArray
       example shouldBe bytes
     }
   }
 
   "unsafeReadInputStream" - {
-    "arbitrary.runLog" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
+    "non-buffered" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
       val is: InputStream = new ByteArrayInputStream(bytes)
       val stream = unsafeReadInputStream(IO(is), chunkSize.get)
-      val example = stream.runLog.unsafeRunSync.toArray
+      val example = stream.compile.toVector.unsafeRunSync.toArray
       example shouldBe bytes
     }
   }
 
   "unsafeReadInputStreamAsync" - {
-    "arbitrary.runLog" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
+    "non-buffered" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
       val is: InputStream = new ByteArrayInputStream(bytes)
       val stream = unsafeReadInputStreamAsync(IO(is), chunkSize.get)
-      val example = stream.runLog.unsafeRunSync.toArray
+      val example = stream.compile.toVector.unsafeRunSync.toArray
       example shouldBe bytes
     }
   }

--- a/io/src/test/scala/fs2/io/tcp/SocketSpec.scala
+++ b/io/src/test/scala/fs2/io/tcp/SocketSpec.scala
@@ -55,7 +55,7 @@ class SocketSpec extends Fs2Spec with BeforeAndAfterAll {
         }.join(10)
       }
 
-      val result = Stream(echoServer.drain, clients).join(2).take(clientCount).runLog.unsafeRunTimed(timeout).get
+      val result = Stream(echoServer.drain, clients).join(2).take(clientCount).compile.toVector.unsafeRunTimed(timeout).get
       result.size shouldBe clientCount
       result.map { new String(_) }.toSet shouldBe Set("fs2.rocks")
     }


### PR DESCRIPTION
 introduced `s.compile.{drain,toVector,toList,last,fold,foldMonoid,foldSemigroup}`. Fixes #1017. See discussion in #1017 for motivation. Also, see the section added to the 0.10 migration guide:

----


In 0.9, a stream was compiled in to an effectful value via one of the `run` methods -- e.g., `run`, `runLog`, `runLast`. In 0.10, all methods which compile a stream in to an effectful value are under the `compile` prefix:


|0.9|0.10|
|---|---|
|s.run|s.compile.drain|
|s.runLog|s.compile.toVector|
| |s.compile.toList|
|s.runLast|s.compile.last|
|s.runFold|s.compile.fold|
| |s.compile.foldSemigroup|
| |s.compile.foldMonoid|