### PR TITLE
Remove race condition in Scheduler.effect.delayCancellable

### DIFF
--- a/core/jvm/src/test/scala/fs2/SchedulerSpec.scala
+++ b/core/jvm/src/test/scala/fs2/SchedulerSpec.scala
@@ -37,5 +37,16 @@ class SchedulerSpec extends AsyncFs2Spec {
         assert(r == Vector(3, 6))
       }
     }
+
+    "delay cancellable: cancel after completion is no op" in {
+      val s = mkScheduler
+        .evalMap { s =>
+          s.effect.delayCancellable(IO.unit, 20.millis).flatMap(t => t._1 <* t._2)
+        }
+
+      runLogF(s).map { r =>
+        r.head shouldBe Some(())
+      }
+    }
   }
 }


### PR DESCRIPTION
Fixes #1077 

`Scheduler.effect.timedCancellable` schedules an action that completes a Promise with `Some(a)` after a timer completes, and returns the result of reading the Promise along with an action that cancel s the timer and completes the Promise with `None`.
This means that if `cancel` is called after the timer and the action have completed, it will try to complete the Promise with None after the action has already completed it with `Some(a)`, and therefore the cancel action will fail with a PromiseAlreadyCompletedException.

If you look at `timedGet` (or `timedDecrementBy` in Semaphore, which has the same problem), we can see where the problem is:

```scala
cancellableGet.flatMap {
      case (g, cancelGet) =>
        scheduler.effect.delayCancellable(F.unit, timeout).flatMap {
          case (timer, cancelTimer) =>
            fs2.async
              .race(g, timer)
              .flatMap(_.fold(a => cancelTimer.as(Some(a)), _ => cancelGet.as(None)))
        }
    }
```
If `g` wins the `race`, then `cancelTimer.as(Some(a))` is executed, but if in the meantime `timer` has completed (so it lost the `race`, but it completed before `cancelTimer` executes), then `cancelTimer.as(Some(a))` will be a failed `F` as explained above, and therefore it will short circuit over the `as(Some(a))` and result in the whole `timedGet` failing with a `PromiseAlreadyCompleted` exception.

The fix is to make sure that `cancelTimer` is a no op if called after the timer has already completed, instead of having it fail.