### PR TITLE
Feature/merge interrupt

### DIFF
--- a/core/jvm/src/test/scala/fs2/MergeJoinSpec.scala
+++ b/core/jvm/src/test/scala/fs2/MergeJoinSpec.scala
@@ -72,7 +72,10 @@ class MergeJoinSpec extends Fs2Spec {
       (s1: PureStream[Int], f: Failure) =>
         an[Err.type] should be thrownBy {
           s1.get
-            .merge(f.get)
+          // To ensure errors are generated before the merge occurs, we chunk/unchunk here to force any segment computations
+          // This is necessary b/c this test depends on any errors in f occurring before the first flatMapped output of the
+          // merged stream
+            .merge(f.get.chunks.flatMap(Stream.chunk(_)))
             .flatMap { _ =>
               Stream.eval(IO.async[Unit](_ => ()))
             }
@@ -86,7 +89,10 @@ class MergeJoinSpec extends Fs2Spec {
       (s1: PureStream[Int], f: Failure) =>
         an[Err.type] should be thrownBy {
           s1.get
-            .merge(f.get)
+          // To ensure errors are generated before the merge occurs, we chunk/unchunk here to force any segment computations
+          // This is necessary b/c this test depends on any errors in f occurring before the first flatMapped output of the
+          // merged stream
+            .merge(f.get.chunks.flatMap(Stream.chunk(_)))
             .flatMap { _ =>
               Stream.constant(true)
             }

--- a/core/jvm/src/test/scala/fs2/MergeJoinSpec.scala
+++ b/core/jvm/src/test/scala/fs2/MergeJoinSpec.scala
@@ -68,6 +68,34 @@ class MergeJoinSpec extends Fs2Spec {
       }
     }
 
+    "merge (left/right failure) never-ending flatMap, failure after emit" in forAll {
+      (s1: PureStream[Int], f: Failure) =>
+        an[Err.type] should be thrownBy {
+          s1.get
+            .merge(f.get)
+            .flatMap { _ =>
+              Stream.eval(IO.async[Unit](_ => ()))
+            }
+            .compile
+            .drain
+            .unsafeRunSync()
+        }
+    }
+
+    "merge (left/right failure) constant flatMap, failure after emit" in forAll {
+      (s1: PureStream[Int], f: Failure) =>
+        an[Err.type] should be thrownBy {
+          s1.get
+            .merge(f.get)
+            .flatMap { _ =>
+              Stream.constant(true)
+            }
+            .compile
+            .drain
+            .unsafeRunSync()
+        }
+    }
+
     "hanging awaits" - {
 
       val full = Stream.constant(42).covary[IO]


### PR DESCRIPTION
merge is now implemented w/o unconsAsync : 
- there is no `race` combinator required, except the one resulting from `interrupt` in streams
- the implementation now behaves equally to `s1.concurrently(s2)`, however `concurrently` has little less ovrhead. 

There is spurious failure of `Pipe.handle errors from observing sink` test. I am not sure if the `sink` behaviour expected in test is correct. I feel very weird, that when sink is about to fail for each `O` it will just to be stopped to be observed for next `O`. I am perhaps missing something here @mpilquist any thoughts? 
  