### PR TITLE
Workaround for #1046; use forked JVM in tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,6 +56,7 @@ lazy val commonSettings = Seq(
 ) ++ testSettings ++ scaladocSettings ++ publishingSettings ++ releaseSettings
 
 lazy val testSettings = Seq(
+  fork in Test := ! isScalaJSProject.value,
   parallelExecution in Test := false,
   testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
   publishArtifact in Test := true


### PR DESCRIPTION
Not a fundamental fix, but handy in repeated tests.