### PR TITLE
Add `groupWithin`

### DIFF
--- a/core/jvm/src/test/scala/fs2/GroupWithinSpec.scala
+++ b/core/jvm/src/test/scala/fs2/GroupWithinSpec.scala
@@ -16,7 +16,7 @@ class GroupWithinSpec extends Fs2Spec {
           .covary[IO]
           .evalTap(shortDuration => IO.sleep(shortDuration.get))
           .groupWithin(maxGroupSize.get, d.get)
-          .flatMap(s => Stream.emits(s.force.toList))
+          .flatMap(s => Stream.emits(s.toList))
 
       runLog(action) shouldBe (result)
   }
@@ -29,7 +29,7 @@ class GroupWithinSpec extends Fs2Spec {
           .covary[IO]
           .evalTap(shortDuration => IO.sleep(shortDuration.get))
           .groupWithin(maxGroupSizeAsInt, d.get)
-          .map(_.force.toList.size)
+          .map(_.toList.size)
 
       runLog(action).foreach(size => size shouldBe <=(maxGroupSizeAsInt))
   }
@@ -44,7 +44,7 @@ class GroupWithinSpec extends Fs2Spec {
 
       val fullResult = runLog(action)
       withClue(s"Our full result looked like: $fullResult") {
-        fullResult.head.force.toList shouldBe streamAsList.toList
+        fullResult.head.toList shouldBe streamAsList.toList
       }
   }
 

--- a/core/jvm/src/test/scala/fs2/GroupWithinSpec.scala
+++ b/core/jvm/src/test/scala/fs2/GroupWithinSpec.scala
@@ -1,0 +1,51 @@
+package fs2
+
+import scala.concurrent.duration._
+import cats.effect._
+import cats.data.NonEmptyList
+
+import cats.laws.discipline.arbitrary._
+import TestUtil._
+
+class GroupWithinSpec extends Fs2Spec {
+  "groupWithin should never lose any elements" in forAll {
+    (s: PureStream[VeryShortFiniteDuration], d: ShortFiniteDuration, maxGroupSize: SmallPositive) =>
+      val result = s.get.toVector
+      val action =
+        s.get
+          .covary[IO]
+          .evalTap(shortDuration => IO.sleep(shortDuration.get))
+          .groupWithin(maxGroupSize.get, d.get)
+          .flatMap(s => Stream.emits(s.force.toList))
+
+      runLog(action) shouldBe (result)
+  }
+
+  "groupWithin should never have more elements than in its specified limit" in forAll {
+    (s: PureStream[VeryShortFiniteDuration], d: ShortFiniteDuration, maxGroupSize: SmallPositive) =>
+      val maxGroupSizeAsInt = maxGroupSize.get
+      val action =
+        s.get
+          .covary[IO]
+          .evalTap(shortDuration => IO.sleep(shortDuration.get))
+          .groupWithin(maxGroupSizeAsInt, d.get)
+          .map(_.force.toList.size)
+
+      runLog(action).foreach(size => size shouldBe <=(maxGroupSizeAsInt))
+  }
+
+  "groupWithin should return a finite stream back in a single chunk given a group size equal to the stream size and an absurdly high duration" in forAll {
+    (streamAsList: NonEmptyList[Int]) =>
+      val action =
+        Stream
+          .emits(streamAsList.toList)
+          .covary[IO]
+          .groupWithin(streamAsList.size, (Long.MaxValue - 1L).nanoseconds)
+
+      val fullResult = runLog(action)
+      withClue(s"Our full result looked like: $fullResult") {
+        fullResult.head.force.toList shouldBe streamAsList.toList
+      }
+  }
+
+}

