### PR TITLE
Bugfix/interrupt fold

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/FreeCBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/FreeCBenchmark.scala
@@ -14,7 +14,7 @@ class FreeCBenchmark {
   @Benchmark
   def nestedMaps = {
     val nestedMapsFreeC =
-      (0 to N).foldLeft(FreeC.Pure[IO, Int](0): FreeC[IO, Int]) { (acc, i) =>
+      (0 to N).foldLeft(FreeC.pure[IO, Int](0): FreeC[IO, Int]) { (acc, i) =>
         acc.map(_ + i)
       }
     nestedMapsFreeC.run
@@ -23,8 +23,8 @@ class FreeCBenchmark {
   @Benchmark
   def nestedFlatMaps = {
     val nestedFlatMapsFreeC =
-      (0 to N).foldLeft(FreeC.Pure[IO, Int](0): FreeC[IO, Int]) { (acc, i) =>
-        acc.flatMap(j => FreeC.Pure(i + j))
+      (0 to N).foldLeft(FreeC.pure[IO, Int](0): FreeC[IO, Int]) { (acc, i) =>
+        acc.flatMap(j => FreeC.pure(i + j))
       }
     nestedFlatMapsFreeC.run
   }

--- a/core/jvm/src/test/scala/fs2/ConcurrentlySpec.scala
+++ b/core/jvm/src/test/scala/fs2/ConcurrentlySpec.scala
@@ -73,7 +73,7 @@ class ConcurrentlySpec extends Fs2Spec with EventuallySupport {
                 s.get
                   .covary[IO]
                   .concurrently(
-                    (Stream.eval_(IO.sleep(20.millis)) ++
+                    (Stream.eval_(IO.sleep(50.millis)) ++
                       Stream
                         .eval_(halt.complete(())))
                       .onFinalize(

--- a/core/jvm/src/test/scala/fs2/Pipe2Spec.scala
+++ b/core/jvm/src/test/scala/fs2/Pipe2Spec.scala
@@ -459,8 +459,8 @@ class Pipe2Spec extends Fs2Spec {
             .through(p)
         )
 
-//      println(s"RES: $result")
-//      println(s"EXP: ${result.headOption.toVector ++ result.tail.filter(_ != 0)}")
+      println(s"RES: $result")
+      println(s"EXP: ${result.headOption.toVector ++ result.tail.filter(_ != 0)}")
 
       result shouldBe (result.headOption.toVector ++ result.tail.filter(_ != 0))
 

--- a/core/jvm/src/test/scala/fs2/Pipe2Spec.scala
+++ b/core/jvm/src/test/scala/fs2/Pipe2Spec.scala
@@ -461,7 +461,7 @@ class Pipe2Spec extends Fs2Spec {
 
       def s1 = Stream(1).covary[IO].unchunk
 
-      def interrupt = IO.sleep(3000.millis).attempt
+      def interrupt = IO.sleep(100.millis).attempt
 
       def prg =
         s1.interruptWhen(interrupt)

--- a/core/jvm/src/test/scala/fs2/Pipe2Spec.scala
+++ b/core/jvm/src/test/scala/fs2/Pipe2Spec.scala
@@ -452,7 +452,6 @@ class Pipe2Spec extends Fs2Spec {
             .through(p)
         )
 
-
       result shouldBe (result.headOption.toVector ++ result.tail.filter(_ != 0))
 
     }

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -97,13 +97,6 @@ abstract class Chunk[+O] extends Serializable { self =>
     acc
   }
 
-  private[fs2] final def foldRightLazy[B](z: B)(f: (O, => B) => B): B = {
-    val sz = size
-    def loop(idx: Int): B =
-      if (idx < sz) f(apply(idx), loop(idx + 1))
-      else z
-    loop(0)
-  }
 
   /** Returns true if the predicate passes for all elements. */
   def forall(p: O => Boolean): Boolean = {

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -97,7 +97,6 @@ abstract class Chunk[+O] extends Serializable { self =>
     acc
   }
 
-
   /** Returns true if the predicate passes for all elements. */
   def forall(p: O => Boolean): Boolean = {
     var i = 0

--- a/core/shared/src/main/scala/fs2/CompositeFailure.scala
+++ b/core/shared/src/main/scala/fs2/CompositeFailure.scala
@@ -15,7 +15,9 @@ final class CompositeFailure(
 }
 
 object CompositeFailure {
-  def apply(first: Throwable, second: Throwable, rest: List[Throwable]): CompositeFailure =
+  def apply(first: Throwable,
+            second: Throwable,
+            rest: List[Throwable] = List.empty): CompositeFailure =
     new CompositeFailure(first, NonEmptyList(second, rest))
 
   def fromList(errors: List[Throwable]): Option[Throwable] = errors match {

--- a/core/shared/src/main/scala/fs2/Pipe.scala
+++ b/core/shared/src/main/scala/fs2/Pipe.scala
@@ -34,15 +34,16 @@ object Pipe {
 
     def go(s: Read[UO]): Stepper[I, O] = Stepper.Suspend { () =>
       s.viewL.get match {
-        case FreeC.Pure(None)           => Stepper.Done
-        case FreeC.Pure(Some((hd, tl))) => Stepper.Emits(hd, go(stepf(tl)))
-        case FreeC.Fail(t)              => Stepper.Fail(t)
+        case FreeC.Result.Pure(None)           => Stepper.Done
+        case FreeC.Result.Pure(Some((hd, tl))) => Stepper.Emits(hd, go(stepf(tl)))
+        case FreeC.Result.Fail(t)              => Stepper.Fail(t)
+        case FreeC.Result.Interrupted(_, _)    => ???
         case bound: FreeC.Bind[ReadChunk, x, UO] =>
           val fx = bound.fx.asInstanceOf[FreeC.Eval[ReadChunk, x]].fr
           Stepper.Await(
             chunk =>
-              try go(bound.f(Right(fx(chunk))))
-              catch { case NonFatal(t) => go(bound.f(Left(t))) })
+              try go(bound.f(FreeC.Result.Pure(fx(chunk))))
+              catch { case NonFatal(t) => go(bound.f(FreeC.Result.Fail(t))) })
         case e =>
           sys.error(
             "FreeC.ViewL structure must be Pure(a), Fail(e), or Bind(Eval(fx),k), was: " + e)

--- a/core/shared/src/main/scala/fs2/Pipe2.scala
+++ b/core/shared/src/main/scala/fs2/Pipe2.scala
@@ -36,7 +36,12 @@ object Pipe2 {
         case FreeC.Result.Pure(None)           => Stepper.Done
         case FreeC.Result.Pure(Some((hd, tl))) => Stepper.Emits(hd, go(stepf(tl)))
         case FreeC.Result.Fail(t)              => Stepper.Fail(t)
-        case FreeC.Result.Interrupted(_, _)    => ???
+        case FreeC.Result.Interrupted(_, err) =>
+          err
+            .map { t =>
+              Stepper.Fail(t)
+            }
+            .getOrElse(Stepper.Done)
         case bound: FreeC.Bind[ReadChunk, _, UO] =>
           val f = bound.asInstanceOf[FreeC.Bind[ReadChunk, Any, UO]].f
           val fx = bound.fx.asInstanceOf[FreeC.Eval[ReadChunk, UO]].fr

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -32,7 +32,7 @@ final class Pull[+F[_], +O, +R] private (private val free: FreeC[Algebra[Nothing
 
   /** Returns a pull with the result wrapped in `Right`, or an error wrapped in `Left` if the pull has failed. */
   def attempt: Pull[F, O, Either[Throwable, R]] =
-    Pull.fromFreeC(get[F, O, R].map(r => Right(r)).handleErrorWith(t => FreeC.Pure(Left(t))))
+    Pull.fromFreeC(get[F, O, R].map(r => Right(r)).handleErrorWith(t => FreeC.pure(Left(t))))
 
   /** Interpret this `Pull` to produce a `Stream`. The result type `R` is discarded. */
   def stream: Stream[F, O] =

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -811,8 +811,10 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
                 f(hd(idx)).get.transformWith {
                   case Result.Pure(_)   => go(idx + 1)
                   case Result.Fail(err) => Algebra.raiseError(err)
-                  case Result.Interrupted(scopeId, err) =>
+                  case Result.Interrupted(scopeId: Token, err) =>
                     Stream.fromFreeC(Algebra.interruptBoundary(tl, scopeId, err)).flatMap(f).get
+                  case Result.Interrupted(invalid, err) =>
+                    sys.error(s"Invalid interruption context: $invalid (flatMap)")
                 }
               }
 

--- a/core/shared/src/main/scala/fs2/internal/Algebra.scala
+++ b/core/shared/src/main/scala/fs2/internal/Algebra.scala
@@ -198,24 +198,16 @@ private[fs2] object Algebra {
    * Reason for this is unlike interruption of `F` type (i.e. IO) we need to find
    * recovery point where stream evaluation has to continue in Stream algebra
    *
-   * As such the `CompileInterruptContext` is passed to FreeC.Interrupted as glue between FreeC/Algebra that allows pass-along
+   * As such the `Token` is passed to FreeC.Interrupted as glue between FreeC/Algebra that allows pass-along
    * information for Algebra and scope to correctly compute recovery point after interruption was signalled via `CompilerScope`.
    *
-   *
-   * Parameter `scopeId` indicates scope of the computation where interruption actually happened.
+   * This token indicates scope of the computation where interruption actually happened.
    * This is used to precisely find most relevant interruption scope where interruption shall be resumed
    * for normal continuation of the stream evaluation.
    *
    * Interpreter uses this to find any parents of this scope that has to be interrupted, and guards the
    * interruption so it won't propagate to scope that shall not be anymore interrupted.
    *
-   *
-   * Parameter `finalizerErrors` allows to collect errors that may accumulate during interruption propagation.
-   * When interruption is executed, all finalizers are executed, until interruption resumes. During this time,
-   * finalizers may accumulate errors. These errors are then stored in `finalizerErrors`,
-   * and are raised when interruption resumes.
-   *
-   * Reason for this approach is delayed error propagation is to allow proper recovery with `handleErrorWith` handlers.
    */
 
   private[fs2] def compileLoop[F[_], O](

--- a/core/shared/src/main/scala/fs2/internal/Algebra.scala
+++ b/core/shared/src/main/scala/fs2/internal/Algebra.scala
@@ -391,7 +391,7 @@ private[fs2] object Algebra {
         }
 
       case OpenInterruptibly(scope, concurrent, onInterrupt, next) =>
-        F.flatMap(scope.open(Some((concurrent, onInterrupt)))) { childScope =>
+        F.flatMap(scope.open(Some(concurrent))) { childScope =>
           compileLoop(childScope, next(Right(childScope)))
         }
     }

--- a/core/shared/src/main/scala/fs2/internal/CompileScope.scala
+++ b/core/shared/src/main/scala/fs2/internal/CompileScope.scala
@@ -443,7 +443,9 @@ private[fs2] final class CompileScope[F[_], O] private (
           iCtx.concurrent
             .race(iCtx.deferred.get, F.attempt(iCtx.concurrent.uncancelable(f)))) {
           case Right(result) => result.left.map(Left(_))
-          case Left(other)   => Left(other)
+          case Left(other)   =>
+            //println(s"XXXY INTERRUPT RESULT: $other")
+            Left(other)
         }
     }
 
@@ -510,6 +512,8 @@ private[internal] object CompileScope {
     * A context of interruption status. This is shared from the parent that was created as interruptible to all
     * its children. It assures consistent view of the interruption through the stack
     * @param concurrent   Concurrent, used to create interruption at Eval.
+    * @param ec       Execution context used to create promise and ref, and interruption at Eval.
+    * @param promise  Promise signalling once the interruption to the scopes. Only completed once.
     *                 If signalled with None, normal interruption is signalled. If signaled with Some(err) failure is signalled.
     * @param ref      When None, scope is not interrupted,
     *                 when Some(None) scope was interrupted, and shall continue with `whenInterrupted`

--- a/core/shared/src/main/scala/fs2/internal/CompileScope.scala
+++ b/core/shared/src/main/scala/fs2/internal/CompileScope.scala
@@ -510,8 +510,6 @@ private[internal] object CompileScope {
     * A context of interruption status. This is shared from the parent that was created as interruptible to all
     * its children. It assures consistent view of the interruption through the stack
     * @param concurrent   Concurrent, used to create interruption at Eval.
-    * @param ec       Execution context used to create promise and ref, and interruption at Eval.
-    * @param promise  Promise signalling once the interruption to the scopes. Only completed once.
     *                 If signalled with None, normal interruption is signalled. If signaled with Some(err) failure is signalled.
     * @param ref      When None, scope is not interrupted,
     *                 when Some(None) scope was interrupted, and shall continue with `whenInterrupted`

--- a/core/shared/src/main/scala/fs2/internal/FreeC.scala
+++ b/core/shared/src/main/scala/fs2/internal/FreeC.scala
@@ -85,7 +85,7 @@ private[fs2] object FreeC {
       case Result.Interrupted(_, _) => ExitCase.Canceled
     }
 
-    def covary[R2 >: R]: Result[R2] = self.asInstanceOf[Result[R2]]
+    def covary[R2 >: R]: Result[R2] = self
 
     def recoverWith[R2 >: R](f: Throwable => Result[R2]): Result[R2] = self match {
       case Result.Fail(err) =>
@@ -128,14 +128,33 @@ private[fs2] object FreeC {
       override def toString: String = s"FreeC.Fail($error)"
     }
 
-    // finalizerErrors contains accumulated errors during finalization of interruption.
-    // they will be presented to freeC after interupted scope will be closed
+    /*
+     * Interruption of the stream is tightly coupled between FreeC, Algebra and CompileScope
+     * Reason for this is unlike interruption of `F` type (i.e. IO) we need to find
+     * recovery point where stream evaluation has to continue in Stream algebra
+     *
+     * As such the `Interrupted` is necessary glue between FreeC/Algebra that allows pass-along
+     * information for Algebra and scope to correctly compute recovery point after interruption was signalled via `CompilerScope`.
+     *
+     * Parameter `scope` indicates scope of the computation where interruption actually happened.
+     * This is used to precisely find most relevant interruption scope where interruption shall be resumed
+     * for normal continuation.
+     * Essentially interpreter uses this to find any parents of this scope that has to be interrupted, and guards the
+     * interruption so it won't propagate to scope that shall not be anymore interrupted.
+     *
+     * Parameter `finalizerErrors` allows to collect errors that may accumulate during interruption propagation.
+     * When interruption is executed, all finalizers are executed, until interruption resumes. During this time,
+     * finalizers may accumulate errors. These errors are then stored here, and are raised when interruption resumes.
+     * Reason for this delayed reporting is to allow proper recovery with `handleErrorWith` handlers.
+     *
+     */
     final case class Interrupted[F[_], R](scope: Token, finalizerErrors: Option[Throwable])
         extends FreeC[F, R]
         with Result[R] {
       override def translate[G[_]](f: F ~> G): FreeC[G, R] =
         this.asInstanceOf[FreeC[G, R]]
-      override def toString: String = s"FreeC.Interrupted($scope, ${})"
+      override def toString: String =
+        s"FreeC.Interrupted($scope, ${finalizerErrors.map(_.getMessage)})"
     }
 
     implicit class ResultSyntax[R](val self: Result[R]) extends AnyVal {

--- a/core/shared/src/main/scala/fs2/internal/FreeC.scala
+++ b/core/shared/src/main/scala/fs2/internal/FreeC.scala
@@ -133,7 +133,10 @@ private[fs2] object FreeC {
       *
       * @param context Any user specific context that needs to be captured during interruption
       *                for eventual resume of the operation.
+      *
       * @param deferredError Any errors, accumulated during resume of the interruption.
+      *                      Instead throwing errors immediately during interruption,
+      *                      signalling of the errors may be deferred until the Interruption resumes.
       */
     final case class Interrupted[F[_], X, R](context: X, deferredError: Option[Throwable])
         extends FreeC[F, R]

--- a/core/shared/src/main/scala/fs2/internal/FreeC.scala
+++ b/core/shared/src/main/scala/fs2/internal/FreeC.scala
@@ -1,11 +1,11 @@
 package fs2.internal
 
-import cats.{MonadError, ~>}
+import cats.{Monad, MonadError, ~>}
 import cats.effect.{ExitCase, Sync}
-
 import fs2.CompositeFailure
 import FreeC._
 
+import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
 /** Free monad with a catch -- catches exceptions and provides mechanisms for handling them. */
@@ -31,7 +31,7 @@ private[fs2] sealed abstract class FreeC[F[_], +R] {
                      catch { case NonFatal(e) => FreeC.Result.Fail(e) })
 
   def map[R2](f: R => R2): FreeC[F, R2] =
-    Bind[F, R, R2](this, _.map(f).asFreeC[F])
+    Bind[F, R, R2](this, Result.monadInstance.map(_)(f).asFreeC[F])
 
   def handleErrorWith[R2 >: R](h: Throwable => FreeC[F, R2]): FreeC[F, R2] =
     Bind[F, R2, R2](this,
@@ -157,15 +157,28 @@ private[fs2] object FreeC {
         s"FreeC.Interrupted($scope, ${finalizerErrors.map(_.getMessage)})"
     }
 
-    implicit class ResultSyntax[R](val self: Result[R]) extends AnyVal {
-
-      def map[R2](f: R => R2): Result[R2] = self match {
+    val monadInstance: Monad[Result] = new Monad[Result] {
+      def flatMap[A, B](fa: Result[A])(f: A => Result[B]): Result[B] = fa match {
         case Result.Pure(r) =>
-          try { Result.Pure(f(r)) } catch { case NonFatal(err) => Result.Fail(err) }
-        case failure @ Result.Fail(_)               => failure.asInstanceOf[Result[R2]]
-        case interrupted @ Result.Interrupted(_, _) => interrupted.asInstanceOf[Result[R2]]
+          try { f(r) } catch { case NonFatal(err) => Result.Fail(err) }
+        case failure @ Result.Fail(_)               => failure.asInstanceOf[Result[B]]
+        case interrupted @ Result.Interrupted(_, _) => interrupted.asInstanceOf[Result[B]]
       }
 
+      def tailRecM[A, B](a: A)(f: A => Result[Either[A, B]]): Result[B] = {
+        @tailrec
+        def go(a: A): Result[B] =
+          f(a) match {
+            case Result.Pure(Left(a))                   => go(a)
+            case Result.Pure(Right(b))                  => Result.Pure(b)
+            case failure @ Result.Fail(_)               => failure.asInstanceOf[Result[B]]
+            case interrupted @ Result.Interrupted(_, _) => interrupted.asInstanceOf[Result[B]]
+          }
+
+        try { go(a) } catch { case t: Throwable => Result.Fail(t) }
+      }
+
+      def pure[A](x: A): Result[A] = Result.Pure(x)
     }
 
   }

--- a/core/shared/src/main/scala/fs2/internal/FreeC.scala
+++ b/core/shared/src/main/scala/fs2/internal/FreeC.scala
@@ -12,45 +12,43 @@ import scala.util.control.NonFatal
 private[fs2] sealed abstract class FreeC[F[_], +R] {
 
   def flatMap[R2](f: R => FreeC[F, R2]): FreeC[F, R2] =
-    Bind[F, R, R2](this,
-                   e =>
-                     e match {
-                       case Right(r) =>
-                         try f(r)
-                         catch { case NonFatal(e) => FreeC.Fail(e) }
-                       case Left(e) => FreeC.Fail(e)
-                   })
+    Bind[F, R, R2](
+      this,
+      e =>
+        e match {
+          case Result.Pure(r) =>
+            try f(r)
+            catch { case NonFatal(e) => FreeC.Result.Fail(e) }
+          case Result.Interrupted(scope, err) => FreeC.Result.Interrupted(scope, err)
+          case Result.Fail(e)                 => FreeC.Result.Fail(e)
+      }
+    )
 
-  def transformWith[R2](f: Either[Throwable, R] => FreeC[F, R2]): FreeC[F, R2] =
+  def transformWith[R2](f: Result[R] => FreeC[F, R2]): FreeC[F, R2] =
     Bind[F, R, R2](this,
                    r =>
                      try f(r)
-                     catch { case NonFatal(e) => FreeC.Fail(e) })
+                     catch { case NonFatal(e) => FreeC.Result.Fail(e) })
 
   def map[R2](f: R => R2): FreeC[F, R2] =
-    Bind(this,
-         (r: Either[Throwable, R]) =>
-           r match {
-             case Right(r) =>
-               try FreeC.Pure(f(r))
-               catch { case NonFatal(e) => FreeC.Fail(e) }
-             case Left(e) => FreeC.Fail(e)
-         })
+    Bind[F, R, R2](this, _.map(f).asFreeC[F])
 
   def handleErrorWith[R2 >: R](h: Throwable => FreeC[F, R2]): FreeC[F, R2] =
     Bind[F, R2, R2](this,
                     e =>
                       e match {
-                        case Right(a) => FreeC.Pure(a)
-                        case Left(e) =>
+                        case Result.Fail(e) =>
                           try h(e)
-                          catch { case NonFatal(e) => FreeC.Fail(e) }
+                          catch { case NonFatal(e) => FreeC.Result.Fail(e) }
+                        case other => other.covary[R2].asFreeC[F]
                     })
 
   def asHandler(e: Throwable): FreeC[F, R] = viewL.get match {
-    case Pure(_)    => Fail(e)
-    case Fail(e2)   => Fail(e)
-    case Bind(_, k) => k(Left(e))
+    case Result.Pure(_)  => Result.Fail(e)
+    case Result.Fail(e2) => Result.Fail(CompositeFailure(e2, e))
+    case Result.Interrupted(scope, err) =>
+      Result.Interrupted(scope, err.map(t => CompositeFailure(e, t)).orElse(Some(e)))
+    case Bind(_, k) => k(Result.Fail(e))
     case Eval(_)    => sys.error("impossible")
   }
 
@@ -58,92 +56,160 @@ private[fs2] sealed abstract class FreeC[F[_], +R] {
 
   def translate[G[_]](f: F ~> G): FreeC[G, R] = FreeC.suspend {
     viewL.get match {
-      case Pure(r) => Pure(r)
       case Bind(fx, k) =>
-        Bind(fx.translate(f), (e: Either[Throwable, Any]) => k(e).translate(f))
-      case Fail(e)  => Fail(e)
-      case Eval(fx) => sys.error("impossible")
+        Bind(fx.translate(f), (e: Result[Any]) => k(e).translate(f))
+      case Eval(fx)  => sys.error("impossible")
+      case Result(r) => r.asFreeC[G]
     }
   }
 }
 
 private[fs2] object FreeC {
-  final case class Pure[F[_], R](r: R) extends FreeC[F, R] {
-    override def translate[G[_]](f: F ~> G): FreeC[G, R] =
-      this.asInstanceOf[FreeC[G, R]]
-    override def toString: String = s"FreeC.Pure($r)"
+
+  def pure[F[_], A](a: A): FreeC[F, A] = Result.Pure(a)
+
+  def eval[F[_], A](f: F[A]): FreeC[F, A] = Eval(f)
+
+  def raiseError[F[_], A](rsn: Throwable): FreeC[F, A] = Result.Fail(rsn)
+
+  def interrupted[F[_], A](scopeId: Token, failure: Option[Throwable]): FreeC[F, A] =
+    Result.Interrupted(scopeId, failure)
+
+  sealed trait Result[+R] { self =>
+
+    def asFreeC[F[_]]: FreeC[F, R] = self.asInstanceOf[FreeC[F, R]]
+
+    def asExitCase: ExitCase[Throwable] = self match {
+      case Result.Pure(_)           => ExitCase.Completed
+      case Result.Fail(err)         => ExitCase.Error(err)
+      case Result.Interrupted(_, _) => ExitCase.Canceled
+    }
+
+    def covary[R2 >: R]: Result[R2] = self.asInstanceOf[Result[R2]]
+
+    def recoverWith[R2 >: R](f: Throwable => Result[R2]): Result[R2] = self match {
+      case Result.Fail(err) =>
+        try { f(err) } catch { case NonFatal(err2) => Result.Fail(CompositeFailure(err, err2)) }
+      case _ => covary[R2]
+    }
+
   }
+
+  object Result {
+
+    val unit: Result[Unit] = pure(())
+
+    def pure[A](a: A): Result[A] = Result.Pure(a)
+
+    def raiseError[A](rsn: Throwable): Result[A] = Result.Fail(rsn)
+
+    def interrupted[A](scopeId: Token, failure: Option[Throwable]): Result[A] =
+      Result.Interrupted(scopeId, failure)
+
+    def fromEither[F[_], R](either: Either[Throwable, R]): Result[R] =
+      either.fold(Result.Fail(_), Result.Pure(_))
+
+    def unapply[F[_], R](freeC: FreeC[F, R]): Option[Result[R]] = freeC match {
+      case r @ Result.Pure(_)           => Some(r: Result[R])
+      case r @ Result.Fail(_)           => Some(r: Result[R])
+      case r @ Result.Interrupted(_, _) => Some(r: Result[R])
+      case _                            => None
+    }
+
+    final case class Pure[F[_], R](r: R) extends FreeC[F, R] with Result[R] {
+      override def translate[G[_]](f: F ~> G): FreeC[G, R] =
+        this.asInstanceOf[FreeC[G, R]]
+      override def toString: String = s"FreeC.Pure($r)"
+    }
+
+    final case class Fail[F[_], R](error: Throwable) extends FreeC[F, R] with Result[R] {
+      override def translate[G[_]](f: F ~> G): FreeC[G, R] =
+        this.asInstanceOf[FreeC[G, R]]
+      override def toString: String = s"FreeC.Fail($error)"
+    }
+
+    // finalizerErrors contains accumulated errors during finalization of interruption.
+    // they will be presented to freeC after interupted scope will be closed
+    final case class Interrupted[F[_], R](scope: Token, finalizerErrors: Option[Throwable])
+        extends FreeC[F, R]
+        with Result[R] {
+      override def translate[G[_]](f: F ~> G): FreeC[G, R] =
+        this.asInstanceOf[FreeC[G, R]]
+      override def toString: String = s"FreeC.Interrupted($scope, ${})"
+    }
+
+    implicit class ResultSyntax[R](val self: Result[R]) extends AnyVal {
+
+      def map[R2](f: R => R2): Result[R2] = self match {
+        case Result.Pure(r) =>
+          try { Result.Pure(f(r)) } catch { case NonFatal(err) => Result.Fail(err) }
+        case failure @ Result.Fail(_)               => failure.asInstanceOf[Result[R2]]
+        case interrupted @ Result.Interrupted(_, _) => interrupted.asInstanceOf[Result[R2]]
+      }
+
+    }
+
+  }
+
   final case class Eval[F[_], R](fr: F[R]) extends FreeC[F, R] {
     override def translate[G[_]](f: F ~> G): FreeC[G, R] =
       try Eval(f(fr))
-      catch { case NonFatal(t) => Fail[G, R](t) }
+      catch { case NonFatal(t) => Result.Fail[G, R](t) }
     override def toString: String = s"FreeC.Eval($fr)"
   }
-  final case class Bind[F[_], X, R](fx: FreeC[F, X], f: Either[Throwable, X] => FreeC[F, R])
+  final case class Bind[F[_], X, R](fx: FreeC[F, X], f: Result[X] => FreeC[F, R])
       extends FreeC[F, R] {
     override def toString: String = s"FreeC.Bind($fx, $f)"
   }
-  final case class Fail[F[_], R](error: Throwable) extends FreeC[F, R] {
-    override def translate[G[_]](f: F ~> G): FreeC[G, R] =
-      this.asInstanceOf[FreeC[G, R]]
-    override def toString: String = s"FreeC.Fail($error)"
-  }
 
-  private val pureContinuation_ = (e: Either[Throwable, Any]) =>
-    e match {
-      case Right(r) => Pure[Any, Any](r)
-      case Left(e)  => Fail[Any, Any](e)
-  }
-
-  def pureContinuation[F[_], R]: Either[Throwable, R] => FreeC[F, R] =
-    pureContinuation_.asInstanceOf[Either[Throwable, R] => FreeC[F, R]]
+  def pureContinuation[F[_], R]: Result[R] => FreeC[F, R] =
+    _.asFreeC[F]
 
   def suspend[F[_], R](fr: => FreeC[F, R]): FreeC[F, R] =
-    Pure[F, Unit](()).flatMap(_ => fr)
+    Result.Pure[F, Unit](()).flatMap(_ => fr)
 
   /**
     * Unrolled view of a `FreeC` structure. The `get` value is guaranteed to be one of:
-    * `Pure(r)`, `Fail(e)`, `Bind(Eval(fx), k)`.
+    * `Result(r)`,  `Bind(Eval(fx), k)`.
     */
   final class ViewL[F[_], +R](val get: FreeC[F, R]) extends AnyVal
 
   private def mkViewL[F[_], R](free: FreeC[F, R]): ViewL[F, R] = {
     @annotation.tailrec
     def go[X](free: FreeC[F, X]): ViewL[F, R] = free match {
-      case Pure(x) => new ViewL(free.asInstanceOf[FreeC[F, R]])
       case Eval(fx) =>
         new ViewL(Bind(free.asInstanceOf[FreeC[F, R]], pureContinuation[F, R]))
-      case Fail(err) => new ViewL(free.asInstanceOf[FreeC[F, R]])
       case b: FreeC.Bind[F, y, X] =>
         b.fx match {
-          case Pure(x) => go(b.f(Right(x)))
-          case Fail(e) => go(b.f(Left(e)))
-          case Eval(_) => new ViewL(b.asInstanceOf[FreeC[F, R]])
-          case Bind(w, g) =>
-            go(Bind(w, (e: Either[Throwable, Any]) => Bind(g(e), b.f)))
+          case Result(r)  => go(b.f(r))
+          case Eval(_)    => new ViewL(b.asInstanceOf[FreeC[F, R]])
+          case Bind(w, g) => go(Bind(w, (e: Result[Any]) => Bind(g(e), b.f)))
         }
+      case Result(r) => new ViewL(r.asInstanceOf[FreeC[F, R]])
     }
     go(free)
   }
 
   implicit final class InvariantOps[F[_], R](private val self: FreeC[F, R]) extends AnyVal {
-    def run(implicit F: MonadError[F, Throwable]): F[R] =
+    // None indicates the FreeC was interrupted
+    def run(implicit F: MonadError[F, Throwable]): F[Option[R]] =
       self.viewL.get match {
-        case Pure(r) => F.pure(r)
-        case Fail(e) => F.raiseError(e)
+        case Result.Pure(r)             => F.pure(Some(r))
+        case Result.Fail(e)             => F.raiseError(e)
+        case Result.Interrupted(_, err) => err.fold[F[Option[R]]](F.pure(None)) { F.raiseError }
         case Bind(fr, k) =>
-          F.flatMap(F.attempt(fr.asInstanceOf[Eval[F, Any]].fr)) { e =>
-            k(e).run
+          F.flatMap(F.attempt(fr.asInstanceOf[Eval[F, Any]].fr)) { r =>
+            k(Result.fromEither(r)).run
           }
         case Eval(_) => sys.error("impossible")
       }
   }
 
   implicit def syncInstance[F[_]]: Sync[FreeC[F, ?]] = new Sync[FreeC[F, ?]] {
-    def pure[A](a: A): FreeC[F, A] = FreeC.Pure(a)
+    def pure[A](a: A): FreeC[F, A] = FreeC.Result.Pure(a)
     def handleErrorWith[A](fa: FreeC[F, A])(f: Throwable => FreeC[F, A]): FreeC[F, A] =
       fa.handleErrorWith(f)
-    def raiseError[A](t: Throwable): FreeC[F, A] = FreeC.Fail(t)
+    def raiseError[A](t: Throwable): FreeC[F, A] = FreeC.Result.Fail(t)
     def flatMap[A, B](fa: FreeC[F, A])(f: A => FreeC[F, B]): FreeC[F, B] =
       fa.flatMap(f)
     def tailRecM[A, B](a: A)(f: A => FreeC[F, Either[A, B]]): FreeC[F, B] =
@@ -157,11 +223,16 @@ private[fs2] object FreeC {
       acquire.flatMap { a =>
         val used =
           try use(a)
-          catch { case NonFatal(t) => FreeC.Fail[F, B](t) }
+          catch { case NonFatal(t) => FreeC.Result.Fail[F, B](t) }
         used.transformWith { result =>
-          release(a, ExitCase.attempt(result)).transformWith {
-            case Left(t2) => FreeC.Fail(result.fold(t => CompositeFailure(t, t2, Nil), _ => t2))
-            case Right(_) => result.fold(FreeC.Fail(_), FreeC.Pure(_))
+          release(a, result.asExitCase).transformWith {
+            case Result.Fail(t2) =>
+              result
+                .recoverWith { t =>
+                  Result.Fail(CompositeFailure(t, t2))
+                }
+                .asFreeC[F]
+            case _ => result.asFreeC[F]
           }
         }
       }

--- a/core/shared/src/test/scala/fs2/FreeCSpec.scala
+++ b/core/shared/src/test/scala/fs2/FreeCSpec.scala
@@ -8,9 +8,9 @@ import cats.effect.laws.discipline.SyncTests
 import cats.effect.laws.discipline.arbitrary._
 import cats.effect.laws.util.TestContext
 import cats.effect.laws.util.TestInstances._
-
 import org.scalacheck.{Arbitrary, Cogen, Gen}
-import Arbitrary.{arbitrary, arbFunction1}
+import Arbitrary.{arbFunction1, arbitrary}
+import fs2.internal.FreeC.Result
 
 class FreeCSpec extends Fs2Spec {
 
@@ -23,9 +23,9 @@ class FreeCSpec extends Fs2Spec {
   // from commit ef05c76d92076f7ba0e1589b8a736cb973a9f610 - only change is addition of Fail nodes and replaced flatMap with transformWith
   private def freeGen[F[_], A](maxDepth: Int)(implicit F: Arbitrary[F[A]], A: Arbitrary[A]): Gen[FreeC[F, A]] = {
     val noBinds = Gen.oneOf(
-      A.arbitrary.map(FreeC.Pure[F, A](_)),
-      F.arbitrary.map(FreeC.Eval[F, A](_)),
-      arbitrary[Throwable].map(FreeC.Fail[F, A](_))
+      A.arbitrary.map(FreeC.pure[F, A](_)),
+      F.arbitrary.map(FreeC.eval[F, A](_)),
+      arbitrary[Throwable].map(FreeC.raiseError[F, A](_))
     )
 
     val nextDepth = Gen.chooseNum(1, math.max(1, maxDepth - 1))
@@ -33,7 +33,7 @@ class FreeCSpec extends Fs2Spec {
     def withBinds = for {
       fDepth <- nextDepth
       freeDepth <- nextDepth
-      f <- arbFunction1[Either[Throwable, A], FreeC[F, A]](Arbitrary(freeGen[F, A](fDepth)), Cogen[Unit].contramap(_ => ())).arbitrary
+      f <- arbFunction1[Result[A], FreeC[F, A]](Arbitrary(freeGen[F, A](fDepth)), Cogen[Unit].contramap(_ => ())).arbitrary
       freeFA <- freeGen[F, A](freeDepth)
     } yield freeFA.transformWith(f)
 


### PR DESCRIPTION
@mpilquist @SystemFw 
This fixes #1179 
Some notable changes: 

- FreeC now have special case for stream evaluation being interrupted
- FreeC now in `bind` takes `FreeC.Result` as argument, instead of Either. Result Type are pure cases of FreeC, so this also saves a bit on allocation
- Interruption is now signalled via CompileScope, however no longer scope keeps the `case` to run when interrupted
- Interpreter now does not have to `jump-off` in Uncons cases to open scope. Not only this makes it cleaner, but also it shall increase performance in certain scope-heavy interrupted streams. 
- Stream#flatMap has been simplified, which not only made code cleaner, but also leads to up to 70% speed increase in certain tests (See StreamPerformanceSpec)
- I am not sure 100% about Pipe.Stepper and Pipe2.Stepper implementation. There are no tests whatsoever for these. I think we shall either write some, or perhaps remove Stepper. 

 
