### PR TITLE
Removed new scope in bracket + optimised eval_

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1255,7 +1255,10 @@ object Stream {
   def bracket[F[_], R, O](r: F[R])(use: R => Stream[F, O], release: R => F[Unit]): Stream[F, O] =
     fromFreeC(Algebra.acquire[F, O, R](r, release).flatMap {
       case (r, token) =>
-        use(r).onComplete { fromFreeC(Algebra.release(token)) }.get
+        use(r).get[F, O].transformWith {
+          case Left(err) => Algebra.release(token).flatMap(_ => FreeC.Fail(err))
+          case Right(_)  => Algebra.release(token)
+        }
     })
 
   private[fs2] def bracketWithToken[F[_], R, O](
@@ -1264,8 +1267,11 @@ object Stream {
       case (r, token) =>
         use(r)
           .map(o => (token, o))
-          .onComplete { fromFreeC(Algebra.release(token)) }
-          .get
+          .get[F, (Token, O)]
+          .transformWith {
+            case Left(err) => Algebra.release(token).flatMap(_ => FreeC.Fail(err))
+            case Right(_)  => Algebra.release(token)
+          }
     })
 
   /**
@@ -1359,7 +1365,8 @@ object Stream {
     * res0: Vector[Nothing] = Vector()
     * }}}
     */
-  def eval_[F[_], A](fa: F[A]): Stream[F, Nothing] = eval(fa).drain
+  def eval_[F[_], A](fa: F[A]): Stream[F, Nothing] =
+    fromFreeC(Algebra.eval(fa).map(_ => ()))
 
   /**
     * A continuous stream which is true after `d, 2d, 3d...` elapsed duration,


### PR DESCRIPTION
Since we started to look a bit to performance, I noticed these two things:

As of now we created new scope for each bracket, which is a minor issue in terms of performance, but since we already have the Aquire/Release algebra, why not to use it properly right? 

Second, thing that bugged me was that `eval_` was implemented via `eval(fa).drain` which adds an unnecessary `Output` and `Step` algebra. 

Running a stream that did 10000 `eval_` seen about 25% increase in performance.