### PR TITLE
Create Ref.fromF

### DIFF
--- a/core/shared/src/main/scala/fs2/async/Ref.scala
+++ b/core/shared/src/main/scala/fs2/async/Ref.scala
@@ -128,6 +128,9 @@ object Ref {
   def apply[F[_], A](a: A)(implicit F: Sync[F]): F[Ref[F, A]] =
     F.delay(new Ref[F, A](new AtomicReference[A](a)))
 
+  def fromF[F[_], A](fa: F[A])(implicit F: Sync[F]): F[Ref[F, A]] =
+    fa.map(a => new Ref[F, A](new AtomicReference(a)))
+
   /**
     * The result of a modification to a [[Ref]]
     *


### PR DESCRIPTION
Without this, I find myself having to do things like `fa.flatMap(Ref(_))`.  That could be because I'm missing something, but I can't find any indication of that being the case.