### PR TITLE
Fix groupAdjacentBy handling empty chunks

### DIFF
--- a/core/jvm/src/test/scala/fs2/PipeSpec.scala
+++ b/core/jvm/src/test/scala/fs2/PipeSpec.scala
@@ -275,7 +275,7 @@ class PipeSpec extends Fs2Spec {
     }
 
     "mapSegments" in forAll { (s: PureStream[Int]) =>
-      runLog(s.get.mapSegments(identity).segments) shouldBe runLog(s.get.segments)
+      runLog(s.get.mapSegments(identity).segments.map(_.force.toVector)) shouldBe runLog(s.get.segments.map(_.force.toVector))
     }
 
     "performance of multi-stage pipeline" in {

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -593,8 +593,12 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
            s: Stream[F, O]): Pull[F, (O2, Segment[O, Unit]), Unit] =
       s.pull.unconsChunk.flatMap {
         case Some((hd, tl)) =>
-          val (k1, out) = current.getOrElse((f(hd(0)), Segment.empty[O]))
-          doChunk(hd, tl, k1, out, None)
+          if (hd.nonEmpty) {
+            val (k1, out) = current.getOrElse((f(hd(0)), Segment.empty[O]))
+            doChunk(hd, tl, k1, out, None)
+          } else {
+            go(current, tl)
+          }
         case None =>
           val l = current
             .map { case (k1, out) => Pull.output1((k1, out)) }


### PR DESCRIPTION
Add a new test generator that gives us a filtered stream, which can emit
empty chunks.

The groupAdjacentBy test goes red with only the generator change; the
code change brings it back to green

Closes #1162 

-----

I don't know the right way to fix the `mapSegments` test failure yet.

I think the test is nonsensical; The test says

```scala
runLog(s.get.mapSegments(identity).segments) shouldBe runLog(s.get.segments)
```

but the `Segment` docstring says

>   The `equals` and `hashCode` methods are not defined for `Segment`.

So this means that `shouldBe` is not safe to use with `Segment` values

What if we change the test to say this?

```scala
runLog(s.get.mapSegments(identity).segments.map(_.force.toVector) shouldBe runLog(s.get.segments.map(_.force.toVector))
```