### PR TITLE
Fix scope passing in Algebra.Step evaluation.

### DIFF
--- a/core/jvm/src/test/scala/fs2/Pipe2Spec.scala
+++ b/core/jvm/src/test/scala/fs2/Pipe2Spec.scala
@@ -89,6 +89,19 @@ class Pipe2Spec extends Fs2Spec {
       (s ++ s).zip(s).toList
     }
 
+    "issue #1120 - zip with uncons" in {
+      // this tests we can properly look up scopes for the zipped streams
+      //
+      val rangeStream = Stream.emits((0 to 3).toList).covary[IO]
+
+      runLog(rangeStream.zip(rangeStream).attempt.map(identity)) shouldBe Vector(
+        Right((0, 0)),
+        Right((1, 1)),
+        Right((2, 2)),
+        Right((3, 3))
+      )
+    }
+
     "interleave left/right side infinite" in {
       val ones = Stream.constant("1")
       val s = Stream("A", "B", "C")

--- a/core/shared/src/main/scala/fs2/internal/CompileScope.scala
+++ b/core/shared/src/main/scala/fs2/internal/CompileScope.scala
@@ -328,7 +328,7 @@ private[fs2] final class CompileScope[F[_], O] private (
     if (scopeId == self.id) F.pure(Some(self))
     else {
       self.parent match {
-        case None => F.pure(None)
+        case None => self.findSelfOrChild(scopeId)
         case Some(parent) =>
           F.flatMap(parent.findSelfOrChild(scopeId)) {
             case Some(scope) => F.pure(Some(scope))


### PR DESCRIPTION
We did not correctly pass the next scope for the `Algebra.Step` we always passed the original scope before the evaluation of the algebra. 

As well there was an issue that if we already were on root scope we would not search its children for scopes for `Algebra.Step`.

This fixes #1120 .