--- a/core/jvm/src/test/scala/fs2/StreamCancelationSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamCancelationSpec.scala
@@ -14,7 +14,8 @@ class StreamCancelationSpec extends AsyncFs2Spec {
 
   "cancelation of compiled streams" - {
     "constant" in testCancelation(Stream.constant(1))
-    "bracketed stream" in testCancelation(Stream.bracket(IO.unit)(_ => IO.unit).flatMap(_ => Stream.constant(1)))
+    "bracketed stream" in testCancelation(
+      Stream.bracket(IO.unit)(_ => IO.unit).flatMap(_ => Stream.constant(1)))
     "concurrently" in testCancelation {
       val s = Stream.constant(1).covary[IO]
       s.concurrently(s)
@@ -28,7 +29,8 @@ class StreamCancelationSpec extends AsyncFs2Spec {
       Stream(s, s).parJoin(2)
     }
     "#1236" in testCancelation {
-      Stream.eval(async.boundedQueue[IO, Int](1))
+      Stream
+        .eval(async.boundedQueue[IO, Int](1))
         .flatMap { q =>
           Stream(
             Stream

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -4,6 +4,7 @@ import cats._
 import cats.data.NonEmptyList
 import cats.effect._
 import cats.effect.concurrent._
+import cats.effect.implicits._
 import cats.implicits.{catsSyntaxEither => _, _}
 import fs2.internal.FreeC.Result
 import fs2.internal._
@@ -952,6 +953,53 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
 
     go(None, this).stream
   }
+
+  /**
+    * Divide this streams into groups of elements received within a time window,
+    * or limited by the number of the elements, whichever happens first.
+    * Empty groups, which can occur if no elements can be pulled from upstream
+    * in a given time window, will not be emitted.
+    *
+    * Note: a time window starts each time downstream pulls.
+    */
+  def groupWithin[F2[x] >: F[x]: Concurrent](n: Int, d: FiniteDuration)(
+      implicit timer: Timer[F2]): Stream[F2, Segment[O, Unit]] =
+    Stream.eval(async.boundedQueue[F2, Option[Either[Int, O]]](n)).flatMap { q =>
+      def startTimeout(tick: Int): Stream[F2, Nothing] =
+        Stream.eval {
+          (timer.sleep(d) *> q.enqueue1(tick.asLeft.some)).start
+        }.drain
+
+      def producer = this.map(_.asRight.some).to(q.enqueue).onFinalize(q.enqueue1(None))
+
+      def emitNonEmpty(c: Catenable[Segment[O, Unit]]): Stream[F2, Segment[O, Unit]] =
+        if (c.nonEmpty) Stream.emit(Segment.catenated(c))
+        else Stream.empty
+
+      def go(acc: Catenable[Segment[O, Unit]],
+             elems: Int,
+             currentTimeout: Int): Stream[F2, Segment[O, Unit]] =
+        Stream.eval(q.dequeue1).flatMap {
+          case None => emitNonEmpty(acc)
+          case Some(e) =>
+            e match {
+              case Left(t) if t == currentTimeout =>
+                emitNonEmpty(acc) ++ startTimeout(currentTimeout + 1) ++ go(Catenable.empty,
+                                                                            0,
+                                                                            currentTimeout + 1)
+              case Left(t) => go(acc, elems, currentTimeout)
+              case Right(a) if elems >= n =>
+                emitNonEmpty(acc) ++ startTimeout(currentTimeout + 1) ++ go(
+                  Catenable.singleton(Segment.singleton(a)),
+                  1,
+                  currentTimeout + 1)
+              case Right(a) if elems < n =>
+                go(acc.snoc(Segment.singleton(a)), elems + 1, currentTimeout)
+            }
+        }
+
+      startTimeout(0) ++ go(Catenable.empty, 0, 0).concurrently(producer)
+    }
 
   /**
     * If `this` terminates with `Stream.raiseError(e)`, invoke `h(e)`.

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -964,7 +964,7 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
   def groupWithin[F2[x] >: F[x]](n: Int, d: FiniteDuration)(
       implicit timer: Timer[F2],
       F: Concurrent[F2]): Stream[F2, Chunk[O]] =
-    Stream.eval(async.boundedQueue[F2, Option[Either[Token, O]]](n)).flatMap { q =>
+    Stream.eval(async.boundedQueue[F2, Option[Either[Token, Chunk[O]]]](n)).flatMap { q =>
       def startTimeout: Stream[F2, Token] =
         Stream.eval {
           F.delay(new Token).flatTap { t =>
@@ -972,11 +972,17 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
           }
         }
 
-      def producer = this.map(_.asRight.some).to(q.enqueue).onFinalize(q.enqueue1(None))
-
+      def producer = this.chunks.map(_.asRight.some).to(q.enqueue).onFinalize(q.enqueue1(None))
       def emitNonEmpty(c: Catenable[Chunk[O]]): Stream[F2, Chunk[O]] =
         if (c.nonEmpty) Stream.emit(Chunk.concat(c.toList))
         else Stream.empty
+
+      def resize(c: Chunk[O], s: Stream[F2, Chunk[O]]): (Stream[F2, Chunk[O]], Chunk[O]) =
+        if (c.size < n) s -> c
+        else {
+          val (unit, rest) = c.splitAt(n)
+          resize(rest, s ++ Stream.emit(unit))
+        }
 
       def go(acc: Catenable[Chunk[O]], elems: Int, currentTimeout: Token): Stream[F2, Chunk[O]] =
         Stream.eval(q.dequeue1).flatMap {
@@ -987,14 +993,16 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
                 emitNonEmpty(acc) ++ startTimeout.flatMap { newTimeout =>
                   go(Catenable.empty, 0, newTimeout)
                 }
+              case Left(t) if t != currentTimeout => go(acc, elems, currentTimeout)
+              case Right(c) if elems + c.size >= n =>
+                val totalChunk = Chunk.concat(acc.snoc(c).toList)
+                val (toEmit, rest) = resize(totalChunk, Stream.empty)
 
-              case Left(t) => go(acc, elems, currentTimeout)
-              case Right(a) if elems >= n =>
-                emitNonEmpty(acc) ++ startTimeout.flatMap { newTimeout =>
-                  go(Catenable.singleton(Chunk.singleton(a)), 1, newTimeout)
+                toEmit ++ startTimeout.flatMap { newTimeout =>
+                  go(Catenable.singleton(rest), rest.size, newTimeout)
                 }
-              case Right(a) if elems < n =>
-                go(acc.snoc(Chunk.singleton(a)), elems + 1, currentTimeout)
+              case Right(c) if elems + c.size < n =>
+                go(acc.snoc(c), elems + c.size, currentTimeout)
             }
         }
 

--- a/core/shared/src/test/scala/fs2/TestUtil.scala
+++ b/core/shared/src/test/scala/fs2/TestUtil.scala
@@ -5,6 +5,7 @@ import org.scalacheck.{Arbitrary, Cogen, Gen, Shrink}
 
 import scala.concurrent.Future
 import scala.util.control.NonFatal
+import scala.concurrent.duration._
 
 import cats.effect.IO
 import cats.implicits._
@@ -47,6 +48,20 @@ object TestUtil extends TestUtilPlatform {
 
   case class SmallNonnegative(get: Int)
   implicit def arbSmallNonnegative = Arbitrary(Gen.choose(0,20).map(SmallNonnegative(_)))
+
+    case class ShortFiniteDuration(get: FiniteDuration)
+   implicit def arbShortFiniteDuration = Arbitrary{
+     Gen.choose(1L, 50000L)
+       .map(_.microseconds)
+       .map(ShortFiniteDuration(_))
+   }
+
+   case class VeryShortFiniteDuration(get: FiniteDuration)
+   implicit def arbVeryShortFiniteDuration = Arbitrary{
+     Gen.choose(1L, 500L)
+       .map(_.microseconds)
+       .map(VeryShortFiniteDuration(_))
+   }
 
   object PureStream {
     def singleChunk[A](implicit A: Arbitrary[A]): Gen[PureStream[A]] = Gen.sized { size =>


### PR DESCRIPTION
This is a prototype for `groupWithin`, same as #1157 

Still missing tests and docs, but worth submitting since it uses a different approach.

Looking for feedback from @Daenyth and @changlinli 