### PR TITLE
Introduced FreeC.ViewL type

### DIFF
--- a/core/shared/src/main/scala/fs2/Pipe.scala
+++ b/core/shared/src/main/scala/fs2/Pipe.scala
@@ -3,6 +3,7 @@ package fs2
 import cats.effect.Concurrent
 import fs2.async.mutable.Queue
 import fs2.internal.FreeC
+import fs2.internal.FreeC.ViewL
 
 import scala.util.control.NonFatal
 
@@ -34,7 +35,7 @@ object Pipe {
         .last
 
     def go(s: Read[UO]): Stepper[I, O] = Stepper.Suspend { () =>
-      s.viewL.get match {
+      s.viewL match {
         case FreeC.Result.Pure(None)           => Stepper.Done
         case FreeC.Result.Pure(Some((hd, tl))) => Stepper.Emits(hd, go(stepf(tl)))
         case FreeC.Result.Fail(t)              => Stepper.Fail(t)
@@ -44,12 +45,11 @@ object Pipe {
               Stepper.Fail(t)
             }
             .getOrElse(Stepper.Done)
-        case bound: FreeC.Bind[ReadChunk, x, UO] =>
-          val fx = bound.fx.asInstanceOf[FreeC.Eval[ReadChunk, x]].fr
+        case view: ViewL.View[ReadChunk, x, UO] =>
           Stepper.Await(
             chunk =>
-              try go(bound.f(FreeC.Result.Pure(fx(chunk))))
-              catch { case NonFatal(t) => go(bound.f(FreeC.Result.Fail(t))) })
+              try go(view.next(FreeC.Result.Pure(view.step(chunk))))
+              catch { case NonFatal(t) => go(view.next(FreeC.Result.Fail(t))) })
         case e =>
           sys.error(
             "FreeC.ViewL structure must be Pure(a), Fail(e), or Bind(Eval(fx),k), was: " + e)

--- a/core/shared/src/main/scala/fs2/internal/Algebra.scala
+++ b/core/shared/src/main/scala/fs2/internal/Algebra.scala
@@ -229,10 +229,7 @@ private[fs2] object Algebra {
         scope: CompileScope[F, O],
         stream: FreeC[Algebra[F, X, ?], Unit]
     ): F[R[X]] = {
-      F.flatMap(F.map(F.delay(stream.viewL)) { a =>
-        //println(s"XXXA $scope : $a"); a
-        a
-      }) {
+      stream.viewL match {
         case _: FreeC.Result.Pure[Algebra[F, X, ?], Unit] =>
           F.pure(Done(scope))
 
@@ -315,7 +312,7 @@ private[fs2] object Algebra {
               }
 
             case _: Algebra.GetScope[F, X, _] =>
-              go(scope, view.next(Result.pure(scope.asInstanceOf[y])))
+              F.suspend(go(scope, view.next(Result.pure(scope.asInstanceOf[y]))))
 
             case open: Algebra.OpenScope[F, X] =>
               interruptGuard(scope) {


### PR DESCRIPTION
@mpilquist, @SystemFw this is a slight modification to ViewL, that is now trait with own case class for Eval Type. I think this cleans pattern match a bit (no Eval case anymore). 

Also this removes need for viewL suspension in main interpreter, savings on 2 allocation through every step of the interpreter (Suspend + Bind of F).  