### PR TITLE
Fix bug with .pull.take computing wrong remainder

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3073,7 +3073,7 @@ object Stream {
           case None => Pull.pure(None)
           case Some((hd, tl)) =>
             hd.size.toLong match {
-              case m if m <= n => Pull.output(hd) >> tl.pull.take(n - m)
+              case m if m < n => Pull.output(hd) >> tl.pull.take(n - m)
               case m if m == n => Pull.output(hd).as(Some(tl))
               case m =>
                 val (pfx, sfx) = hd.splitAt(n.toInt)


### PR DESCRIPTION
Small but nasty bug :)

We'll probably need an M4 soon, fs2-reactive-streams relies on this op and broke on M2-M3