### PR TITLE
Optimized unconsChunk

### DIFF
--- a/core/jvm/src/test/scala/fs2/StreamPerformanceSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamPerformanceSpec.scala
@@ -185,5 +185,14 @@ class StreamPerformanceSpec extends Fs2Spec {
         }
       }
     }
+
+    "chunky map with unconsChunk" - {
+      Ns.take(9).foreach { N =>
+        N.toString in {
+          runLog(emits(Vector.range(0, N)).map(i => i).chunks.flatMap(chunk(_))) shouldBe Vector
+            .range(0, N)
+        }
+      }
+    }
   }
 }

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -1,6 +1,5 @@
 package fs2
 
-import scala.collection.immutable.VectorBuilder
 import scala.reflect.ClassTag
 import java.nio.{ByteBuffer => JByteBuffer}
 
@@ -70,10 +69,10 @@ abstract class Chunk[+O] extends Serializable {
 
   /** Creates a new chunk by applying `f` to each element in this chunk. */
   def map[O2](f: O => O2): Chunk[O2] = {
-    val b = new VectorBuilder[O2]
+    val b = collection.mutable.Buffer.newBuilder[O2]
     b.sizeHint(size)
     for (i <- 0 until size) b += f(apply(i))
-    Chunk.indexedSeq(b.result)
+    Chunk.buffer(b.result)
   }
 
   /** Splits this chunk in to two chunks at the specified index. */

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -50,6 +50,7 @@ abstract class Chunk[+O] extends Serializable { self =>
     acc
   }
 
+  /** Returns true if the predicate passes for all elements. */
   def forall(p: O => Boolean): Boolean = {
     var i = 0
     var result = true

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -19,7 +19,7 @@ import cats.implicits._
   * intermediate chunks being created (1 per call to `map`). In contrast, a chunk can be lifted to a segment
   * (via `toSegment`) to get arbitrary operator fusion.
   */
-abstract class Chunk[+O] extends Serializable {
+abstract class Chunk[+O] extends Serializable { self =>
 
   /** Returns the number of elements in this chunk. */
   def size: Int
@@ -32,6 +32,9 @@ abstract class Chunk[+O] extends Serializable {
 
   /** False if size is zero, true otherwise. */
   final def nonEmpty: Boolean = size > 0
+
+  /** Copies the elements of this chunk in to the specified array at the specified start index. */
+  def copyToArray[O2 >: O](xs: Array[O2], start: Int = 0): Unit
 
   /** Drops the first `n` elements of this chunk. */
   def drop(n: Int): Chunk[O] = splitAt(n)._2
@@ -47,8 +50,25 @@ abstract class Chunk[+O] extends Serializable {
     acc
   }
 
+  def forall(p: O => Boolean): Boolean = {
+    var i = 0
+    var result = true
+    while (i < size && result) {
+      result = p(apply(i))
+      i += 1
+    }
+    result
+  }
+
   /** Gets the first element of this chunk. */
   def head: Option[O] = if (isEmpty) None else Some(apply(0))
+
+  /** Creates an iterator that iterates the elements of this chunk. The returned iterator is not thread safe. */
+  def iterator: Iterator[O] = new Iterator[O] {
+    private[this] var i = 0
+    def hasNext = i < self.size
+    def next = { val result = apply(i); i += 1; result }
+  }
 
   /**
     * Returns the index of the first element which passes the specified predicate (i.e., `p(i) == true`)
@@ -265,6 +285,7 @@ object Chunk {
   private val empty_ : Chunk[Nothing] = new Chunk[Nothing] {
     def size = 0
     def apply(i: Int) = sys.error(s"Chunk.empty.apply($i)")
+    def copyToArray[O2 >: Nothing](xs: Array[O2], start: Int): Unit = ()
     protected def splitAtChunk_(n: Int): (Chunk[Nothing], Chunk[Nothing]) =
       sys.error("impossible")
     override def map[O2](f: Nothing => O2): Chunk[O2] = empty
@@ -279,6 +300,7 @@ object Chunk {
     def size = 1
     def apply(i: Int) =
       if (i == 0) o else throw new IndexOutOfBoundsException()
+    def copyToArray[O2 >: O](xs: Array[O2], start: Int): Unit = xs(start) = o
     protected def splitAtChunk_(n: Int): (Chunk[O], Chunk[O]) =
       sys.error("impossible")
     override def map[O2](f: O => O2): Chunk[O2] = singleton(f(o))
@@ -291,6 +313,7 @@ object Chunk {
       new Chunk[O] {
         def size = v.length
         def apply(i: Int) = v(i)
+        def copyToArray[O2 >: O](xs: Array[O2], start: Int): Unit = v.copyToArray(xs, start)
         override def toVector = v
         protected def splitAtChunk_(n: Int): (Chunk[O], Chunk[O]) = {
           val (fst, snd) = v.splitAt(n)
@@ -317,6 +340,7 @@ object Chunk {
       new Chunk[O] {
         def size = s.length
         def apply(i: Int) = s(i)
+        def copyToArray[O2 >: O](xs: Array[O2], start: Int): Unit = s.copyToArray(xs, start)
         override def toVector = s.toVector
 
         override def drop(n: Int): Chunk[O] =
@@ -354,6 +378,7 @@ object Chunk {
       new Chunk[O] {
         def size = b.length
         def apply(i: Int) = b(i)
+        def copyToArray[O2 >: O](xs: Array[O2], start: Int): Unit = b.copyToArray(xs, start)
         override def toVector = b.toVector
 
         override def drop(n: Int): Chunk[O] =
@@ -406,6 +431,13 @@ object Chunk {
     checkBounds(values, offset, length)
     def size = length
     def apply(i: Int) = values(offset + i)
+
+    def copyToArray[O2 >: O](xs: Array[O2], start: Int): Unit =
+      if (xs.isInstanceOf[Array[AnyRef]])
+        System.arraycopy(values, offset, xs, start, length)
+      else
+        values.iterator.slice(offset, offset + length).copyToArray(xs)
+
     protected def splitAtChunk_(n: Int): (Chunk[O], Chunk[O]) =
       Boxed(values, offset, n) -> Boxed(values, offset + n, length - n)
 
@@ -441,6 +473,12 @@ object Chunk {
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
 
+    def copyToArray[O2 >: Boolean](xs: Array[O2], start: Int): Unit =
+      if (xs.isInstanceOf[Array[Boolean]])
+        System.arraycopy(values, offset, xs, start, length)
+      else
+        values.iterator.slice(offset, offset + length).copyToArray(xs)
+
     override def drop(n: Int): Chunk[Boolean] =
       if (n <= 0) this
       else if (n >= size) Chunk.empty
@@ -474,6 +512,12 @@ object Chunk {
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
 
+    def copyToArray[O2 >: Byte](xs: Array[O2], start: Int): Unit =
+      if (xs.isInstanceOf[Array[Byte]])
+        System.arraycopy(values, offset, xs, start, length)
+      else
+        values.iterator.slice(offset, offset + length).copyToArray(xs)
+
     override def drop(n: Int): Chunk[Byte] =
       if (n <= 0) this
       else if (n >= size) Chunk.empty
@@ -493,12 +537,26 @@ object Chunk {
     def apply(values: Array[Byte]): Bytes = Bytes(values, 0, values.length)
   }
 
-  /** Creates a chunk backed by an byte buffer, bounded by the current position and limit */
+  /** Creates a chunk backed by an byte buffer, bounded by the current position and limit. */
   def byteBuffer(buf: JByteBuffer): Chunk[Byte] = ByteBuffer(buf)
 
   final case class ByteBuffer private (buf: JByteBuffer, offset: Int, size: Int)
       extends Chunk[Byte] {
     def apply(i: Int): Byte = buf.get(i + offset)
+
+    def copyToArray[O2 >: Byte](xs: Array[O2], start: Int): Unit = {
+      val b = buf.asReadOnlyBuffer
+      b.position(offset)
+      b.limit(offset + size)
+      if (xs.isInstanceOf[Array[Byte]]) {
+        b.get(xs.asInstanceOf[Array[Byte]], start, size)
+        ()
+      } else {
+        val arr = new Array[Byte](size)
+        b.get(arr)
+        arr.copyToArray(xs, start)
+      }
+    }
 
     override def drop(n: Int): Chunk[Byte] =
       if (n <= 0) this
@@ -552,6 +610,12 @@ object Chunk {
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
 
+    def copyToArray[O2 >: Short](xs: Array[O2], start: Int): Unit =
+      if (xs.isInstanceOf[Array[Short]])
+        System.arraycopy(values, offset, xs, start, length)
+      else
+        values.iterator.slice(offset, offset + length).copyToArray(xs)
+
     override def drop(n: Int): Chunk[Short] =
       if (n <= 0) this
       else if (n >= size) Chunk.empty
@@ -584,6 +648,12 @@ object Chunk {
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
 
+    def copyToArray[O2 >: Int](xs: Array[O2], start: Int): Unit =
+      if (xs.isInstanceOf[Array[Int]])
+        System.arraycopy(values, offset, xs, start, length)
+      else
+        values.iterator.slice(offset, offset + length).copyToArray(xs)
+
     override def drop(n: Int): Chunk[Int] =
       if (n <= 0) this
       else if (n >= size) Chunk.empty
@@ -615,6 +685,12 @@ object Chunk {
     def size = length
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
+
+    def copyToArray[O2 >: Long](xs: Array[O2], start: Int): Unit =
+      if (xs.isInstanceOf[Array[Long]])
+        System.arraycopy(values, offset, xs, start, length)
+      else
+        values.iterator.slice(offset, offset + length).copyToArray(xs)
 
     override def drop(n: Int): Chunk[Long] =
       if (n <= 0) this
@@ -649,6 +725,12 @@ object Chunk {
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
 
+    def copyToArray[O2 >: Float](xs: Array[O2], start: Int): Unit =
+      if (xs.isInstanceOf[Array[Float]])
+        System.arraycopy(values, offset, xs, start, length)
+      else
+        values.iterator.slice(offset, offset + length).copyToArray(xs)
+
     override def drop(n: Int): Chunk[Float] =
       if (n <= 0) this
       else if (n >= size) Chunk.empty
@@ -682,6 +764,12 @@ object Chunk {
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
 
+    def copyToArray[O2 >: Double](xs: Array[O2], start: Int): Unit =
+      if (xs.isInstanceOf[Array[Double]])
+        System.arraycopy(values, offset, xs, start, length)
+      else
+        values.iterator.slice(offset, offset + length).copyToArray(xs)
+
     override def drop(n: Int): Chunk[Double] =
       if (n <= 0) this
       else if (n >= size) Chunk.empty
@@ -701,6 +789,160 @@ object Chunk {
     def apply(values: Array[Double]): Doubles =
       Doubles(values, 0, values.length)
   }
+
+  /** Concatenates the specified sequence of chunks in to a single chunk, avoiding boxing. */
+  def concat[A](chunks: Seq[Chunk[A]]): Chunk[A] =
+    if (chunks.isEmpty) {
+      Chunk.empty
+    } else if (chunks.forall(c =>
+                 c.isInstanceOf[Chunk.Booleans] ||
+                   c.forall(_.isInstanceOf[Boolean]))) {
+      concatBooleans(chunks.asInstanceOf[Seq[Chunk[Boolean]]]).asInstanceOf[Chunk[A]]
+    } else if (chunks.forall(
+                 c =>
+                   c.isInstanceOf[Chunk.Bytes] ||
+                     c.isInstanceOf[Chunk.ByteBuffer] ||
+                     c.forall(_.isInstanceOf[Byte]))) {
+      concatBytes(chunks.asInstanceOf[Seq[Chunk[Byte]]]).asInstanceOf[Chunk[A]]
+    } else if (chunks.forall(c =>
+                 c.isInstanceOf[Chunk.Floats] ||
+                   c.forall(_.isInstanceOf[Float]))) {
+      concatFloats(chunks.asInstanceOf[Seq[Chunk[Float]]]).asInstanceOf[Chunk[A]]
+    } else if (chunks.forall(c =>
+                 c.isInstanceOf[Chunk.Doubles] ||
+                   c.forall(_.isInstanceOf[Double]))) {
+      concatDoubles(chunks.asInstanceOf[Seq[Chunk[Double]]]).asInstanceOf[Chunk[A]]
+    } else if (chunks.forall(c =>
+                 c.isInstanceOf[Chunk.Shorts] ||
+                   c.forall(_.isInstanceOf[Short]))) {
+      concatShorts(chunks.asInstanceOf[Seq[Chunk[Short]]]).asInstanceOf[Chunk[A]]
+    } else if (chunks.forall(c =>
+                 c.isInstanceOf[Chunk.Ints] ||
+                   c.forall(_.isInstanceOf[Int]))) {
+      concatInts(chunks.asInstanceOf[Seq[Chunk[Int]]]).asInstanceOf[Chunk[A]]
+    } else if (chunks.forall(c =>
+                 c.isInstanceOf[Chunk.Longs] ||
+                   c.forall(_.isInstanceOf[Long]))) {
+      concatLongs(chunks.asInstanceOf[Seq[Chunk[Long]]]).asInstanceOf[Chunk[A]]
+    } else {
+      val size = chunks.foldLeft(0)(_ + _.size)
+      val b = collection.mutable.Buffer.newBuilder[A]
+      b.sizeHint(size)
+      chunks.foreach(c => c.foreach(a => b += a))
+      Chunk.buffer(b.result)
+    }
+
+  /** Concatenates the specified sequence of boolean chunks in to a single chunk. */
+  def concatBooleans(chunks: Seq[Chunk[Boolean]]): Chunk[Boolean] =
+    if (chunks.isEmpty) Chunk.empty
+    else {
+      val size = chunks.foldLeft(0)(_ + _.size)
+      val arr = new Array[Boolean](size)
+      var offset = 0
+      chunks.foreach { c =>
+        if (!c.isEmpty) {
+          c.copyToArray(arr, offset)
+          offset += c.size
+        }
+      }
+      Chunk.booleans(arr)
+    }
+
+  /** Concatenates the specified sequence of byte chunks in to a single chunk. */
+  def concatBytes(chunks: Seq[Chunk[Byte]]): Chunk[Byte] =
+    if (chunks.isEmpty) Chunk.empty
+    else {
+      val size = chunks.foldLeft(0)(_ + _.size)
+      val arr = new Array[Byte](size)
+      var offset = 0
+      chunks.foreach { c =>
+        if (!c.isEmpty) {
+          c.copyToArray(arr, offset)
+          offset += c.size
+        }
+      }
+      Chunk.bytes(arr)
+    }
+
+  /** Concatenates the specified sequence of float chunks in to a single chunk. */
+  def concatFloats(chunks: Seq[Chunk[Float]]): Chunk[Float] =
+    if (chunks.isEmpty) Chunk.empty
+    else {
+      val size = chunks.foldLeft(0)(_ + _.size)
+      val arr = new Array[Float](size)
+      var offset = 0
+      chunks.foreach { c =>
+        if (!c.isEmpty) {
+          c.copyToArray(arr, offset)
+          offset += c.size
+        }
+      }
+      Chunk.floats(arr)
+    }
+
+  /** Concatenates the specified sequence of double chunks in to a single chunk. */
+  def concatDoubles(chunks: Seq[Chunk[Double]]): Chunk[Double] =
+    if (chunks.isEmpty) Chunk.empty
+    else {
+      val size = chunks.foldLeft(0)(_ + _.size)
+      val arr = new Array[Double](size)
+      var offset = 0
+      chunks.foreach { c =>
+        if (!c.isEmpty) {
+          c.copyToArray(arr, offset)
+          offset += c.size
+        }
+      }
+      Chunk.doubles(arr)
+    }
+
+  /** Concatenates the specified sequence of short chunks in to a single chunk. */
+  def concatShorts(chunks: Seq[Chunk[Short]]): Chunk[Short] =
+    if (chunks.isEmpty) Chunk.empty
+    else {
+      val size = chunks.foldLeft(0)(_ + _.size)
+      val arr = new Array[Short](size)
+      var offset = 0
+      chunks.foreach { c =>
+        if (!c.isEmpty) {
+          c.copyToArray(arr, offset)
+          offset += c.size
+        }
+      }
+      Chunk.shorts(arr)
+    }
+
+  /** Concatenates the specified sequence of int chunks in to a single chunk. */
+  def concatInts(chunks: Seq[Chunk[Int]]): Chunk[Int] =
+    if (chunks.isEmpty) Chunk.empty
+    else {
+      val size = chunks.foldLeft(0)(_ + _.size)
+      val arr = new Array[Int](size)
+      var offset = 0
+      chunks.foreach { c =>
+        if (!c.isEmpty) {
+          c.copyToArray(arr, offset)
+          offset += c.size
+        }
+      }
+      Chunk.ints(arr)
+    }
+
+  /** Concatenates the specified sequence of long chunks in to a single chunk. */
+  def concatLongs(chunks: Seq[Chunk[Long]]): Chunk[Long] =
+    if (chunks.isEmpty) Chunk.empty
+    else {
+      val size = chunks.foldLeft(0)(_ + _.size)
+      val arr = new Array[Long](size)
+      var offset = 0
+      chunks.foreach { c =>
+        if (!c.isEmpty) {
+          c.copyToArray(arr, offset)
+          offset += c.size
+        }
+      }
+      Chunk.longs(arr)
+    }
 
   implicit def fs2EqForChunk[A: Eq]: Eq[Chunk[A]] = new Eq[Chunk[A]] {
     def eqv(c1: Chunk[A], c2: Chunk[A]) =

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -437,7 +437,7 @@ object Chunk {
       if (xs.isInstanceOf[Array[AnyRef]])
         System.arraycopy(values, offset, xs, start, length)
       else
-        values.iterator.slice(offset, offset + length).copyToArray(xs)
+        values.iterator.slice(offset, offset + length).copyToArray(xs, start)
 
     protected def splitAtChunk_(n: Int): (Chunk[O], Chunk[O]) =
       Boxed(values, offset, n) -> Boxed(values, offset + n, length - n)
@@ -478,7 +478,7 @@ object Chunk {
       if (xs.isInstanceOf[Array[Boolean]])
         System.arraycopy(values, offset, xs, start, length)
       else
-        values.iterator.slice(offset, offset + length).copyToArray(xs)
+        values.iterator.slice(offset, offset + length).copyToArray(xs, start)
 
     override def drop(n: Int): Chunk[Boolean] =
       if (n <= 0) this
@@ -517,7 +517,7 @@ object Chunk {
       if (xs.isInstanceOf[Array[Byte]])
         System.arraycopy(values, offset, xs, start, length)
       else
-        values.iterator.slice(offset, offset + length).copyToArray(xs)
+        values.iterator.slice(offset, offset + length).copyToArray(xs, start)
 
     override def drop(n: Int): Chunk[Byte] =
       if (n <= 0) this
@@ -615,7 +615,7 @@ object Chunk {
       if (xs.isInstanceOf[Array[Short]])
         System.arraycopy(values, offset, xs, start, length)
       else
-        values.iterator.slice(offset, offset + length).copyToArray(xs)
+        values.iterator.slice(offset, offset + length).copyToArray(xs, start)
 
     override def drop(n: Int): Chunk[Short] =
       if (n <= 0) this
@@ -653,7 +653,7 @@ object Chunk {
       if (xs.isInstanceOf[Array[Int]])
         System.arraycopy(values, offset, xs, start, length)
       else
-        values.iterator.slice(offset, offset + length).copyToArray(xs)
+        values.iterator.slice(offset, offset + length).copyToArray(xs, start)
 
     override def drop(n: Int): Chunk[Int] =
       if (n <= 0) this
@@ -691,7 +691,7 @@ object Chunk {
       if (xs.isInstanceOf[Array[Long]])
         System.arraycopy(values, offset, xs, start, length)
       else
-        values.iterator.slice(offset, offset + length).copyToArray(xs)
+        values.iterator.slice(offset, offset + length).copyToArray(xs, start)
 
     override def drop(n: Int): Chunk[Long] =
       if (n <= 0) this
@@ -730,7 +730,7 @@ object Chunk {
       if (xs.isInstanceOf[Array[Float]])
         System.arraycopy(values, offset, xs, start, length)
       else
-        values.iterator.slice(offset, offset + length).copyToArray(xs)
+        values.iterator.slice(offset, offset + length).copyToArray(xs, start)
 
     override def drop(n: Int): Chunk[Float] =
       if (n <= 0) this
@@ -769,7 +769,7 @@ object Chunk {
       if (xs.isInstanceOf[Array[Double]])
         System.arraycopy(values, offset, xs, start, length)
       else
-        values.iterator.slice(offset, offset + length).copyToArray(xs)
+        values.iterator.slice(offset, offset + length).copyToArray(xs, start)
 
     override def drop(n: Int): Chunk[Double] =
       if (n <= 0) this

--- a/core/shared/src/main/scala/fs2/Segment.scala
+++ b/core/shared/src/main/scala/fs2/Segment.scala
@@ -1658,10 +1658,7 @@ object Segment {
         unconsChunks match {
           case Left(r) => Left(r)
           case Right((cs, tl)) =>
-            Right(cs.uncons.map {
-              case (hd, tl2) =>
-                hd -> tl.prepend(Segment.catenated(tl2.map(Segment.chunk)))
-            }.get)
+            Right(Chunk.concat(cs.toList) -> tl)
         }
     }
 

--- a/core/shared/src/test/scala/fs2/ChunkProps.scala
+++ b/core/shared/src/test/scala/fs2/ChunkProps.scala
@@ -34,6 +34,19 @@ object ChunkProps
     forAll { c: C =>
       c.toArray.toVector shouldBe c.toVector
     }
+    
+  def propCopyToArray[A: ClassTag: Arbitrary, C <: Chunk[A]: Arbitrary] =
+    forAll { c: C =>
+      val arr = new Array[A](c.size * 2)
+      c.copyToArray(arr, 0)
+      c.copyToArray(arr, c.size)
+      arr.toVector shouldBe (c.toVector ++ c.toVector)
+    }
+
+  def propConcat[A: ClassTag: Arbitrary, C <: Chunk[A]: Arbitrary] =
+    forAll { (c1: C, c2: C) =>
+      Chunk.concat(List(Chunk.empty, c1, Chunk.empty, c2)).toVector shouldBe (c1.toVector ++ c2.toVector)
+    }
 
   def propToByteBuffer[C <: Chunk[Byte]: Arbitrary] =
     forAll { c: C =>

--- a/core/shared/src/test/scala/fs2/ChunkSpec.scala
+++ b/core/shared/src/test/scala/fs2/ChunkSpec.scala
@@ -108,11 +108,13 @@ class ChunkSpec extends Fs2Spec {
       "size" in propSize[A, Chunk[A]]
       "take" in propTake[A, Chunk[A]]
       "drop" in propDrop[A, Chunk[A]]
-      "isempty" in propIsEmpty[A, Chunk[A]]
-      "toarray" in propToArray[A, Chunk[A]]
+      "isEmpty" in propIsEmpty[A, Chunk[A]]
+      "toArray" in propToArray[A, Chunk[A]]
+      "copyToArray" in propCopyToArray[A, Chunk[A]]
+      "concat" in propConcat[A, Chunk[A]]
 
       if (implicitly[ClassTag[A]] == ClassTag.Byte)
-        "tobytebuffer.byte" in propToByteBuffer[Chunk[Byte]]
+        "toByteBuffer.byte" in propToByteBuffer[Chunk[Byte]]
 
       checkAll(s"Eq[Chunk[$of]]", EqTests[Chunk[A]].eqv)
       checkAll(s"Monad[Chunk]", MonadTests[Chunk].monad[A, A, A])

--- a/scodec/shared/src/main/scala/fs2/interop/scodec/ByteVectorChunk.scala
+++ b/scodec/shared/src/main/scala/fs2/interop/scodec/ByteVectorChunk.scala
@@ -10,6 +10,11 @@ final class ByteVectorChunk private (val toByteVector: ByteVector) extends Chunk
   def size: Int =
     toByteVector.size.toInt
 
+  def copyToArray[O2 >: Byte](xs: Array[O2], start: Int): Unit =
+    if (xs.isInstanceOf[Array[Byte]])
+      toByteVector.copyToArray(xs.asInstanceOf[Array[Byte]], start)
+    else toByteVector.toIndexedSeq.copyToArray(xs)
+
   override def drop(n: Int): Chunk[Byte] =
     if (n <= 0) this
     else if (n >= size) Chunk.empty

--- a/scodec/shared/src/main/scala/fs2/interop/scodec/ByteVectorChunk.scala
+++ b/scodec/shared/src/main/scala/fs2/interop/scodec/ByteVectorChunk.scala
@@ -1,9 +1,14 @@
 package fs2
 package interop.scodec
 
+import scala.reflect.ClassTag
 import scodec.bits.ByteVector
 
-final class ByteVectorChunk private (val toByteVector: ByteVector) extends Chunk[Byte] {
+final class ByteVectorChunk private (val toByteVector: ByteVector)
+    extends Chunk[Byte]
+    with Chunk.KnownElementType[Byte] {
+  def elementClassTag = ClassTag.Byte
+
   def apply(i: Int): Byte =
     toByteVector(i)
 


### PR DESCRIPTION
See #1160 for details, but basically, operations like `Stream#map` result in dechunking if an `unconsChunk` is encountered. To fix, this PR changes `Segment#unconsChunk` such that when stepping, all of the emitted chunks from a single step get copied to a new chunk instead of taking the first and pushing the rest in to the tail.

In the test added to `StreamPerformanceSpec`, this change results in an improvement from about 2500ms to 15ms.

To implement an efficient `Chunk.concat`, I lifted the implementation from fs2 0.9 and added support for the primitive chunk types. One note: calling `concat` with `ByteVectorChunk`s results in `instanceOf[Byte]` checks on each element. I have two ideas on how to fix this:
1) Introduce a trait like: `trait KnownClass[A] { self: Chunk[A] => val classTag: ClassTag[A] }` and then use an `instanceOf` check on this type in `concat`
2) Move `ByteVectorChunk` in to fs2-core, including the dependency on `scodec-bits`. Note scodec hasn't broken binary compatibility since Feb 2016.