### PR TITLE
Fixes memory leak of Interrupt 

### DIFF
--- a/core/jvm/src/test/scala/fs2/MergeJoinSpec.scala
+++ b/core/jvm/src/test/scala/fs2/MergeJoinSpec.scala
@@ -74,12 +74,13 @@ class MergeJoinSpec extends Fs2Spec {
             )
 
           val s: Stream[IO, Stream[IO, Int]] = bracketed.flatMap { b =>
-            val s1 = (Stream.eval_(IO.sleep(20.millis)) ++
-              Stream.eval_(halt.complete(())))
-              .onFinalize(
-                IO.sleep(100.millis) >>
-                  (if (b.get) IO.raiseError(new Err) else IO(()))
-              )
+            val s1 =
+              Stream
+                .eval_(halt.complete(()))
+                .onFinalize(
+                  IO.sleep(100.millis) >>
+                    (if (b.get) IO.raiseError(new Err) else IO(()))
+                )
 
             Stream(s1, s2.get.covary[IO]).covary[IO]
           }
@@ -142,9 +143,8 @@ class MergeJoinSpec extends Fs2Spec {
               s.get
                 .covary[IO]
                 .merge(
-                  (Stream.eval_(IO.sleep(20.millis)) ++
-                    Stream
-                      .eval(halt.complete(())))
+                  Stream
+                    .eval(halt.complete(()))
                     .onFinalize(
                       IO.sleep(100.millis) >>
                         (if (b.get) IO.raiseError(new Err) else IO(()))

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1066,7 +1066,9 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
     Stream
       .getScope[F2]
       .flatMap { scope =>
-        Stream.eval(F2.start(haltOnSignal.flatMap(scope.interrupt))).flatMap(_ => this)
+        Stream.eval(F2.start(haltOnSignal.flatMap(scope.interrupt))).flatMap { fiber =>
+          this.onFinalize(fiber.cancel)
+        }
       }
       .interruptScope
 


### PR DESCRIPTION
@mpilquist, @SystemFW fixes potential memory leak of interruptWhen and also improves concurrently tests a bit. 