### PR TITLE
Make fs2.internal inhabitants private to fs2

### DIFF
--- a/core/jvm/src/main/scala/fs2/internal/ThreadFactories.scala
+++ b/core/jvm/src/main/scala/fs2/internal/ThreadFactories.scala
@@ -6,7 +6,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import scala.concurrent.ExecutionContext
 
-object ThreadFactories {
+private[fs2] object ThreadFactories {
 
   /** A `ThreadFactory` which names threads according to the pattern ${threadPrefix}-${count}. */
   def named(threadPrefix: String,

--- a/core/shared/src/main/scala/fs2/internal/AcquireAfterScopeClosed.scala
+++ b/core/shared/src/main/scala/fs2/internal/AcquireAfterScopeClosed.scala
@@ -1,5 +1,5 @@
 package fs2.internal
 
-final case object AcquireAfterScopeClosed extends Throwable {
+private[fs2] final case object AcquireAfterScopeClosed extends Throwable {
   override def fillInStackTrace = this
 }

--- a/core/shared/src/main/scala/fs2/internal/Canceled.scala
+++ b/core/shared/src/main/scala/fs2/internal/Canceled.scala
@@ -1,5 +1,5 @@
 package fs2.internal
 
-final case object Canceled extends Throwable {
+private[fs2] final case object Canceled extends Throwable {
   override def fillInStackTrace = this
 }

--- a/core/shared/src/main/scala/fs2/internal/NonFatal.scala
+++ b/core/shared/src/main/scala/fs2/internal/NonFatal.scala
@@ -1,7 +1,7 @@
 package fs2.internal
 
 /** Alternative to `scala.util.control.NonFatal` that only considers `VirtualMachineError`s as fatal. */
-object NonFatal {
+private[fs2] object NonFatal {
 
   def apply(t: Throwable): Boolean = t match {
     case _: VirtualMachineError => false

--- a/core/shared/src/main/scala/fs2/internal/TranslateInterrupt.scala
+++ b/core/shared/src/main/scala/fs2/internal/TranslateInterrupt.scala
@@ -2,11 +2,11 @@ package fs2.internal
 
 import cats.effect.Concurrent
 
-trait TranslateInterrupt[F[_]] {
+private[fs2] trait TranslateInterrupt[F[_]] {
   def concurrentInstance: Option[Concurrent[F]]
 }
 
-trait TranslateInterruptLowPriorityImplicits {
+private[fs2] trait TranslateInterruptLowPriorityImplicits {
 
   implicit def unInterruptibleInstance[F[_]]: TranslateInterrupt[F] = new TranslateInterrupt[F] {
     def concurrentInstance: Option[Concurrent[F]] = None
@@ -14,7 +14,7 @@ trait TranslateInterruptLowPriorityImplicits {
 
 }
 
-object TranslateInterrupt extends TranslateInterruptLowPriorityImplicits {
+private[fs2] object TranslateInterrupt extends TranslateInterruptLowPriorityImplicits {
   implicit def interruptibleInstance[F[_]: Concurrent]: TranslateInterrupt[F] =
     new TranslateInterrupt[F] {
       def concurrentInstance: Option[Concurrent[F]] = Some(implicitly[Concurrent[F]])


### PR DESCRIPTION
I'm not sure what to do about the 0.10 series. The reason I came across this the other day is because we had a dev use things from the internals package.

At least in the 1.0 series, we can hide it from the get-go.