### PR TITLE
Bugfix/hanging nested observe

### DIFF
--- a/core/jvm/src/test/scala/fs2/ConcurrentlySpec.scala
+++ b/core/jvm/src/test/scala/fs2/ConcurrentlySpec.scala
@@ -3,10 +3,10 @@ package fs2
 import scala.concurrent.duration._
 import cats.effect.IO
 import fs2.async.Promise
-
 import TestUtil._
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
 
-class ConcurrentlySpec extends Fs2Spec {
+class ConcurrentlySpec extends Fs2Spec with EventuallySupport {
 
   "concurrently" - {
 
@@ -34,7 +34,7 @@ class ConcurrentlySpec extends Fs2Spec {
         val prg = Scheduler[IO](1).flatMap(scheduler =>
           (scheduler.sleep_[IO](25.millis) ++ f.get).concurrently(bg))
         an[Err.type] should be thrownBy runLog(prg)
-        bgDone shouldBe true
+        eventually(Timeout(3 seconds)) { bgDone shouldBe true }
     }
 
     "when primary stream termiantes, background stream is terminated" in forAll {

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1668,7 +1668,7 @@ object Stream {
             // evaluation of the result.
             Stream.eval(async.fork(runR)) >>
               self
-                .interruptWhen(interruptL.get.map(Either.left))
+                .interruptWhen(interruptL.get.map(Either.left[Throwable, Unit]))
                 .onFinalize { interruptR.complete(()) }
                 .append(Stream.eval(doneR.get).flatMap {
                   case None      => Stream.empty


### PR DESCRIPTION
@mpilquist that fixes subtle issue with termination of the concurrently in case of failure. 

I also noticed, that merge, may suffer from similar issue. 

Also before RC1 I think we need to look on join, as currently my guess is that the join won't interrupt flatMap over blocking stream. 

