### PR TITLE
Put Linebacker in place as the blocking mechanism for io project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -253,6 +253,7 @@ lazy val io = project
   .settings(mimaSettings)
   .settings(
     name := "fs2-io",
+    libraryDependencies ++= Seq("io.chrisdavenport" %% "linebacker" % "0.2.0-M1"),
     OsgiKeys.exportPackage := Seq("fs2.io.*"),
     OsgiKeys.privatePackage := Seq(),
     OsgiKeys.importPackage := {

--- a/io/src/test/scala/fs2/io/IoSpec.scala
+++ b/io/src/test/scala/fs2/io/IoSpec.scala
@@ -5,7 +5,12 @@ import cats.effect.IO
 import fs2.Fs2Spec
 import fs2.TestUtil._
 
+import _root_.io.chrisdavenport.linebacker.Linebacker
+
 class IoSpec extends Fs2Spec {
+  // Use an actual blocking pool for production
+  implicit val linebacker = Linebacker.fromExecutionContext[IO](executionContext)
+
   "readInputStream" - {
     "non-buffered" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
       val is: InputStream = new ByteArrayInputStream(bytes)
@@ -22,18 +27,17 @@ class IoSpec extends Fs2Spec {
       example shouldBe bytes
     }
   }
-
   "readInputStreamAsync" - {
     "non-buffered" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
       val is: InputStream = new ByteArrayInputStream(bytes)
-      val stream = readInputStreamAsync(IO(is), chunkSize.get, executionContext)
+      val stream = readInputStreamAsync(IO(is), chunkSize.get)
       val example = stream.compile.toVector.unsafeRunSync.toArray
       example shouldBe bytes
     }
 
     "buffered" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
       val is: InputStream = new ByteArrayInputStream(bytes)
-      val stream = readInputStreamAsync(IO(is), chunkSize.get, executionContext)
+      val stream = readInputStreamAsync(IO(is), chunkSize.get)
       val example =
         stream.buffer(chunkSize.get * 2).compile.toVector.unsafeRunSync.toArray
       example shouldBe bytes
@@ -52,7 +56,7 @@ class IoSpec extends Fs2Spec {
   "unsafeReadInputStreamAsync" - {
     "non-buffered" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
       val is: InputStream = new ByteArrayInputStream(bytes)
-      val stream = unsafeReadInputStreamAsync(IO(is), chunkSize.get, executionContext)
+      val stream = unsafeReadInputStreamAsync(IO(is), chunkSize.get)
       val example = stream.compile.toVector.unsafeRunSync.toArray
       example shouldBe bytes
     }


### PR DESCRIPTION
Order of parameters may not be to taste. 

This is off published milestone since we're off cats-effect but will happily go to 1.0 with extended support as necessary with cats-effect and fs2.

Left the blocking in place in the odd locations, but we can add it in as well inside where ConcurrentEffect is currently being utilized.