### PR TITLE
Simplification of interpreter, fixing the SOE

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 import microsites.ExtraMdFileConfig
 import com.typesafe.sbt.pgp.PgpKeys.publishSigned
+import com.typesafe.tools.mima.core.{Problem, ProblemFilters}
 import sbtrelease.Version
 
 val ReleaseTag = """^release/([\d\.]+a?)$""".r
@@ -186,7 +187,9 @@ lazy val mimaSettings = Seq(
     organization.value % (normalizedName.value + "_" + scalaBinaryVersion.value) % pv
   }.toSet,
   mimaBinaryIssueFilters ++= Seq(
-    )
+    ProblemFilters.exclude[Problem]("fs2.internal.*"),
+    ProblemFilters.exclude[Problem]("fs2.Stream#StepLeg.this")
+  )
 )
 
 def previousVersion(currentVersion: String): Option[String] = {

--- a/core/jvm/src/main/scala/fs2/StreamApp.scala
+++ b/core/jvm/src/main/scala/fs2/StreamApp.scala
@@ -75,7 +75,6 @@ abstract class StreamApp[F[_]](implicit F: Effect[F]) {
             halted.set(true) *>
             exitCodePromise.complete(ExitCode.Error)
         case Right(exitCode) =>
-          println("XXXA returning code: " + exitCode)
           halted.set(true) *>
             exitCodePromise.complete(exitCode.getOrElse(ExitCode.Success))
       } *> exitCodePromise.get

--- a/core/jvm/src/main/scala/fs2/StreamApp.scala
+++ b/core/jvm/src/main/scala/fs2/StreamApp.scala
@@ -75,6 +75,7 @@ abstract class StreamApp[F[_]](implicit F: Effect[F]) {
             halted.set(true) *>
             exitCodePromise.complete(ExitCode.Error)
         case Right(exitCode) =>
+          println("XXXA returning code: " + exitCode)
           halted.set(true) *>
             exitCodePromise.complete(exitCode.getOrElse(ExitCode.Success))
       } *> exitCodePromise.get

--- a/core/jvm/src/test/scala/fs2/StreamSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamSpec.scala
@@ -469,7 +469,6 @@ class StreamSpec extends Fs2Spec with Inside {
     }
 
     "regression #1107 - scope" in {
-      pending
       Stream(0)
         .covary[IO]
         .scope // Create a source that opens/closes a new scope for every element emitted
@@ -483,7 +482,6 @@ class StreamSpec extends Fs2Spec with Inside {
     }
 
     "regression #1107 - queue" in {
-      pending
       Stream
         .range(0, 10000)
         .covary[IO]

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -8,7 +8,7 @@ import cats.{Applicative, Eq, Functor, Monoid, Semigroup, ~>}
 import cats.effect.{Effect, IO, Sync}
 import cats.implicits.{catsSyntaxEither => _, _}
 import fs2.async.Promise
-import fs2.internal.{Algebra, CompileScope, FreeC, Token}
+import fs2.internal.{Algebra, FreeC, Token}
 
 /**
   * A stream producing output of type `O` and which may evaluate `F`
@@ -2983,7 +2983,7 @@ object Stream {
       Pull
         .fromFreeC(Algebra.getScope[F, Nothing, O])
         .flatMap { scope =>
-          new StepLeg[F, O](Segment.empty, scope, self.get).stepLeg
+          new StepLeg[F, O](Segment.empty, scope.id, self.get).stepLeg
         }
 
     /** Emits the first `n` elements of the input. */
@@ -3165,7 +3165,7 @@ object Stream {
     */
   final class StepLeg[F[_], O](
       val head: Segment[O, Unit],
-      private[fs2] val scope: CompileScope[F, O],
+      private[fs2] val scopeId: Token,
       private[fs2] val next: FreeC[Algebra[F, O, ?], Unit]
   ) { self =>
 
@@ -3177,13 +3177,13 @@ object Stream {
       * Note that resulting stream won't contain the `head` of this leg.
       */
     def stream: Stream[F, O] =
-      Stream.fromFreeC(Algebra.setScope(scope.id).flatMap { _ =>
+      Stream.fromFreeC(Algebra.setScope(scopeId).flatMap { _ =>
         next
       })
 
     /** Replaces head of this leg. Useful when the head was not fully consumed. */
     def setHead(nextHead: Segment[O, Unit]): StepLeg[F, O] =
-      new StepLeg[F, O](nextHead, scope, next)
+      new StepLeg[F, O](nextHead, scopeId, next)
 
     /** Provides an `uncons`-like operation on this leg of the stream. */
     def stepLeg: Pull[F, Nothing, Option[StepLeg[F, O]]] =

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3177,9 +3177,11 @@ object Stream {
       * Note that resulting stream won't contain the `head` of this leg.
       */
     def stream: Stream[F, O] =
-      Stream.fromFreeC(Algebra.setScope(scopeId).flatMap { _ =>
-        next
-      })
+      Pull
+        .loop[F, O, StepLeg[F, O]] { leg =>
+          Pull.output(leg.head).flatMap(_ => leg.stepLeg)
+        }(self.setHead(Segment.empty))
+        .stream
 
     /** Replaces head of this leg. Useful when the head was not fully consumed. */
     def setHead(nextHead: Segment[O, Unit]): StepLeg[F, O] =

--- a/core/shared/src/main/scala/fs2/internal/CompileScope.scala
+++ b/core/shared/src/main/scala/fs2/internal/CompileScope.scala
@@ -309,6 +309,18 @@ private[fs2] final class CompileScope[F[_], O] private (
       }
   }
 
+  /**
+    * Tries to locate scope for the step.
+    * It is good chance, that scope is either current scope or the sibling of current scope.
+    * As such the order of search is:
+    * - check if id is current scope,
+    * - check if id is parent or any of its children
+    * - traverse all known scope ids, starting from the root.
+    *
+    */
+  def findStepScope(scopeId: Token): F[Option[CompileScope[F, O]]] =
+    ???
+
   // See docs on [[Scope#lease]]
   def lease: F[Option[Scope.Lease[F]]] = {
     val T = Catenable.instance

--- a/core/shared/src/main/scala/fs2/internal/CompileScope.scala
+++ b/core/shared/src/main/scala/fs2/internal/CompileScope.scala
@@ -318,8 +318,25 @@ private[fs2] final class CompileScope[F[_], O] private (
     * - traverse all known scope ids, starting from the root.
     *
     */
-  def findStepScope(scopeId: Token): F[Option[CompileScope[F, O]]] =
-    ???
+  def findStepScope(scopeId: Token): F[Option[CompileScope[F, O]]] = {
+    def go(scope: CompileScope[F, O]): CompileScope[F, O] =
+      scope.parent match {
+        case None         => scope
+        case Some(parent) => go(parent)
+      }
+
+    if (scopeId == self.id) F.pure(Some(self))
+    else {
+      self.parent match {
+        case None => F.pure(None)
+        case Some(parent) =>
+          F.flatMap(parent.findSelfOrChild(scopeId)) {
+            case Some(scope) => F.pure(Some(scope))
+            case None        => go(self).findSelfOrChild(scopeId)
+          }
+      }
+    }
+  }
 
   // See docs on [[Scope#lease]]
   def lease: F[Option[Scope.Lease[F]]] = {


### PR DESCRIPTION
@mpilquist @SystemFw 

Pavel have came up with simplified interpreter, that did multiple things for us: 

+ Fixed the SOE and memory leak for the #1107 .
+ Merged `StepLeg` and `Uncons` into one operation, which simplified translate for these cases.
+ Remove of `SetScope` from algebra.

I implemented largely simplified translate. 

The main idea of the new interpreter is that there is no more specialised interpretation of the `Algrebra` for when in normal stream, uncons stream or stepLeg stream. They all have been merged. The interpreter no longer needs to go to he lowest level when opening scope, but does it where it requires. The only exception for this is when creating an interruptible scope, which needs to be done on the `compileLoop` level, this is however optimised with passing the next step the interpreter should take. These things together will prevent the SOE.