### PR TITLE
fs2.async.once

### DIFF
--- a/core/shared/src/main/scala/fs2/internal/Resource.scala
+++ b/core/shared/src/main/scala/fs2/internal/Resource.scala
@@ -75,7 +75,7 @@ private[internal] sealed abstract class Resource[F[_]] {
   /**
     * Signals that this resource was leased by another scope than one allocating this resource.
     *
-    * Yields to `Some(lease)`, if this resource was successfully leased, and scope must bind `lease.concel` it when not needed anymore.
+    * Yields to `Some(lease)`, if this resource was successfully leased, and scope must bind `lease.cancel` it when not needed anymore.
     * or to `None` when this resource cannot be leased because resource is already released.
     */
   def lease: F[Option[Scope.Lease[F]]]

--- a/core/shared/src/test/scala/fs2/async/PromiseSpec.scala
+++ b/core/shared/src/test/scala/fs2/async/PromiseSpec.scala
@@ -73,4 +73,60 @@ class PromiseSpec extends AsyncFs2Spec with EitherValues {
       }.compile.last.unsafeToFuture.map(_ shouldBe Some(None))
     }
   }
+
+  "async.once" - {
+
+    "effect is not evaluated if the inner `F[A]` isn't bound" in {
+      mkScheduler.evalMap { scheduler =>
+        for {
+          ref <- async.refOf[IO, Int](42)
+          act = ref.modify(_ + 1)
+          _ <- async.once(act)
+          _ <- scheduler.effect.sleep[IO](100.millis)
+          v <- ref.get
+        } yield v
+      }.compile.last.unsafeToFuture.map(_ shouldBe Some(42))
+    }
+
+    "effect is evaluated once if the inner `F[A]` is bound twice" in {
+      val tsk = for {
+        ref <- async.refOf[IO, Int](42)
+        act = ref.modify(_ + 1).map(_.now)
+        memoized <- async.once(act)
+        x <- memoized
+        y <- memoized
+        v <- ref.get
+      } yield (x, y, v)
+      tsk.unsafeToFuture.map(_ shouldBe ((43, 43, 43)))
+    }
+
+    "effect is evaluated once if the inner `F[A]` is bound twice (race)" in {
+      mkScheduler.evalMap { scheduler =>
+        for {
+          ref <- async.refOf[IO, Int](42)
+          act = ref.modify(_ + 1).map(_.now)
+          memoized <- async.once(act)
+          _ <- async.fork(memoized)
+          x <- memoized
+          _ <- scheduler.effect.sleep[IO](100.millis)
+          v <- ref.get
+        } yield (x, v)
+      }.compile.last.unsafeToFuture.map(_ shouldBe Some((43, 43)))
+    }
+
+    "once andThen flatten is identity" in {
+      val n = 10
+      mkScheduler.evalMap { scheduler =>
+        for {
+          ref <- async.refOf[IO, Int](42)
+          act1 = ref.modify(_ + 1).map(_.now)
+          act2 = async.once(act1).flatten
+          _ <- async.fork(Stream.repeatEval(act1).take(n).compile.drain)
+          _ <- async.fork(Stream.repeatEval(act2).take(n).compile.drain)
+          _ <- scheduler.effect.sleep[IO](200.millis)
+          v <- ref.get
+        } yield v
+      }.compile.last.unsafeToFuture.map(_ shouldBe Some(42 + 2 * n))
+    }
+  }
 }


### PR DESCRIPTION
This PR adds `fs2.async.once`. We already have `start` for eager memoization; `once` has the same signature, but it memoizes lazily.