### PR TITLE
Small performance improvements in Segment#unconsChunks

### DIFF
--- a/core/shared/src/main/scala/fs2/Catenable.scala
+++ b/core/shared/src/main/scala/fs2/Catenable.scala
@@ -179,6 +179,7 @@ object Catenable {
   /** Creates a catenable from the specified sequence. */
   def fromSeq[A](s: Seq[A]): Catenable[A] =
     if (s.isEmpty) empty
+    else if (s.size == 1) singleton(s.head)
     else s.view.reverse.map(singleton).reduceLeft((x, y) => Append(y, x))
 
   /** Creates a catenable from the specified elements. */

--- a/core/shared/src/main/scala/fs2/Catenable.scala
+++ b/core/shared/src/main/scala/fs2/Catenable.scala
@@ -15,28 +15,31 @@ import scala.annotation.tailrec
 sealed abstract class Catenable[+A] {
 
   /** Returns the head and tail of this catenable if non empty, none otherwise. Amortized O(1). */
-  final def uncons: Option[(A, Catenable[A])] = {
-    var c: Catenable[A] = this
-    val rights = new collection.mutable.ArrayBuffer[Catenable[A]]
-    var result: Option[(A, Catenable[A])] = null
-    while (result eq null) {
-      c match {
-        case Empty =>
-          if (rights.isEmpty) {
-            result = None
-          } else {
-            c = rights.last
-            rights.trimEnd(1)
-          }
-        case Singleton(a) =>
-          val next =
-            if (rights.isEmpty) empty
-            else rights.reduceLeft((x, y) => Append(y, x))
-          result = Some(a -> next)
-        case Append(l, r) => c = l; rights += r
+  final def uncons: Option[(A, Catenable[A])] = this match {
+    case Empty        => None
+    case Singleton(a) => Some((a, Empty))
+    case other =>
+      var c: Catenable[A] = this
+      val rights = new collection.mutable.ArrayBuffer[Catenable[A]]
+      var result: Option[(A, Catenable[A])] = null
+      while (result eq null) {
+        c match {
+          case Empty =>
+            if (rights.isEmpty) {
+              result = None
+            } else {
+              c = rights.last
+              rights.trimEnd(1)
+            }
+          case Singleton(a) =>
+            val next =
+              if (rights.isEmpty) empty
+              else rights.reduceLeft((x, y) => Append(y, x))
+            result = Some(a -> next)
+          case Append(l, r) => c = l; rights += r
+        }
       }
-    }
-    result
+      result
   }
 
   /** Returns true if there are no elements in this collection. */
@@ -107,27 +110,30 @@ sealed abstract class Catenable[+A] {
   }
 
   /** Applies the supplied function to each element, left to right. */
-  final def foreach(f: A => Unit): Unit = {
-    var c: Catenable[A] = this
-    val rights = new collection.mutable.ArrayBuffer[Catenable[A]]
-    while (c ne null) {
-      c match {
-        case Empty =>
-          if (rights.isEmpty) {
-            c = null
-          } else {
-            c = rights.last
-            rights.trimEnd(1)
-          }
-        case Singleton(a) =>
-          f(a)
-          c =
-            if (rights.isEmpty) Empty
-            else rights.reduceLeft((x, y) => Append(y, x))
-          rights.clear()
-        case Append(l, r) => c = l; rights += r
+  final def foreach(f: A => Unit): Unit = this match {
+    case Empty        => ()
+    case Singleton(a) => f(a)
+    case _ =>
+      var c: Catenable[A] = this
+      val rights = new collection.mutable.ArrayBuffer[Catenable[A]]
+      while (c ne null) {
+        c match {
+          case Empty =>
+            if (rights.isEmpty) {
+              c = null
+            } else {
+              c = rights.last
+              rights.trimEnd(1)
+            }
+          case Singleton(a) =>
+            f(a)
+            c =
+              if (rights.isEmpty) Empty
+              else rights.reduceLeft((x, y) => Append(y, x))
+            rights.clear()
+          case Append(l, r) => c = l; rights += r
+        }
       }
-    }
   }
 
   /** Converts to a list. */

--- a/core/shared/src/main/scala/fs2/Segment.scala
+++ b/core/shared/src/main/scala/fs2/Segment.scala
@@ -433,9 +433,9 @@ abstract class Segment[+O, +R] { self =>
   private[fs2] final def foldRightLazy[B](z: B)(f: (O, => B) => B): B =
     force.unconsChunks match {
       case Right((hds, tl)) =>
-        def loopOnChunks(hds: Catenable[Chunk[O]]): B =
-          hds.uncons match {
-            case Some((hd, hds)) =>
+        def loopOnChunks(hds: List[Chunk[O]]): B =
+          hds match {
+            case hd :: hds =>
               val sz = hd.size
               if (sz == 1) f(hd(0), loopOnChunks(hds))
               else {
@@ -444,7 +444,7 @@ abstract class Segment[+O, +R] { self =>
                   else loopOnChunks(hds)
                 loopOnElements(0)
               }
-            case None => tl.foldRightLazy(z)(f)
+            case Nil => tl.foldRightLazy(z)(f)
           }
         loopOnChunks(hds)
 
@@ -1593,7 +1593,7 @@ object Segment {
           unconsChunks match {
             case Left(r) => Left(r)
             case Right((cs, tl)) =>
-              Right(catenated(cs.map(Segment.chunk)) -> tl)
+              Right(catenatedChunks(Catenable.fromSeq(cs)) -> tl)
           }
       }
 
@@ -1611,7 +1611,7 @@ object Segment {
       @annotation.tailrec
       def go(acc: Catenable[Chunk[O]], s: Segment[O, R]): (Catenable[Chunk[O]], R) =
         s.force.unconsChunks match {
-          case Right((hds, tl)) => go(acc ++ hds, tl)
+          case Right((hds, tl)) => go(acc ++ Catenable.fromSeq(hds), tl)
           case Left(r)          => (acc, r)
         }
       go(Catenable.empty, self)
@@ -1658,7 +1658,7 @@ object Segment {
         unconsChunks match {
           case Left(r) => Left(r)
           case Right((cs, tl)) =>
-            Right(Chunk.concat(cs.toList) -> tl)
+            Right(Chunk.concat(cs) -> tl)
         }
     }
 
@@ -1670,39 +1670,40 @@ object Segment {
       *
       * @example {{{
       * scala> Segment(1, 2, 3).prepend(Segment(-1, 0)).force.unconsChunks
-      * res0: Either[Unit,(Catenable[Chunk[Int]], Segment[Int,Unit])] = Right((Catenable(Chunk(-1, 0)),Chunk(1, 2, 3)))
+      * res0: Either[Unit,(List[Chunk[Int]], Segment[Int,Unit])] = Right((List(Chunk(-1, 0)),Chunk(1, 2, 3)))
       * scala> Segment.empty[Int].force.unconsChunks
-      * res1: Either[Unit,(Catenable[Chunk[Int]], Segment[Int,Unit])] = Left(())
+      * res1: Either[Unit,(List[Chunk[Int]], Segment[Int,Unit])] = Left(())
       * }}}
       */
-    final def unconsChunks: Either[R, (Catenable[Chunk[O]], Segment[O, R])] =
+    final def unconsChunks: Either[R, (List[Chunk[O]], Segment[O, R])] =
       self match {
         case c: SingleChunk[O] =>
           if (c.chunk.isEmpty) Left(().asInstanceOf[R])
           else
             Right(
-              Catenable.singleton(c.chunk) -> empty[O]
+              List(c.chunk) -> empty[O]
                 .asInstanceOf[Segment[O, R]])
         case _ =>
-          var out: Catenable[Chunk[O]] = Catenable.empty
+          var out = List.newBuilder[Chunk[O]]
           var result: Option[R] = None
           var ok = true
           val trampoline = new Trampoline
           val step = self
             .stage(Depth(0), trampoline.defer, o => {
-              out = out :+ Chunk.singleton(o); ok = false
-            }, os => { out = out :+ os; ok = false }, r => {
+              out = out += Chunk.singleton(o); ok = false
+            }, os => { out = out += os; ok = false }, r => {
               result = Some(r); throw Done
             })
             .value
           try while (ok) stepAll(step, trampoline)
           catch { case Done => }
+          val outList = out.result
           result match {
             case None =>
-              Right(out -> step.remainder)
+              Right(outList -> step.remainder)
             case Some(r) =>
-              if (out.isEmpty) Left(r)
-              else Right(out -> pure(r))
+              if (outList.isEmpty) Left(r)
+              else Right(outList -> pure(r))
           }
       }
   }


### PR DESCRIPTION
By changing `unconsChunks` to use a list instead of catenable, we avoid overhead of tracking the rights in `Segment#uncons` and `Segment#foreach`.

Additionally, `Catenable#{uncons,foreach}` was allocating an `ArrayBuffer` even if the catenable was a singleton or empty. This resulted in a 16-element array allocation.