### PR TITLE
Changed core interpreter and API to be chunk based instead of segment based

### DIFF
--- a/core/jvm/src/main/scala/fs2/compress.scala
+++ b/core/jvm/src/main/scala/fs2/compress.scala
@@ -31,19 +31,19 @@ object compress {
 
   private def _deflate_stream[F[_]](deflater: Deflater,
                                     buffer: Array[Byte]): Stream[F, Byte] => Pull[F, Byte, Unit] =
-    _.pull.unconsChunk.flatMap {
+    _.pull.uncons.flatMap {
       case Some((hd, tl)) =>
         deflater.setInput(hd.toArray)
         val result =
           _deflate_collect(deflater, buffer, ArrayBuffer.empty, false).toArray
-        Pull.outputChunk(Chunk.bytes(result)) >> _deflate_stream(deflater, buffer)(tl)
+        Pull.output(Chunk.bytes(result)) >> _deflate_stream(deflater, buffer)(tl)
       case None =>
         deflater.setInput(Array.empty)
         deflater.finish()
         val result =
           _deflate_collect(deflater, buffer, ArrayBuffer.empty, true).toArray
         deflater.end()
-        Pull.outputChunk(Chunk.bytes(result))
+        Pull.output(Chunk.bytes(result))
     }
 
   @tailrec
@@ -65,7 +65,7 @@ object compress {
     *                   decompressor. Default size is 32 KB.
     */
   def inflate[F[_]](nowrap: Boolean = false, bufferSize: Int = 1024 * 32): Pipe[F, Byte, Byte] =
-    _.pull.unconsChunk.flatMap {
+    _.pull.uncons.flatMap {
       case None => Pull.pure(None)
       case Some((hd, tl)) =>
         val inflater = new Inflater(nowrap)
@@ -73,17 +73,17 @@ object compress {
         inflater.setInput(hd.toArray)
         val result =
           _inflate_collect(inflater, buffer, ArrayBuffer.empty).toArray
-        Pull.outputChunk(Chunk.bytes(result)) >> _inflate_stream(inflater, buffer)(tl)
+        Pull.output(Chunk.bytes(result)) >> _inflate_stream(inflater, buffer)(tl)
     }.stream
 
   private def _inflate_stream[F[_]](inflater: Inflater,
                                     buffer: Array[Byte]): Stream[F, Byte] => Pull[F, Byte, Unit] =
-    _.pull.unconsChunk.flatMap {
+    _.pull.uncons.flatMap {
       case Some((hd, tl)) =>
         inflater.setInput(hd.toArray)
         val result =
           _inflate_collect(inflater, buffer, ArrayBuffer.empty).toArray
-        Pull.outputChunk(Chunk.bytes(result)) >> _inflate_stream(inflater, buffer)(tl)
+        Pull.output(Chunk.bytes(result)) >> _inflate_stream(inflater, buffer)(tl)
       case None =>
         if (!inflater.finished)
           Pull.raiseError(new DataFormatException("Insufficient data"))

--- a/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
+++ b/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
@@ -139,8 +139,8 @@ object StepperSanityTest extends App {
       stepper.step match {
         case Stepper.Done      => Pull.done
         case Stepper.Fail(err) => Pull.raiseError(err)
-        case Stepper.Emits(segment, next) =>
-          Pull.output(segment) >> go(next, s)
+        case Stepper.Emits(chunk, next) =>
+          Pull.output(chunk) >> go(next, s)
         case Stepper.Await(receive) =>
           s.pull.uncons.flatMap {
             case Some((hd, tl)) => go(receive(Some(hd)), tl)
@@ -161,7 +161,7 @@ object StepperSanityTest2 extends App {
       case Stepper.Done        => ()
       case Stepper.Fail(err)   => throw err
       case Stepper.Emits(s, n) => go(i)(n)
-      case Stepper.Await(r)    => go(i)(r(Some(Segment(i))))
+      case Stepper.Await(r)    => go(i)(r(Some(Chunk(i))))
     }
   go(0)(Pipe.stepper(_.map(_ + 1)))
 }

--- a/core/jvm/src/test/scala/fs2/MergeJoinSpec.scala
+++ b/core/jvm/src/test/scala/fs2/MergeJoinSpec.scala
@@ -77,10 +77,7 @@ class MergeJoinSpec extends Fs2Spec {
       forAll { (s1: PureStream[Int], f: Failure) =>
         an[Err] should be thrownBy {
           s1.get
-          // To ensure errors are generated before the merge occurs, we chunk/unchunk here to force any segment computations
-          // This is necessary b/c this test depends on any errors in f occurring before the first flatMapped output of the
-          // merged stream
-            .merge(f.get.chunks.flatMap(Stream.chunk(_)))
+            .merge(f.get)
             .flatMap { _ =>
               Stream.eval(IO.async[Unit](_ => ()))
             }
@@ -96,10 +93,7 @@ class MergeJoinSpec extends Fs2Spec {
       forAll { (s1: PureStream[Int], f: Failure) =>
         an[Err] should be thrownBy {
           s1.get
-          // To ensure errors are generated before the merge occurs, we chunk/unchunk here to force any segment computations
-          // This is necessary b/c this test depends on any errors in f occurring before the first flatMapped output of the
-          // merged stream
-            .merge(f.get.chunks.flatMap(Stream.chunk(_)))
+            .merge(f.get)
             .flatMap { _ =>
               Stream.constant(true)
             }

--- a/core/jvm/src/test/scala/fs2/ResourceSafetySpec.scala
+++ b/core/jvm/src/test/scala/fs2/ResourceSafetySpec.scala
@@ -96,7 +96,7 @@ class ResourceSafetySpec extends Fs2Spec with EventuallySupport {
       Stream(1, 2, 3)
         .onFinalize(IO { n = 1 })
         .pull
-        .echoSegment
+        .echoChunk
         .stream
         .compile
         .drain

--- a/core/jvm/src/test/scala/fs2/StreamPerformanceSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamPerformanceSpec.scala
@@ -186,7 +186,7 @@ class StreamPerformanceSpec extends Fs2Spec {
       }
     }
 
-    "chunky map with unconsChunk" - {
+    "chunky map with uncons" - {
       Ns.foreach { N =>
         N.toString in {
           runLog(emits(Vector.range(0, N)).map(i => i).chunks.flatMap(chunk(_))) shouldBe Vector

--- a/core/jvm/src/test/scala/fs2/async/QueueSpec.scala
+++ b/core/jvm/src/test/scala/fs2/async/QueueSpec.scala
@@ -40,10 +40,10 @@ class QueueSpec extends Fs2Spec {
             runLog(Stream.eval(async.unboundedQueue[IO, Option[Int]]).flatMap { q =>
               s.get.noneTerminate
                 .evalMap(q.enqueue1)
-                .drain ++ q.dequeueAvailable.unNoneTerminate.segments
+                .drain ++ q.dequeueAvailable.unNoneTerminate.chunks
             })
           result.size should be < 2
-          result.flatMap(_.force.toVector) shouldBe s.get.toVector
+          result.flatMap(_.toVector) shouldBe s.get.toVector
         }
       }
     }

--- a/core/shared/src/test/scala/fs2/CompilationTest.scala
+++ b/core/shared/src/test/scala/fs2/CompilationTest.scala
@@ -53,8 +53,8 @@ object ThisModuleShouldCompile {
   t2.attachL(p2)
   t2.attachR(p2)
 
-  val p: Pull[Pure,Nothing,Option[(Segment[Int,Unit],Stream[Pure,Int])]] = Stream(1, 2, 3).pull.uncons
-  val q: Pull[IO,Nothing,Option[(Segment[Int,Unit],Stream[Pure,Int])]] = p
+  val p: Pull[Pure,Nothing,Option[(Chunk[Int],Stream[Pure,Int])]] = Stream(1, 2, 3).pull.uncons
+  val q: Pull[IO,Nothing,Option[(Chunk[Int],Stream[Pure,Int])]] = p
 
   val streamId: Stream[Id, Int] = Stream(1,2,3)
   (streamId.covaryId[IO]): Stream[IO, Int]

--- a/core/shared/src/test/scala/fs2/SegmentSpec.scala
+++ b/core/shared/src/test/scala/fs2/SegmentSpec.scala
@@ -223,7 +223,7 @@ class SegmentSpec extends Fs2Spec {
       Segment.catenated(Segment.unfold(0)(i => if (i < 1000) Some((i, i + 1)) else None).takeWhile(_ != 5, true).force.unconsAll._1.map(Segment.chunk)).force.toList shouldBe List(0, 1, 2, 3, 4, 5)
     }
 
-    "unconsChunk" in {
+    "uncons" in {
       forAll { (xss: List[List[Int]]) =>
         val seg = xss.foldRight(Segment.empty[Int])((xs, acc) => Segment.array(xs.toArray) ++ acc)
         // Consecutive empty chunks are collapsed to a single empty chunk

--- a/core/shared/src/test/scala/fs2/TextSpec.scala
+++ b/core/shared/src/test/scala/fs2/TextSpec.scala
@@ -49,7 +49,7 @@ class TextSpec extends Fs2Spec {
       }
 
       "1 byte sequences" in forAll { (s: String) =>
-        Stream.chunk(utf8Bytes(s)).chunkLimit(1).flatMap(Stream.chunk).through(utf8Decode).toList shouldBe s.grouped(1).toList
+        Stream.chunk(utf8Bytes(s)).chunkLimit(1).flatMap(Stream.chunk).through(utf8Decode).filter(_.nonEmpty).toList shouldBe s.grouped(1).toList
       }
 
       "n byte sequences" in forAll { (s: String) =>

--- a/docs/ReadmeExample.md
+++ b/docs/ReadmeExample.md
@@ -98,7 +98,7 @@ There are a number of ways of interpreting the stream. In this case, we call `co
 
 ```scala
 scala> val task: IO[Unit] = written.compile.drain
-task: cats.effect.IO[Unit] = IO$1013542189
+task: cats.effect.IO[Unit] = IO$1492455941
 ```
 
 We still haven't *done* anything yet. Effects only occur when we run the resulting task. We can run a `IO` by calling `unsafeRunSync()` -- the name is telling us that calling it performs effects and hence, it is not referentially transparent.

--- a/io/src/main/scala/fs2/io/file/file.scala
+++ b/io/src/main/scala/fs2/io/file/file.scala
@@ -88,7 +88,7 @@ package object file {
   private def _writeAll0[F[_]](in: Stream[F, Byte],
                                out: FileHandle[F],
                                offset: Long): Pull[F, Nothing, Unit] =
-    in.pull.unconsChunk.flatMap {
+    in.pull.uncons.flatMap {
       case None => Pull.done
       case Some((hd, tl)) =>
         _writeAll1(hd, out, offset) >> _writeAll0(tl, out, offset + hd.size)

--- a/io/src/main/scala/fs2/io/file/pulls.scala
+++ b/io/src/main/scala/fs2/io/file/pulls.scala
@@ -21,7 +21,7 @@ object pulls {
       h: FileHandle[F]): Pull[F, Byte, Unit] =
     Pull.eval(h.read(chunkSize, offset)).flatMap {
       case Some(o) =>
-        Pull.outputChunk(o) >> _readAllFromFileHandle0(chunkSize, offset + o.size)(h)
+        Pull.output(o) >> _readAllFromFileHandle0(chunkSize, offset + o.size)(h)
       case None => Pull.done
     }
 
@@ -34,7 +34,7 @@ object pulls {
   private def _writeAllToFileHandle1[F[_]](in: Stream[F, Byte],
                                            out: FileHandle[F],
                                            offset: Long): Pull[F, Nothing, Unit] =
-    in.pull.unconsChunk.flatMap {
+    in.pull.uncons.flatMap {
       case None => Pull.done
       case Some((hd, tl)) =>
         _writeAllToFileHandle2(hd, out, offset) >> _writeAllToFileHandle1(tl, out, offset + hd.size)


### PR DESCRIPTION
Fixes #1175

See #1175 for performance test results before and after this change.

Overall, chunk based streams perform better than segment based streams. It's possible to construct specialized benchmarks where segment based streams perform better but such benchmarks aren't transferrable to real stream programs. Given that we get better performance and the API ends up *significantly* simpler to work with, these issues outweigh the API breakage concerns, which I do take very seriously. Also note that we no longer have weirdness around when evaluation occurs and when exceptions are thrown due to the lazy nature of `Segment`.

I left `Segment` in place, and kept the `Stream.segment` and `Pull.segment` constructors, which now lazily unfold the segment in to chunks. This is nice in that users can opt-in to full fusion for workloads that require it, while not paying the cost of `Segment` for the more common cases.

Note: I'll work on a migration guide soon, which will include directions on dealing with the conversion. We should probably also consider providing a scalafix to help with the upgrade. We won't be able to rewrite pulls that used `Segment` to pulls that use `Chunk` but we will be able to handle method renames like `outputChunk` to `output`.

Credit to @djspiewak for getting me to re-benchmark FS2 with and without `Segment` and challenging the assumptions that `Segment` based streams are faster due to fusion.