### PR TITLE
Introduce Chunk.ByteBuffer

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/ByteBufferChunkBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/ByteBufferChunkBenchmark.scala
@@ -1,0 +1,62 @@
+package fs2
+package benchmark
+
+import org.openjdk.jmh.annotations.{Benchmark, Param, Setup, State, Scope}
+import java.nio.ByteBuffer
+
+@State(Scope.Thread)
+class ByteBufferChunkBenchmark {
+  @Param(Array("16", "256", "4096", "65536"))
+  var size: Int = _
+
+  var bbIndirect: ByteBuffer = _
+  var bbDirect: ByteBuffer = _
+
+  @Setup
+  def setup() = {
+    bbIndirect = ByteBuffer.allocate(size)
+    bbDirect = ByteBuffer.allocate(size)
+  }
+
+  @Benchmark
+  def bytesToArrayIndirect(): Array[Byte] =
+    Chunk.bytes(bbIndirect.array).toArray
+
+  @Benchmark
+  def bytesToArrayDirect(): Array[Byte] = {
+    Chunk.bytes {
+      val arr = new Array[Byte](bbDirect.remaining)
+      bbDirect.slice.get(arr, 0, bbDirect.remaining)
+      arr
+    }.toArray
+  }
+
+  @Benchmark
+  def bytesToByteBufferIndirect(): ByteBuffer =
+    Chunk.bytes(bbIndirect.array).toByteBuffer
+
+  @Benchmark
+  def bytesToByteBufferDirect(): ByteBuffer = {
+    Chunk.bytes {
+      val arr = new Array[Byte](bbDirect.remaining)
+      bbDirect.slice.get(arr, 0, bbDirect.remaining)
+      arr
+    }.toByteBuffer
+  }
+
+  @Benchmark
+  def byteBufferToArrayIndirect(): Array[Byte] =
+    Chunk.byteBuffer(bbIndirect).toArray
+
+  @Benchmark
+  def byteBufferToArrayDirect(): Array[Byte] = 
+    Chunk.byteBuffer(bbDirect).toArray
+
+  @Benchmark
+  def byteBufferToByteBufferIndirect(): ByteBuffer =
+    Chunk.byteBuffer(bbIndirect).toByteBuffer
+
+  @Benchmark
+  def byteBufferToByteBufferDirect(): ByteBuffer =
+    Chunk.byteBuffer(bbDirect).toByteBuffer
+}

