### PR TITLE
Renamed join/joinUnbounded to parJoin/parJoinUnbounded and defined fl…

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/ConcurrentBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/ConcurrentBenchmark.scala
@@ -10,10 +10,10 @@ class ConcurrentBenchmark {
 
   @GenerateN(1, 2, 4, 7, 16, 32, 64, 128, 256)
   @Benchmark
-  def join(N: Int): Int = {
+  def parJoin(N: Int): Int = {
     val each = Stream
       .segment(Segment.seq(0 to 1000).map(i => Stream.eval(IO.pure(i))))
       .covary[IO]
-    each.join(N).compile.last.unsafeRunSync.get
+    each.parJoin(N).compile.last.unsafeRunSync.get
   }
 }

--- a/core/js/src/test/scala/fs2/ScalaJsSanityTests.scala
+++ b/core/js/src/test/scala/fs2/ScalaJsSanityTests.scala
@@ -10,12 +10,12 @@ import TestUtil._
 // tested as a result of the ScalaTest limitation.
 class ScalaJsSanityTests extends AsyncFs2Spec {
 
-  "join" in {
+  "parJoin" in {
     val src: Stream[IO, Stream[IO, Int]] =
       Stream.range(1, 100).covary[IO].map { i =>
         Stream.repeatEval(IO(i)).take(10)
       }
-    runLogF(src.join(10)).map { result =>
+    runLogF(src.parJoin(10)).map { result =>
       result.sorted shouldBe (1 until 100).toVector
         .flatMap(Vector.fill(10)(_))
         .sorted

--- a/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
+++ b/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
@@ -46,11 +46,11 @@ object DrainOnCompleteSanityTest extends App {
   Stream.empty.covary[IO].merge(s).compile.drain.unsafeRunSync()
 }
 
-object ConcurrentJoinSanityTest extends App {
+object ParJoinSanityTest extends App {
   import ExecutionContext.Implicits.global
   Stream
     .constant(Stream.empty[IO])
-    .join(5)
+    .parJoin(5)
     .compile
     .drain
     .unsafeRunSync
@@ -211,7 +211,7 @@ object HungMerge extends App {
   hung.merge(progress).compile.drain.unsafeRunSync()
 }
 
-object ZipThenBindThenJoin extends App {
+object ZipThenBindThenParJoin extends App {
   import scala.concurrent.ExecutionContext.Implicits.global
   import scala.concurrent.duration._
 
@@ -222,7 +222,7 @@ object ZipThenBindThenJoin extends App {
     .zip(sources)
     .flatMap {
       case (_, s) =>
-        s.map(Stream.constant(_).covary[IO]).joinUnbounded
+        s.map(Stream.constant(_).covary[IO]).parJoinUnbounded
     }
     .compile
     .drain

--- a/core/jvm/src/test/scala/fs2/ResourceSafetySpec.scala
+++ b/core/jvm/src/test/scala/fs2/ResourceSafetySpec.scala
@@ -176,8 +176,8 @@ class ResourceSafetySpec extends Fs2Spec with EventuallySupport {
                   .getOrElse(bracket(inner)(s.get))
               else bracket(inner)(s.get)
           })
-          swallow { runLog { s2.join(n.get).take(10) } }
-          swallow { runLog { s2.join(n.get) } }
+          swallow { runLog { s2.parJoin(n.get).take(10) } }
+          swallow { runLog { s2.parJoin(n.get) } }
           eventually(Timeout(3 seconds)) { outer.get shouldBe 0L }
           outer.get shouldBe 0L
           eventually(Timeout(3 seconds)) { inner.get shouldBe 0L }

--- a/core/jvm/src/test/scala/fs2/StreamSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamSpec.scala
@@ -132,7 +132,7 @@ class StreamSpec extends Fs2Spec with Inside {
                       Stream.raiseError(new Err).covary[IO],
                       Stream.emit(2).covary[IO])
         .covary[IO]
-        .join(4)
+        .parJoin(4)
         .attempt
         .compile
         .toVector

--- a/core/jvm/src/test/scala/fs2/StreamTimerSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamTimerSpec.scala
@@ -59,7 +59,7 @@ class StreamTimerSpec extends AsyncFs2Spec {
           IO.async[Unit](cb => executionContext.execute(() => cb(Right(()))))
         }
         .take(200)
-      Stream(s, s, s, s, s).join(5).compile.toVector.unsafeToFuture().map { _ =>
+      Stream(s, s, s, s, s).parJoin(5).compile.toVector.unsafeToFuture().map { _ =>
         Succeeded
       }
     }

--- a/core/jvm/src/test/scala/fs2/async/TopicSpec.scala
+++ b/core/jvm/src/test/scala/fs2/async/TopicSpec.scala
@@ -30,7 +30,7 @@ class TopicSpec extends Fs2Spec {
       val result = (Stream
         .range(0, subs)
         .map(idx => subscriber.map(idx -> _)) ++ publisher.drain)
-        .join(subs + 1)
+        .parJoin(subs + 1)
         .compile
         .toVector
         .unsafeRunSync()
@@ -66,7 +66,7 @@ class TopicSpec extends Fs2Spec {
       val result = (Stream
         .range(0, subs)
         .map(idx => subscriber.map(idx -> _)) ++ publisher.drain)
-        .join(subs + 1)
+        .parJoin(subs + 1)
         .compile
         .toVector
         .unsafeRunSync()

--- a/core/shared/src/test/scala/fs2/CompilationTest.scala
+++ b/core/shared/src/test/scala/fs2/CompilationTest.scala
@@ -70,8 +70,8 @@ object ThisModuleShouldCompile {
   }
 
   // Join a pure stream of effectful streams without type annotations
-  Stream(s, s).joinUnbounded
+  Stream(s, s).parJoinUnbounded
 
   // Join an effectul stream of pure streams requires type annotation on inner stream
-  Stream[IO, Stream[IO, Nothing]](Stream.empty).joinUnbounded
+  Stream[IO, Stream[IO, Nothing]](Stream.empty).parJoinUnbounded
 }

--- a/io/src/main/scala/fs2/io/tcp/tcp.scala
+++ b/io/src/main/scala/fs2/io/tcp/tcp.scala
@@ -69,7 +69,7 @@ package object tcp {
     *
     * The outer stream first emits a left value specifying the bound address followed by right values -- one per client connection.
     */
-  def serverWithLocalAddress[F[_]](flatMap: InetSocketAddress,
+  def serverWithLocalAddress[F[_]](bind: InetSocketAddress,
                                    maxQueued: Int = 0,
                                    reuseAddress: Boolean = true,
                                    receiveBufferSize: Int = 256 * 1024)(
@@ -77,5 +77,5 @@ package object tcp {
       F: ConcurrentEffect[F],
       timer: Timer[F]
   ): Stream[F, Either[InetSocketAddress, Resource[F, Socket[F]]]] =
-    Socket.server(flatMap, maxQueued, reuseAddress, receiveBufferSize)
+    Socket.server(bind, maxQueued, reuseAddress, receiveBufferSize)
 }

--- a/io/src/test/scala/fs2/io/tcp/SocketSpec.scala
+++ b/io/src/test/scala/fs2/io/tcp/SocketSpec.scala
@@ -49,7 +49,7 @@ class SocketSpec extends Fs2Spec with BeforeAndAfterAll {
                 .to(socket.writes())
                 .onFinalize(socket.endOfOutput)
             }
-        }.joinUnbounded
+        }.parJoinUnbounded
       }
 
       val clients: Stream[IO, Array[Byte]] = {
@@ -67,11 +67,11 @@ class SocketSpec extends Fs2Spec with BeforeAndAfterAll {
               }
             }
           }
-          .join(10)
+          .parJoin(10)
       }
 
       val result = Stream(echoServer.drain, clients)
-        .join(2)
+        .parJoin(2)
         .take(clientCount)
         .compile
         .toVector
@@ -102,7 +102,7 @@ class SocketSpec extends Fs2Spec with BeforeAndAfterAll {
                   .onFinalize(socket.endOfOutput)
               })
           }
-          .joinUnbounded
+          .parJoinUnbounded
           .drain
 
       val sizes = Vector(1, 2, 3, 4, 3, 2, 1)
@@ -117,7 +117,7 @@ class SocketSpec extends Fs2Spec with BeforeAndAfterAll {
 
       val result =
         Stream(junkServer, klient)
-          .join(2)
+          .parJoin(2)
           .take(sizes.length)
           .compile
           .toVector

--- a/io/src/test/scala/fs2/io/udp/UdpSpec.scala
+++ b/io/src/test/scala/fs2/io/udp/UdpSpec.scala
@@ -78,7 +78,7 @@ class UdpSpec extends Fs2Spec with BeforeAndAfterAll {
             val clients = Stream
               .constant(client)
               .take(numClients)
-              .join(numParallelClients)
+              .parJoin(numParallelClients)
             server.mergeHaltBoth(clients)
           }
         }

--- a/site/src/guide.md
+++ b/site/src/guide.md
@@ -382,12 +382,12 @@ Stream(1,2,3).merge(Stream.eval(IO { Thread.sleep(200); 4 })).compile.toVector.u
 
 The `merge` function supports concurrency. FS2 has a number of other useful concurrency functions like `concurrently` (runs another stream concurrently and discards its output), `interrupt` (halts if the left branch produces `false`), `either` (like `merge` but returns an `Either`), `mergeHaltBoth` (halts if either branch halts), and others.
 
-The function `join` runs multiple streams concurrently. The signature is:
+The function `parJoin` runs multiple streams concurrently. The signature is:
 
 ```Scala
 // note Concurrent[F] bound
 import cats.effect.Concurrent
-def join[F[_]:Concurrent,O](maxOpen: Int)(outer: Stream[F,Stream[F,O]]): Stream[F,O]
+def parJoin[F[_]: Concurrent,O](maxOpen: Int)(outer: Stream[F, Stream[F, O]]): Stream[F, O]
 ```
 
 It flattens the nested stream, letting up to `maxOpen` inner streams run at a time.


### PR DESCRIPTION
…atten on Stream

Fixes #1185

Note the concurrency page of the site is outdated. We can update that in a separate PR as we'll want to cover changes to Ref, Semaphore, etc.