### PR TITLE
Refactor drop and take to be specialized.

### DIFF
--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -299,13 +299,13 @@ object Chunk {
         }
 
         override def drop(n: Int): Chunk[O] =
-          if (n <= 0) Chunk.empty
+          if (n <= 0) this
           else if (n >= size) Chunk.empty
           else vector(v.drop(n))
 
         override def take(n: Int): Chunk[O] =
           if (n <= 0) Chunk.empty
-          else if (n >= size) Chunk.empty
+          else if (n >= size) this
           else vector(v.take(n))
 
         override def map[O2](f: O => O2): Chunk[O2] = vector(v.map(f))
@@ -321,13 +321,13 @@ object Chunk {
         override def toVector = s.toVector
 
         override def drop(n: Int): Chunk[O] =
-          if (n <= 0) Chunk.empty
+          if (n <= 0) this
           else if (n >= size) Chunk.empty
           else indexedSeq(s.drop(n))
 
         override def take(n: Int): Chunk[O] =
           if (n <= 0) Chunk.empty
-          else if (n >= size) Chunk.empty
+          else if (n >= size) this
           else indexedSeq(s.take(n))
 
         protected def splitAtChunk_(n: Int): (Chunk[O], Chunk[O]) = {
@@ -377,13 +377,13 @@ object Chunk {
       Boxed(values, offset, n) -> Boxed(values, offset + n, length - n)
 
     override def drop(n: Int): Chunk[O] =
-      if (n <= 0) Chunk.empty
+      if (n <= 0) this
       else if (n >= size) Chunk.empty
       else Boxed(values, offset + n, length - n)
 
     override def take(n: Int): Chunk[O] =
       if (n <= 0) Chunk.empty
-      else if (n >= size) Chunk.empty
+      else if (n >= size) this
       else Boxed(values, offset, n)
 
     override def toArray[O2 >: O: ClassTag]: Array[O2] =
@@ -409,13 +409,13 @@ object Chunk {
     def at(i: Int) = values(offset + i)
 
     override def drop(n: Int): Chunk[Boolean] =
-      if (n <= 0) Chunk.empty
+      if (n <= 0) this
       else if (n >= size) Chunk.empty
       else Booleans(values, offset + n, length - n)
 
     override def take(n: Int): Chunk[Boolean] =
       if (n <= 0) Chunk.empty
-      else if (n >= size) Chunk.empty
+      else if (n >= size) this
       else Booleans(values, offset, n)
 
     protected def splitAtChunk_(n: Int): (Chunk[Boolean], Chunk[Boolean]) =
@@ -442,13 +442,13 @@ object Chunk {
     def at(i: Int) = values(offset + i)
 
     override def drop(n: Int): Chunk[Byte] =
-      if (n <= 0) Chunk.empty
+      if (n <= 0) this
       else if (n >= size) Chunk.empty
       else Bytes(values, offset + n, length - n)
 
     override def take(n: Int): Chunk[Byte] =
       if (n <= 0) Chunk.empty
-      else if (n >= size) Chunk.empty
+      else if (n >= size) this
       else Bytes(values, offset, n)
 
     protected def splitAtChunk_(n: Int): (Chunk[Byte], Chunk[Byte]) =
@@ -468,21 +468,21 @@ object Chunk {
     def apply(i: Int): Byte = buf.get(i + offset)
 
     override def drop(n: Int): Chunk[Byte] =
-      if (n <= 0) Chunk.empty
-      else if (n >= size) Chunk.empty
-      else {
-        val first = buf.asReadOnlyBuffer
-        first.limit(n + offset)
-        ByteBuffer(first)
-      }
-
-    override def take(n: Int): Chunk[Byte] =
-      if (n <= 0) Chunk.empty
+      if (n <= 0) this
       else if (n >= size) Chunk.empty
       else {
         val second = buf.asReadOnlyBuffer
         second.position(n + offset)
         ByteBuffer(second)
+      }
+
+    override def take(n: Int): Chunk[Byte] =
+      if (n <= 0) Chunk.empty
+      else if (n >= size) this
+      else {
+        val first = buf.asReadOnlyBuffer
+        first.limit(n + offset)
+        ByteBuffer(first)
       }
 
     protected def splitAtChunk_(n: Int): (Chunk[Byte], Chunk[Byte]) = {
@@ -520,13 +520,13 @@ object Chunk {
     def at(i: Int) = values(offset + i)
 
     override def drop(n: Int): Chunk[Short] =
-      if (n <= 0) Chunk.empty
+      if (n <= 0) this
       else if (n >= size) Chunk.empty
       else Shorts(values, offset + n, length - n)
 
     override def take(n: Int): Chunk[Short] =
       if (n <= 0) Chunk.empty
-      else if (n >= size) Chunk.empty
+      else if (n >= size) this
       else Shorts(values, offset, n)
 
     protected def splitAtChunk_(n: Int): (Chunk[Short], Chunk[Short]) =
@@ -552,13 +552,13 @@ object Chunk {
     def at(i: Int) = values(offset + i)
 
     override def drop(n: Int): Chunk[Int] =
-      if (n <= 0) Chunk.empty
+      if (n <= 0) this
       else if (n >= size) Chunk.empty
       else Ints(values, offset + n, length - n)
 
     override def take(n: Int): Chunk[Int] =
       if (n <= 0) Chunk.empty
-      else if (n >= size) Chunk.empty
+      else if (n >= size) this
       else Ints(values, offset, n)
 
     protected def splitAtChunk_(n: Int): (Chunk[Int], Chunk[Int]) =
@@ -584,13 +584,13 @@ object Chunk {
     def at(i: Int) = values(offset + i)
 
     override def drop(n: Int): Chunk[Long] =
-      if (n <= 0) Chunk.empty
+      if (n <= 0) this
       else if (n >= size) Chunk.empty
       else Longs(values, offset + n, length - n)
 
     override def take(n: Int): Chunk[Long] =
       if (n <= 0) Chunk.empty
-      else if (n >= size) Chunk.empty
+      else if (n >= size) this
       else Longs(values, offset, n)
 
     protected def splitAtChunk_(n: Int): (Chunk[Long], Chunk[Long]) =
@@ -617,13 +617,13 @@ object Chunk {
     def at(i: Int) = values(offset + i)
 
     override def drop(n: Int): Chunk[Float] =
-      if (n <= 0) Chunk.empty
+      if (n <= 0) this
       else if (n >= size) Chunk.empty
       else Floats(values, offset + n, length - n)
 
     override def take(n: Int): Chunk[Float] =
       if (n <= 0) Chunk.empty
-      else if (n >= size) Chunk.empty
+      else if (n >= size) this
       else Floats(values, offset, n)
 
     protected def splitAtChunk_(n: Int): (Chunk[Float], Chunk[Float]) =
@@ -650,13 +650,13 @@ object Chunk {
     def at(i: Int) = values(offset + i)
 
     override def drop(n: Int): Chunk[Double] =
-      if (n <= 0) Chunk.empty
+      if (n <= 0) this
       else if (n >= size) Chunk.empty
       else Doubles(values, offset + n, length - n)
 
     override def take(n: Int): Chunk[Double] =
       if (n <= 0) Chunk.empty
-      else if (n >= size) Chunk.empty
+      else if (n >= size) this
       else Doubles(values, offset, n)
 
     protected def splitAtChunk_(n: Int): (Chunk[Double], Chunk[Double]) =

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -299,10 +299,14 @@ object Chunk {
         }
 
         override def drop(n: Int): Chunk[O] =
-          vector(v.drop(n))
+          if (n <= 0) Chunk.empty
+          else if (n >= size) Chunk.empty
+          else vector(v.drop(n))
 
         override def take(n: Int): Chunk[O] =
-          vector(v.take(n))
+          if (n <= 0) Chunk.empty
+          else if (n >= size) Chunk.empty
+          else vector(v.take(n))
 
         override def map[O2](f: O => O2): Chunk[O2] = vector(v.map(f))
       }
@@ -316,9 +320,15 @@ object Chunk {
         def apply(i: Int) = s(i)
         override def toVector = s.toVector
 
-        override def drop(n: Int): Chunk[O] = indexedSeq(s.drop(n))
+        override def drop(n: Int): Chunk[O] =
+          if (n <= 0) Chunk.empty
+          else if (n >= size) Chunk.empty
+          else indexedSeq(s.drop(n))
 
-        override def take(n: Int): Chunk[O] = indexedSeq(s.take(n))
+        override def take(n: Int): Chunk[O] =
+          if (n <= 0) Chunk.empty
+          else if (n >= size) Chunk.empty
+          else indexedSeq(s.take(n))
 
         protected def splitAtChunk_(n: Int): (Chunk[O], Chunk[O]) = {
           val (fst, snd) = s.splitAt(n)
@@ -366,9 +376,15 @@ object Chunk {
     protected def splitAtChunk_(n: Int): (Chunk[O], Chunk[O]) =
       Boxed(values, offset, n) -> Boxed(values, offset + n, length - n)
 
-    override def drop(n: Int): Chunk[O] = Boxed(values, offset + n, length - n)
+    override def drop(n: Int): Chunk[O] =
+      if (n <= 0) Chunk.empty
+      else if (n >= size) Chunk.empty
+      else Boxed(values, offset + n, length - n)
 
-    override def take(n: Int): Chunk[O] = Boxed(values, offset, n)
+    override def take(n: Int): Chunk[O] =
+      if (n <= 0) Chunk.empty
+      else if (n >= size) Chunk.empty
+      else Boxed(values, offset, n)
 
     override def toArray[O2 >: O: ClassTag]: Array[O2] =
       values.slice(offset, offset + length).asInstanceOf[Array[O2]]
@@ -393,10 +409,14 @@ object Chunk {
     def at(i: Int) = values(offset + i)
 
     override def drop(n: Int): Chunk[Boolean] =
-      Booleans(values, offset + n, length - n)
+      if (n <= 0) Chunk.empty
+      else if (n >= size) Chunk.empty
+      else Booleans(values, offset + n, length - n)
 
     override def take(n: Int): Chunk[Boolean] =
-      Booleans(values, offset, n)
+      if (n <= 0) Chunk.empty
+      else if (n >= size) Chunk.empty
+      else Booleans(values, offset, n)
 
     protected def splitAtChunk_(n: Int): (Chunk[Boolean], Chunk[Boolean]) =
       Booleans(values, offset, n) -> Booleans(values, offset + n, length - n)
@@ -421,9 +441,15 @@ object Chunk {
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
 
-    override def drop(n: Int): Chunk[Byte] = Bytes(values, offset + n, length - n)
+    override def drop(n: Int): Chunk[Byte] =
+      if (n <= 0) Chunk.empty
+      else if (n >= size) Chunk.empty
+      else Bytes(values, offset + n, length - n)
 
-    override def take(n: Int): Chunk[Byte] = Bytes(values, offset, n)
+    override def take(n: Int): Chunk[Byte] =
+      if (n <= 0) Chunk.empty
+      else if (n >= size) Chunk.empty
+      else Bytes(values, offset, n)
 
     protected def splitAtChunk_(n: Int): (Chunk[Byte], Chunk[Byte]) =
       Bytes(values, offset, n) -> Bytes(values, offset + n, length - n)
@@ -441,17 +467,23 @@ object Chunk {
       extends Chunk[Byte] {
     def apply(i: Int): Byte = buf.get(i + offset)
 
-    override def drop(n: Int): Chunk[Byte] = {
-      val first = buf.asReadOnlyBuffer
-      first.limit(n + offset)
-      ByteBuffer(first)
-    }
+    override def drop(n: Int): Chunk[Byte] =
+      if (n <= 0) Chunk.empty
+      else if (n >= size) Chunk.empty
+      else {
+        val first = buf.asReadOnlyBuffer
+        first.limit(n + offset)
+        ByteBuffer(first)
+      }
 
-    override def take(n: Int): Chunk[Byte] = {
-      val second = buf.asReadOnlyBuffer
-      second.position(n + offset)
-      ByteBuffer(second)
-    }
+    override def take(n: Int): Chunk[Byte] =
+      if (n <= 0) Chunk.empty
+      else if (n >= size) Chunk.empty
+      else {
+        val second = buf.asReadOnlyBuffer
+        second.position(n + offset)
+        ByteBuffer(second)
+      }
 
     protected def splitAtChunk_(n: Int): (Chunk[Byte], Chunk[Byte]) = {
       val first = buf.asReadOnlyBuffer
@@ -487,9 +519,15 @@ object Chunk {
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
 
-    override def drop(n: Int): Chunk[Short] = Shorts(values, offset + n, length - n)
+    override def drop(n: Int): Chunk[Short] =
+      if (n <= 0) Chunk.empty
+      else if (n >= size) Chunk.empty
+      else Shorts(values, offset + n, length - n)
 
-    override def take(n: Int): Chunk[Short] = Shorts(values, offset, n)
+    override def take(n: Int): Chunk[Short] =
+      if (n <= 0) Chunk.empty
+      else if (n >= size) Chunk.empty
+      else Shorts(values, offset, n)
 
     protected def splitAtChunk_(n: Int): (Chunk[Short], Chunk[Short]) =
       Shorts(values, offset, n) -> Shorts(values, offset + n, length - n)
@@ -513,9 +551,15 @@ object Chunk {
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
 
-    override def drop(n: Int): Chunk[Int] = Ints(values, offset + n, length - n)
+    override def drop(n: Int): Chunk[Int] =
+      if (n <= 0) Chunk.empty
+      else if (n >= size) Chunk.empty
+      else Ints(values, offset + n, length - n)
 
-    override def take(n: Int): Chunk[Int] = Ints(values, offset, n)
+    override def take(n: Int): Chunk[Int] =
+      if (n <= 0) Chunk.empty
+      else if (n >= size) Chunk.empty
+      else Ints(values, offset, n)
 
     protected def splitAtChunk_(n: Int): (Chunk[Int], Chunk[Int]) =
       Ints(values, offset, n) -> Ints(values, offset + n, length - n)
@@ -539,9 +583,15 @@ object Chunk {
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
 
-    override def drop(n: Int): Chunk[Long] = Longs(values, offset + n, length - n)
+    override def drop(n: Int): Chunk[Long] =
+      if (n <= 0) Chunk.empty
+      else if (n >= size) Chunk.empty
+      else Longs(values, offset + n, length - n)
 
-    override def take(n: Int): Chunk[Long] = Longs(values, offset, n)
+    override def take(n: Int): Chunk[Long] =
+      if (n <= 0) Chunk.empty
+      else if (n >= size) Chunk.empty
+      else Longs(values, offset, n)
 
     protected def splitAtChunk_(n: Int): (Chunk[Long], Chunk[Long]) =
       Longs(values, offset, n) -> Longs(values, offset + n, length - n)
@@ -566,9 +616,15 @@ object Chunk {
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
 
-    override def drop(n: Int): Chunk[Float] = Floats(values, offset + n, length - n)
+    override def drop(n: Int): Chunk[Float] =
+      if (n <= 0) Chunk.empty
+      else if (n >= size) Chunk.empty
+      else Floats(values, offset + n, length - n)
 
-    override def take(n: Int): Chunk[Float] = Floats(values, offset, n)
+    override def take(n: Int): Chunk[Float] =
+      if (n <= 0) Chunk.empty
+      else if (n >= size) Chunk.empty
+      else Floats(values, offset, n)
 
     protected def splitAtChunk_(n: Int): (Chunk[Float], Chunk[Float]) =
       Floats(values, offset, n) -> Floats(values, offset + n, length - n)
@@ -593,9 +649,15 @@ object Chunk {
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
 
-    override def drop(n: Int): Chunk[Double] = Doubles(values, offset + n, length - n)
+    override def drop(n: Int): Chunk[Double] =
+      if (n <= 0) Chunk.empty
+      else if (n >= size) Chunk.empty
+      else Doubles(values, offset + n, length - n)
 
-    override def take(n: Int): Chunk[Double] = Doubles(values, offset, n)
+    override def take(n: Int): Chunk[Double] =
+      if (n <= 0) Chunk.empty
+      else if (n >= size) Chunk.empty
+      else Doubles(values, offset, n)
 
     protected def splitAtChunk_(n: Int): (Chunk[Double], Chunk[Double]) =
       Doubles(values, offset, n) -> Doubles(values, offset + n, length - n)

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -297,6 +297,13 @@ object Chunk {
           val (fst, snd) = v.splitAt(n)
           vector(fst) -> vector(snd)
         }
+
+        override def drop(n: Int): Chunk[O] =
+          vector(v.drop(n))
+
+        override def take(n: Int): Chunk[O] =
+          vector(v.take(n))
+
         override def map[O2](f: O => O2): Chunk[O2] = vector(v.map(f))
       }
 
@@ -308,6 +315,11 @@ object Chunk {
         def size = s.length
         def apply(i: Int) = s(i)
         override def toVector = s.toVector
+
+        override def drop(n: Int): Chunk[O] = indexedSeq(s.drop(n))
+
+        override def take(n: Int): Chunk[O] = indexedSeq(s.take(n))
+
         protected def splitAtChunk_(n: Int): (Chunk[O], Chunk[O]) = {
           val (fst, snd) = s.splitAt(n)
           indexedSeq(fst) -> indexedSeq(snd)
@@ -353,6 +365,11 @@ object Chunk {
     def apply(i: Int) = values(offset + i)
     protected def splitAtChunk_(n: Int): (Chunk[O], Chunk[O]) =
       Boxed(values, offset, n) -> Boxed(values, offset + n, length - n)
+
+    override def drop(n: Int): Chunk[O] = Boxed(values, offset + n, length - n)
+
+    override def take(n: Int): Chunk[O] = Boxed(values, offset, n)
+
     override def toArray[O2 >: O: ClassTag]: Array[O2] =
       values.slice(offset, offset + length).asInstanceOf[Array[O2]]
   }
@@ -374,6 +391,13 @@ object Chunk {
     def size = length
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
+
+    override def drop(n: Int): Chunk[Boolean] =
+      Booleans(values, offset + n, length - n)
+
+    override def take(n: Int): Chunk[Boolean] =
+      Booleans(values, offset, n)
+
     protected def splitAtChunk_(n: Int): (Chunk[Boolean], Chunk[Boolean]) =
       Booleans(values, offset, n) -> Booleans(values, offset + n, length - n)
     override def toArray[O2 >: Boolean: ClassTag]: Array[O2] =
@@ -396,6 +420,11 @@ object Chunk {
     def size = length
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
+
+    override def drop(n: Int): Chunk[Byte] = Bytes(values, offset + n, length - n)
+
+    override def take(n: Int): Chunk[Byte] = Bytes(values, offset, n)
+
     protected def splitAtChunk_(n: Int): (Chunk[Byte], Chunk[Byte]) =
       Bytes(values, offset, n) -> Bytes(values, offset + n, length - n)
     override def toArray[O2 >: Byte: ClassTag]: Array[O2] =
@@ -411,6 +440,19 @@ object Chunk {
   final case class ByteBuffer private (buf: JByteBuffer, offset: Int, size: Int)
       extends Chunk[Byte] {
     def apply(i: Int): Byte = buf.get(i + offset)
+
+    override def drop(n: Int): Chunk[Byte] = {
+      val first = buf.asReadOnlyBuffer
+      first.limit(n + offset)
+      ByteBuffer(first)
+    }
+
+    override def take(n: Int): Chunk[Byte] = {
+      val second = buf.asReadOnlyBuffer
+      second.position(n + offset)
+      ByteBuffer(second)
+    }
+
     protected def splitAtChunk_(n: Int): (Chunk[Byte], Chunk[Byte]) = {
       val first = buf.asReadOnlyBuffer
       first.limit(n + offset)
@@ -444,6 +486,11 @@ object Chunk {
     def size = length
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
+
+    override def drop(n: Int): Chunk[Short] = Shorts(values, offset + n, length - n)
+
+    override def take(n: Int): Chunk[Short] = Shorts(values, offset, n)
+
     protected def splitAtChunk_(n: Int): (Chunk[Short], Chunk[Short]) =
       Shorts(values, offset, n) -> Shorts(values, offset + n, length - n)
     override def toArray[O2 >: Short: ClassTag]: Array[O2] =
@@ -465,6 +512,11 @@ object Chunk {
     def size = length
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
+
+    override def drop(n: Int): Chunk[Int] = Ints(values, offset + n, length - n)
+
+    override def take(n: Int): Chunk[Int] = Ints(values, offset, n)
+
     protected def splitAtChunk_(n: Int): (Chunk[Int], Chunk[Int]) =
       Ints(values, offset, n) -> Ints(values, offset + n, length - n)
     override def toArray[O2 >: Int: ClassTag]: Array[O2] =
@@ -486,6 +538,11 @@ object Chunk {
     def size = length
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
+
+    override def drop(n: Int): Chunk[Long] = Longs(values, offset + n, length - n)
+
+    override def take(n: Int): Chunk[Long] = Longs(values, offset, n)
+
     protected def splitAtChunk_(n: Int): (Chunk[Long], Chunk[Long]) =
       Longs(values, offset, n) -> Longs(values, offset + n, length - n)
     override def toArray[O2 >: Long: ClassTag]: Array[O2] =
@@ -508,6 +565,11 @@ object Chunk {
     def size = length
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
+
+    override def drop(n: Int): Chunk[Float] = Floats(values, offset + n, length - n)
+
+    override def take(n: Int): Chunk[Float] = Floats(values, offset, n)
+
     protected def splitAtChunk_(n: Int): (Chunk[Float], Chunk[Float]) =
       Floats(values, offset, n) -> Floats(values, offset + n, length - n)
     override def toArray[O2 >: Float: ClassTag]: Array[O2] =
@@ -530,6 +592,11 @@ object Chunk {
     def size = length
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
+
+    override def drop(n: Int): Chunk[Double] = Doubles(values, offset + n, length - n)
+
+    override def take(n: Int): Chunk[Double] = Doubles(values, offset, n)
+
     protected def splitAtChunk_(n: Int): (Chunk[Double], Chunk[Double]) =
       Doubles(values, offset, n) -> Doubles(values, offset + n, length - n)
     override def toArray[O2 >: Double: ClassTag]: Array[O2] =

--- a/scodec/shared/src/main/scala/fs2/interop/scodec/ByteVectorChunk.scala
+++ b/scodec/shared/src/main/scala/fs2/interop/scodec/ByteVectorChunk.scala
@@ -11,13 +11,13 @@ final class ByteVectorChunk private (val toByteVector: ByteVector) extends Chunk
     toByteVector.size.toInt
 
   override def drop(n: Int): Chunk[Byte] =
-    if (n <= 0) Chunk.empty
+    if (n <= 0) this
     else if (n >= size) Chunk.empty
     else ByteVectorChunk(toByteVector.drop(n))
 
   override def take(n: Int): Chunk[Byte] =
     if (n <= 0) Chunk.empty
-    else if (n >= size) Chunk.empty
+    else if (n >= size) this
     else ByteVectorChunk(toByteVector.take(n))
 
   protected def splitAtChunk_(n: Int): (Chunk[Byte], Chunk[Byte]) = {

--- a/scodec/shared/src/main/scala/fs2/interop/scodec/ByteVectorChunk.scala
+++ b/scodec/shared/src/main/scala/fs2/interop/scodec/ByteVectorChunk.scala
@@ -10,6 +10,10 @@ final class ByteVectorChunk private (val toByteVector: ByteVector) extends Chunk
   def size: Int =
     toByteVector.size.toInt
 
+  override def drop(n: Int): Chunk[Byte] = ByteVectorChunk(toByteVector.drop(n))
+
+  override def take(n: Int): Chunk[Byte] = ByteVectorChunk(toByteVector.take(n))
+
   protected def splitAtChunk_(n: Int): (Chunk[Byte], Chunk[Byte]) = {
     val (before, after) = toByteVector.splitAt(n)
     (ByteVectorChunk(before), ByteVectorChunk(after))

--- a/scodec/shared/src/main/scala/fs2/interop/scodec/ByteVectorChunk.scala
+++ b/scodec/shared/src/main/scala/fs2/interop/scodec/ByteVectorChunk.scala
@@ -10,9 +10,15 @@ final class ByteVectorChunk private (val toByteVector: ByteVector) extends Chunk
   def size: Int =
     toByteVector.size.toInt
 
-  override def drop(n: Int): Chunk[Byte] = ByteVectorChunk(toByteVector.drop(n))
+  override def drop(n: Int): Chunk[Byte] =
+    if (n <= 0) Chunk.empty
+    else if (n >= size) Chunk.empty
+    else ByteVectorChunk(toByteVector.drop(n))
 
-  override def take(n: Int): Chunk[Byte] = ByteVectorChunk(toByteVector.take(n))
+  override def take(n: Int): Chunk[Byte] =
+    if (n <= 0) Chunk.empty
+    else if (n >= size) Chunk.empty
+    else ByteVectorChunk(toByteVector.take(n))
 
   protected def splitAtChunk_(n: Int): (Chunk[Byte], Chunk[Byte]) = {
     val (before, after) = toByteVector.splitAt(n)


### PR DESCRIPTION
Unfortunately, the override is necessary as discussed on [gitter](https://gitter.im/functional-streams-for-scala/fs2?at=5aa462170a1614b712061479) as making `splitAtChunk` different breaks binary compat.