--- a/core/shared/src/test/scala/fs2/ChunkProps.scala
+++ b/core/shared/src/test/scala/fs2/ChunkProps.scala
@@ -1,69 +1,45 @@
-// package fs2
-//
-// import scala.reflect.ClassTag
-//
-// import org.scalacheck.Arbitrary
-// import org.scalatest.Matchers
-// import org.scalatest.prop.GeneratorDrivenPropertyChecks
-//
-// object ChunkProps
-//     extends Matchers
-//     with GeneratorDrivenPropertyChecks
-//     with TestUtil
-// {
-//   def propSize[A: Arbitrary, C <: Chunk[A]: Arbitrary] =
-//     forAll { c: C =>
-//       c.size shouldBe c.toVector.size
-//     }
-//
-//   def propTake[A: Arbitrary, C <: Chunk[A]: Arbitrary] =
-//     forAll { (c: C, n: SmallNonnegative) =>
-//       c.take(n.get).toVector shouldBe c.toVector.take(n.get)
-//     }
-//
-//   def propDrop[A: Arbitrary, C <: Chunk[A]: Arbitrary] =
-//     forAll { (c: C, n: SmallNonnegative) =>
-//       c.drop(n.get).toVector shouldBe c.toVector.drop(n.get)
-//     }
-//
-//   def propUncons[A: Arbitrary, C <: Chunk[A]: Arbitrary] =
-//     forAll { c: C =>
-//       if (c.toVector.isEmpty)
-//         c.uncons.isEmpty
-//       else
-//         c.uncons.contains((c(0), c.drop(1)))
-//     }
-//
-//   def propIsEmpty[A: Arbitrary, C <: Chunk[A]: Arbitrary] =
-//     forAll { c: C =>
-//       c.isEmpty shouldBe c.toVector.isEmpty
-//     }
-//
-//   def propFilter[A: Arbitrary, C <: Chunk[A]: Arbitrary](implicit F: Arbitrary[A => Boolean]) =
-//     forAll { (c: C, pred: A => Boolean) =>
-//       c.filter(pred).toVector shouldBe c.toVector.filter(pred)
-//     }
-//
-//   def propFoldLeft[A: Arbitrary, C <: Chunk[A]: Arbitrary](implicit F: Arbitrary[(Long, A) => Long]) =
-//     forAll { (c: C, z: Long, f: (Long, A) => Long) =>
-//       c.foldLeft(z)(f) shouldBe c.toVector.foldLeft(z)(f)
-//     }
-//
-//   def propFoldRight[A: Arbitrary, C <: Chunk[A]: Arbitrary](implicit F: Arbitrary[(A, Long) => Long]) =
-//     forAll { (c: C, z: Long, f: (A, Long) => Long) =>
-//       c.foldRight(z)(f) shouldBe c.toVector.foldRight(z)(f)
-//     }
-//
-//   def propToArray[A: ClassTag: Arbitrary, C <: Chunk[A]: Arbitrary] =
-//     forAll { c: C =>
-//       c.toArray.toVector shouldBe c.toVector
-//     }
-//
-//   def propConcat[A: Arbitrary, C <: Chunk[A]: Arbitrary: ClassTag] =
-//     forAll { cs: List[C] =>
-//       val result = Chunk.concat(cs)
-//       result.toVector shouldBe cs.foldLeft(Vector.empty[A])(_ ++ _.toVector)
-//       if (!result.isEmpty) result shouldBe a[C]
-//       result
-//     }
-// }
+package fs2
+
+import scala.reflect.ClassTag
+
+import org.scalacheck.Arbitrary
+import org.scalatest.Matchers
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+
+object ChunkProps
+    extends Matchers
+    with GeneratorDrivenPropertyChecks
+    with TestUtil
+{
+  def propSize[A: Arbitrary, C <: Chunk[A]: Arbitrary] =
+    forAll { c: C =>
+      c.size shouldBe c.toVector.size
+    }
+
+  def propTake[A: Arbitrary, C <: Chunk[A]: Arbitrary] =
+    forAll { (c: C, n: SmallNonnegative) =>
+      c.take(n.get).toVector shouldBe c.toVector.take(n.get)
+    }
+
+  def propDrop[A: Arbitrary, C <: Chunk[A]: Arbitrary] =
+    forAll { (c: C, n: SmallNonnegative) =>
+      c.drop(n.get).toVector shouldBe c.toVector.drop(n.get)
+    }
+
+  def propIsEmpty[A: Arbitrary, C <: Chunk[A]: Arbitrary] =
+    forAll { c: C =>
+      c.isEmpty shouldBe c.toVector.isEmpty
+    }
+
+  def propToArray[A: ClassTag: Arbitrary, C <: Chunk[A]: Arbitrary] =
+    forAll { c: C =>
+      c.toArray.toVector shouldBe c.toVector
+    }
+
+  def propToByteBuffer[C <: Chunk[Byte]: Arbitrary] =
+    forAll { c: C =>
+      val arr = new Array[Byte](c.size)
+      c.toByteBuffer.get(arr, 0, c.size)
+      arr.toVector shouldBe c.toArray.toVector
+    }
+}

