### PR TITLE
Remove `equals` introduced by case class

### DIFF
--- a/core/shared/src/main/scala/fs2/Segment.scala
+++ b/core/shared/src/main/scala/fs2/Segment.scala
@@ -1383,7 +1383,7 @@ object Segment {
             r => {
               if (result.isEmpty || result
                     .flatMap(_.toOption)
-                    .fold(false)(_ == Segment.empty)) result = Some(Left(r));
+                    .fold(false)(_ eq Segment.empty)) result = Some(Left(r));
               throw Done
             }
           )


### PR DESCRIPTION
This part in `Segment` (line 1393) compares a segment against the empty segment

```scala
        val step = self
          .stage(
            Depth(0),
            trampoline.defer,
            o => emits(Chunk.singleton(o)),
            os => emits(os),
            r => {
              if (result.isEmpty || result
                    .flatMap(_.toOption)
                    .fold(false)(_ == Segment.empty)) result = Some(Left(r));
              throw Done
            }
          )
          .value
```

There is a class `SingleChunk` implementing `Segment` that is defined as a case class. Thus it gets `equals` implicitely. In my case that lead to comparing to SingleChunk segments where one was not empty, calling `equals` on its chunks which dramatically affected performance. In my case the code that took >3s before runs in ~200ms with the `case` modifier removed.