### PR TITLE
Proof of concept of how to implement Segment#unconsChunk to avoid Cat…

### DIFF
--- a/core/shared/src/main/scala/fs2/Catenable.scala
+++ b/core/shared/src/main/scala/fs2/Catenable.scala
@@ -179,6 +179,7 @@ object Catenable {
   /** Creates a catenable from the specified sequence. */
   def fromSeq[A](s: Seq[A]): Catenable[A] =
     if (s.isEmpty) empty
+    else if (s.size == 1) singleton(s.head)
     else s.view.reverse.map(singleton).reduceLeft((x, y) => Append(y, x))
 
   /** Creates a catenable from the specified elements. */

--- a/core/shared/src/main/scala/fs2/Catenable.scala
+++ b/core/shared/src/main/scala/fs2/Catenable.scala
@@ -179,7 +179,6 @@ object Catenable {
   /** Creates a catenable from the specified sequence. */
   def fromSeq[A](s: Seq[A]): Catenable[A] =
     if (s.isEmpty) empty
-    else if (s.size == 1) singleton(s.head)
     else s.view.reverse.map(singleton).reduceLeft((x, y) => Append(y, x))
 
   /** Creates a catenable from the specified elements. */

--- a/core/shared/src/main/scala/fs2/Segment.scala
+++ b/core/shared/src/main/scala/fs2/Segment.scala
@@ -434,9 +434,9 @@ abstract class Segment[+O, +R] { self =>
   private[fs2] final def foldRightLazy[B](z: B)(f: (O, => B) => B): B =
     force.unconsChunks match {
       case Right((hds, tl)) =>
-        def loopOnChunks(hds: List[Chunk[O]]): B =
-          hds match {
-            case hd :: hds =>
+        def loopOnChunks(hds: Catenable[Chunk[O]]): B =
+          hds.uncons match {
+            case Some((hd, hds)) =>
               val sz = hd.size
               if (sz == 1) f(hd(0), loopOnChunks(hds))
               else {
@@ -445,7 +445,7 @@ abstract class Segment[+O, +R] { self =>
                   else loopOnChunks(hds)
                 loopOnElements(0)
               }
-            case Nil => tl.foldRightLazy(z)(f)
+            case None => tl.foldRightLazy(z)(f)
           }
         loopOnChunks(hds)
 
@@ -1594,7 +1594,7 @@ object Segment {
           unconsChunks match {
             case Left(r) => Left(r)
             case Right((cs, tl)) =>
-              Right(catenatedChunks(Catenable.fromSeq(cs)) -> tl)
+              Right(catenated(cs.map(Segment.chunk)) -> tl)
           }
       }
 
@@ -1612,7 +1612,7 @@ object Segment {
       @annotation.tailrec
       def go(acc: Catenable[Chunk[O]], s: Segment[O, R]): (Catenable[Chunk[O]], R) =
         s.force.unconsChunks match {
-          case Right((hds, tl)) => go(acc ++ Catenable.fromSeq(hds), tl)
+          case Right((hds, tl)) => go(acc ++ hds, tl)
           case Left(r)          => (acc, r)
         }
       go(Catenable.empty, self)
@@ -1688,40 +1688,39 @@ object Segment {
       *
       * @example {{{
       * scala> Segment(1, 2, 3).prepend(Segment(-1, 0)).force.unconsChunks
-      * res0: Either[Unit,(List[Chunk[Int]], Segment[Int,Unit])] = Right((List(Chunk(-1, 0)),Chunk(1, 2, 3)))
+      * res0: Either[Unit,(Catenable[Chunk[Int]], Segment[Int,Unit])] = Right((Catenable(Chunk(-1, 0)),Chunk(1, 2, 3)))
       * scala> Segment.empty[Int].force.unconsChunks
-      * res1: Either[Unit,(List[Chunk[Int]], Segment[Int,Unit])] = Left(())
+      * res1: Either[Unit,(Catenable[Chunk[Int]], Segment[Int,Unit])] = Left(())
       * }}}
       */
-    final def unconsChunks: Either[R, (List[Chunk[O]], Segment[O, R])] =
+    final def unconsChunks: Either[R, (Catenable[Chunk[O]], Segment[O, R])] =
       self match {
         case c: SingleChunk[O] =>
           if (c.chunk.isEmpty) Left(().asInstanceOf[R])
           else
             Right(
-              List(c.chunk) -> empty[O]
+              Catenable.singleton(c.chunk) -> empty[O]
                 .asInstanceOf[Segment[O, R]])
         case _ =>
-          var out = List.newBuilder[Chunk[O]]
+          var out: Catenable[Chunk[O]] = Catenable.empty
           var result: Option[R] = None
           var ok = true
           val trampoline = new Trampoline
           val step = self
             .stage(Depth(0), trampoline.defer, o => {
-              out = out += Chunk.singleton(o); ok = false
-            }, os => { out = out += os; ok = false }, r => {
+              out = out :+ Chunk.singleton(o); ok = false
+            }, os => { out = out :+ os; ok = false }, r => {
               result = Some(r); throw Done
             })
             .value
           try while (ok) stepAll(step, trampoline)
           catch { case Done => }
-          val outList = out.result
           result match {
             case None =>
-              Right(outList -> step.remainder)
+              Right(out -> step.remainder)
             case Some(r) =>
-              if (outList.isEmpty) Left(r)
-              else Right(outList -> pure(r))
+              if (out.isEmpty) Left(r)
+              else Right(out -> pure(r))
           }
       }
   }


### PR DESCRIPTION
Not for merge -- for review/awareness only.

@djspiewak This is basically what I was thinking -- in effect, `Segment#unconsChunk` gets its own interpreter which means we have custom callbacks for `emit` and `emits` that can build the resulting chunk directly.

In this proof of concept, I used `collection.mutable.Buffer` but this is terrible -- boxing and inefficient copying. To make this mergeable, we'd at least need to specialize the logic for primitives and use an array instead of a buffer (and hence add size hinting).