--- a/core/shared/src/test/scala/fs2/ChunkSpec.scala
+++ b/core/shared/src/test/scala/fs2/ChunkSpec.scala
@@ -1,128 +1,119 @@
-// package fs2
-//
-// import org.scalacheck.{Gen, Arbitrary}
-//
-// import ChunkProps._
-//
-// class ChunkSpec extends Fs2Spec {
-//
-//   "Chunk" - {
-//
-//     "chunk-formation (1)" in {
-//       Chunk.empty.toList shouldBe List()
-//       Chunk.singleton(23).toList shouldBe List(23)
-//     }
-//
-//     "chunk-formation (2)" in forAll { (c: Vector[Int]) =>
-//       Chunk.seq(c).toVector shouldBe c
-//       Chunk.seq(c).toList shouldBe c.toList
-//       Chunk.indexedSeq(c).toVector shouldBe c
-//       Chunk.indexedSeq(c).toList shouldBe c.toList
-//       Chunk.seq(c).iterator.toList shouldBe c.iterator.toList
-//       Chunk.indexedSeq(c).iterator.toList shouldBe c.iterator.toList
-//     }
-//
-//
-//     implicit val arbBooleanChunk: Arbitrary[Chunk[Boolean]] = Arbitrary {
-//       for {
-//         n <- Gen.choose(0, 100)
-//         values <- Gen.containerOfN[Array, Boolean](n, Arbitrary.arbBool.arbitrary)
-//         offset <- Gen.choose(0, n)
-//         sz <- Gen.choose(0, n - offset)
-//       } yield Chunk.booleans(values, offset, sz)
-//     }
-//
-//     implicit val arbByteChunk: Arbitrary[Chunk[Byte]] = Arbitrary {
-//       for {
-//         n <- Gen.choose(0, 100)
-//         values <- Gen.containerOfN[Array, Byte](n, Arbitrary.arbByte.arbitrary)
-//         offset <- Gen.choose(0, n)
-//         sz <- Gen.choose(0, n - offset)
-//       } yield Chunk.bytes(values, offset, sz)
-//     }
-//
-//     implicit val arbDoubleChunk: Arbitrary[Chunk[Double]] = Arbitrary {
-//       for {
-//         n <- Gen.choose(0, 100)
-//         values <- Gen.containerOfN[Array, Double](n, Arbitrary.arbDouble.arbitrary)
-//         offset <- Gen.choose(0, n)
-//         sz <- Gen.choose(0, n - offset)
-//       } yield Chunk.doubles(values, offset, sz)
-//     }
-//
-//     implicit val arbLongChunk: Arbitrary[Chunk[Long]] = Arbitrary {
-//       for {
-//         n <- Gen.choose(0, 100)
-//         values <- Gen.containerOfN[Array, Long](n, Arbitrary.arbLong.arbitrary)
-//         offset <- Gen.choose(0, n)
-//         sz <- Gen.choose(0, n - offset)
-//       } yield Chunk.longs(values, offset, sz)
-//     }
-//
-//     "size.boolean" in propSize[Boolean, Chunk[Boolean]]
-//     "size.byte" in propSize[Byte, Chunk[Byte]]
-//     "size.double" in propSize[Double, Chunk[Double]]
-//     "size.long" in propSize[Long, Chunk[Long]]
-//     "size.unspecialized" in propSize[Int, Chunk[Int]]
-//
-//     "take.boolean" in propTake[Boolean, Chunk[Boolean]]
-//     "take.byte" in propTake[Byte, Chunk[Byte]]
-//     "take.double" in propTake[Double, Chunk[Double]]
-//     "take.long" in propTake[Long, Chunk[Long]]
-//     "take.unspecialized" in propTake[Int, Chunk[Int]]
-//
-//     "drop.boolean" in propDrop[Boolean, Chunk[Boolean]]
-//     "drop.byte" in propDrop[Byte, Chunk[Byte]]
-//     "drop.double" in propDrop[Double, Chunk[Double]]
-//     "drop.long" in propDrop[Long, Chunk[Long]]
-//     "drop.unspecialized" in propDrop[Int, Chunk[Int]]
-//
-//     "uncons.boolean" in propUncons[Boolean, Chunk[Boolean]]
-//     "uncons.byte" in propUncons[Byte, Chunk[Byte]]
-//     "uncons.double" in propUncons[Double, Chunk[Double]]
-//     "uncons.long" in propUncons[Long, Chunk[Long]]
-//     "uncons.unspecialized" in propUncons[Int, Chunk[Int]]
-//
-//     "isempty.boolean" in propIsEmpty[Boolean, Chunk[Boolean]]
-//     "isempty.byte" in propIsEmpty[Byte, Chunk[Byte]]
-//     "isempty.double" in propIsEmpty[Double, Chunk[Double]]
-//     "isempty.long" in propIsEmpty[Long, Chunk[Long]]
-//     "isempty.unspecialized" in propIsEmpty[Int, Chunk[Int]]
-//
-//     "filter.boolean" in propFilter[Boolean, Chunk[Boolean]]
-//     "filter.byte" in propFilter[Byte, Chunk[Byte]]
-//     "filter.double" in propFilter[Double, Chunk[Double]]
-//     "filter.long" in propFilter[Long, Chunk[Long]]
-//     "filter.unspecialized" in propFilter[Int, Chunk[Int]]
-//
-//     "foldleft.boolean" in propFoldLeft[Boolean, Chunk[Boolean]]
-//     "foldleft.byte" in propFoldLeft[Byte, Chunk[Byte]]
-//     "foldleft.double" in propFoldLeft[Double, Chunk[Double]]
-//     "foldleft.long" in propFoldLeft[Long, Chunk[Long]]
-//     "foldleft.unspecialized" in propFoldLeft[Int, Chunk[Int]]
-//
-//     "foldright.boolean" in propFoldRight[Boolean, Chunk[Boolean]]
-//     "foldright.byte" in propFoldRight[Byte, Chunk[Byte]]
-//     "foldright.double" in propFoldRight[Double, Chunk[Double]]
-//     "foldright.long" in propFoldRight[Long, Chunk[Long]]
-//     "foldright.unspecialized" in propFoldRight[Int, Chunk[Int]]
-//
-//     "toarray.boolean" in propToArray[Boolean, Chunk[Boolean]]
-//     "toarray.byte" in propToArray[Byte, Chunk[Byte]]
-//     "toarray.double" in propToArray[Double, Chunk[Double]]
-//     "toarray.long" in propToArray[Long, Chunk[Long]]
-//     "toarray.unspecialized" in propToArray[Int, Chunk[Int]]
-//
-//     "concat.boolean" in propConcat[Boolean, Chunk[Boolean]]
-//     "concat.byte" in propConcat[Byte, Chunk[Byte]]
-//     "concat.double" in propConcat[Double, Chunk[Double]]
-//     "concat.long" in propConcat[Long, Chunk[Long]]
-//     "concat.unspecialized" in propConcat[Int, Chunk[Int]]
-//
-//     "map.boolean => byte" in forAll { c: Chunk[Boolean] =>
-//       (c map { b => if (b) 0.toByte else 1.toByte }).toArray shouldBe (c.toArray map { b => if (b) 0.toByte else 1.toByte })
-//     }
-//
-//     "map.long => long" in forAll { c: Chunk[Long] => (c map (1 +)).toArray shouldBe (c.toArray map (1 +)) }
-//   }
-// }
+package fs2
+
+import java.nio.ByteBuffer
+import org.scalacheck.{Gen, Arbitrary}
+
+import ChunkProps._
+
+class ChunkSpec extends Fs2Spec {
+
+  "Chunk" - {
+
+    "chunk-formation (1)" in {
+      Chunk.empty.toList shouldBe List()
+      Chunk.singleton(23).toList shouldBe List(23)
+    }
+
+    "chunk-formation (2)" in forAll { (c: Vector[Int]) =>
+      Chunk.seq(c).toVector shouldBe c
+      Chunk.seq(c).toList shouldBe c.toList
+      Chunk.indexedSeq(c).toVector shouldBe c
+      Chunk.indexedSeq(c).toList shouldBe c.toList
+      // Chunk.seq(c).iterator.toList shouldBe c.iterator.toList
+      // Chunk.indexedSeq(c).iterator.toList shouldBe c.iterator.toList
+    }
+
+
+    implicit val arbBooleanChunk: Arbitrary[Chunk[Boolean]] = Arbitrary {
+      for {
+        n <- Gen.choose(0, 100)
+        values <- Gen.containerOfN[Array, Boolean](n, Arbitrary.arbBool.arbitrary)
+        offset <- Gen.choose(0, n)
+        sz <- Gen.choose(0, n - offset)
+      } yield Chunk.booleans(values, offset, sz)
+    }
+
+    implicit val arbByteChunk: Arbitrary[Chunk[Byte]] = Arbitrary {
+      for {
+        n <- Gen.choose(0, 100)
+        values <- Gen.containerOfN[Array, Byte](n, Arbitrary.arbByte.arbitrary)
+        offset <- Gen.choose(0, n)
+        sz <- Gen.choose(0, n - offset)
+      } yield Chunk.bytes(values, offset, sz)
+    }
+
+    implicit val arbByteBufferChunk: Arbitrary[Chunk.ByteBuffer] = Arbitrary {
+      for {
+        n <- Gen.choose(0, 100)
+        values <- Gen.containerOfN[Array, Byte](n, Arbitrary.arbByte.arbitrary)
+        pos <- Gen.choose(0, n)
+        lim <- Gen.choose(pos, n)
+        direct <- Arbitrary.arbBool.arbitrary
+        bb = if (direct) ByteBuffer.allocateDirect(n).put(values) else ByteBuffer.wrap(values)
+        _ = bb.position(pos).limit(lim)
+      } yield Chunk.ByteBuffer(bb)
+    }
+
+    implicit val arbDoubleChunk: Arbitrary[Chunk[Double]] = Arbitrary {
+      for {
+        n <- Gen.choose(0, 100)
+        values <- Gen.containerOfN[Array, Double](n, Arbitrary.arbDouble.arbitrary)
+        offset <- Gen.choose(0, n)
+        sz <- Gen.choose(0, n - offset)
+      } yield Chunk.doubles(values, offset, sz)
+    }
+
+    implicit val arbLongChunk: Arbitrary[Chunk[Long]] = Arbitrary {
+      for {
+        n <- Gen.choose(0, 100)
+        values <- Gen.containerOfN[Array, Long](n, Arbitrary.arbLong.arbitrary)
+        offset <- Gen.choose(0, n)
+        sz <- Gen.choose(0, n - offset)
+      } yield Chunk.longs(values, offset, sz)
+    }
+
+    "size.boolean" in propSize[Boolean, Chunk[Boolean]]
+    "size.byte" in propSize[Byte, Chunk[Byte]]
+    "size.byteBuffer" in propSize[Byte, Chunk.ByteBuffer]
+    "size.double" in propSize[Double, Chunk[Double]]
+    "size.long" in propSize[Long, Chunk[Long]]
+    "size.unspecialized" in propSize[Int, Chunk[Int]]
+
+    "take.boolean" in propTake[Boolean, Chunk[Boolean]]
+    "take.byte" in propTake[Byte, Chunk[Byte]]
+    "take.byteBuffer" in propTake[Byte, Chunk.ByteBuffer]    
+    "take.double" in propTake[Double, Chunk[Double]]
+    "take.long" in propTake[Long, Chunk[Long]]
+    "take.unspecialized" in propTake[Int, Chunk[Int]]
+
+    "drop.boolean" in propDrop[Boolean, Chunk[Boolean]]
+    "drop.byte" in propDrop[Byte, Chunk[Byte]]
+    "drop.byteBuffer" in propDrop[Byte, Chunk.ByteBuffer]
+    "drop.double" in propDrop[Double, Chunk[Double]]
+    "drop.long" in propDrop[Long, Chunk[Long]]
+    "drop.unspecialized" in propDrop[Int, Chunk[Int]]
+
+    "isempty.boolean" in propIsEmpty[Boolean, Chunk[Boolean]]
+    "isempty.byte" in propIsEmpty[Byte, Chunk[Byte]]
+    "isempty.byteBuffer" in propIsEmpty[Byte, Chunk.ByteBuffer]
+    "isempty.double" in propIsEmpty[Double, Chunk[Double]]
+    "isempty.long" in propIsEmpty[Long, Chunk[Long]]
+    "isempty.unspecialized" in propIsEmpty[Int, Chunk[Int]]
+
+    "toarray.boolean" in propToArray[Boolean, Chunk[Boolean]]
+    "toarray.byte" in propToArray[Byte, Chunk[Byte]]
+    "toarray.byteBuffer" in propToArray[Byte, Chunk.ByteBuffer]
+    "toarray.double" in propToArray[Double, Chunk[Double]]
+    "toarray.long" in propToArray[Long, Chunk[Long]]
+    "toarray.unspecialized" in propToArray[Int, Chunk[Int]]
+
+    "tobytebuffer.byte" in propToByteBuffer[Chunk[Byte]]
+    "tobytebuffer.byteBuffer" in propToByteBuffer[Chunk.ByteBuffer]
+
+    // "map.boolean => byte" in forAll { c: Chunk[Boolean] =>
+    //   (c map { b => if (b) 0.toByte else 1.toByte }).toArray shouldBe (c.toArray map { b => if (b) 0.toByte else 1.toByte })
+    // }
+
+    // "map.long => long" in forAll { c: Chunk[Long] => (c map (1 +)).toArray shouldBe (c.toArray map (1 +)) }
+  }
+}


### PR DESCRIPTION
Optimization for streams sourced from and sunk to `ByteBuffer`s.  This avoids copying bytes on direct buffers, and the overhead of wrapping and unwrapping array-backed buffers.

Moves `.toByteBuffer` operation to `Chunk` with `Byte` evidence.

Brings back some properties for `Chunk`, and tests the new implementation. 

