### PR TITLE
RunLeg now only translates what it requires for its step.

### DIFF
--- a/core/jvm/src/test/scala/fs2/StreamSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamSpec.scala
@@ -249,6 +249,75 @@ class StreamSpec extends Fs2Spec with Inside {
         .unsafeRunSync shouldBe List((1, 1))
     }
 
+    "translate (5)" in {
+      // tests that it is ok to have translate step leg that emits multiple segments
+
+      def goStep(step: Option[Stream.StepLeg[Function0, Int]]): Pull[Function0, Int, Unit] =
+        step match {
+          case None       => Pull.done
+          case Some(step) => Pull.output(step.head) >> step.stepLeg.flatMap(goStep)
+        }
+
+      (Stream.eval(() => 1) ++ Stream.eval(() => 2)).pull.stepLeg
+        .flatMap(goStep)
+        .stream
+        .translate(new (Function0 ~> IO) {
+          def apply[A](thunk: Function0[A]) = IO(thunk())
+        })
+        .compile
+        .toList
+        .unsafeRunSync shouldBe List(1, 2)
+    }
+
+    "translate (6)" in {
+      // tests that it is ok to have translate step leg that has uncons in its structure.
+
+      def goStep(step: Option[Stream.StepLeg[Function0, Int]]): Pull[Function0, Int, Unit] =
+        step match {
+          case None       => Pull.done
+          case Some(step) => Pull.output(step.head) >> step.stepLeg.flatMap(goStep)
+        }
+
+      (Stream.eval(() => 1) ++ Stream.eval(() => 2))
+        .flatMap { a =>
+          Stream.emit(a)
+        }
+        .flatMap { a =>
+          Stream.eval(() => a + 1) ++ Stream.eval(() => a + 2)
+        }
+        .pull
+        .stepLeg
+        .flatMap(goStep)
+        .stream
+        .translate(new (Function0 ~> IO) {
+          def apply[A](thunk: Function0[A]) = IO(thunk())
+        })
+        .compile
+        .toList
+        .unsafeRunSync shouldBe List(2, 3, 3, 4)
+    }
+
+    "translate (7)" in {
+      // tests that it is ok to have translate step leg that is later forced back into stream
+
+      def goStep(step: Option[Stream.StepLeg[Function0, Int]]): Pull[Function0, Int, Unit] =
+        step match {
+          case None => Pull.done
+          case Some(step) =>
+            Pull.output(step.head) >> step.stream.pull.echo
+        }
+
+      (Stream.eval(() => 1) ++ Stream.eval(() => 2)).pull.stepLeg
+        .flatMap(goStep)
+        .stream
+        .translate(new (Function0 ~> IO) {
+          def apply[A](thunk: Function0[A]) = IO(thunk())
+        })
+        .compile
+        .toList
+        .unsafeRunSync shouldBe List(1, 2)
+    }
+
     "toList" in forAll { (s: PureStream[Int]) =>
       s.get.toList shouldBe runLog(s.get).toList
     }

--- a/core/shared/src/main/scala/fs2/internal/CompileScope.scala
+++ b/core/shared/src/main/scala/fs2/internal/CompileScope.scala
@@ -66,7 +66,7 @@ private[fs2] final class CompileScope[F[_], O] private (
     val id: Token,
     private val parent: Option[CompileScope[F, O]],
     val interruptible: Option[InterruptContext[F, O]]
-)(implicit private val F: Sync[F])
+)(implicit val F: Sync[F])
     extends Scope[F] { self =>
 
   private val state: Ref[F, CompileScope.State[F, O]] = new Ref(

--- a/core/shared/src/main/scala/fs2/internal/CompileScope.scala
+++ b/core/shared/src/main/scala/fs2/internal/CompileScope.scala
@@ -66,7 +66,7 @@ private[fs2] final class CompileScope[F[_], O] private (
     val id: Token,
     private val parent: Option[CompileScope[F, O]],
     val interruptible: Option[InterruptContext[F, O]]
-)(implicit private[fs2] val F: Sync[F])
+)(implicit private val F: Sync[F])
     extends Scope[F] { self =>
 
   private val state: Ref[F, CompileScope.State[F, O]] = new Ref(


### PR DESCRIPTION
This now properly translates the RunLeg algebra. 

Now I am sure this will properly fix the #1099. 

This implementation will have an issue when someone will manage to pass `Stream.StepLeg` over the `translate` boundary. I have no idea how to properly fix that, it may be just something we will have to live with.

The core issue with that is that the `FreeC` which is stored in the `Stream.StepLeg` can be seen multiple times in the `RunLeg`(as well we can make the `FreeC` go back into the stream that will be once again translated then), as such we cannot translate the whole `FreeC` in one go. 
