### PR TITLE
Constrain raiseError with ApplicativeError

### DIFF
--- a/core/jvm/src/test/scala/fs2/MergeJoinSpec.scala
+++ b/core/jvm/src/test/scala/fs2/MergeJoinSpec.scala
@@ -57,7 +57,7 @@ class MergeJoinSpec extends Fs2Spec {
       val s: Stream[IO, Stream[IO, Unit]] = bracketed.map { b =>
         Stream
           .eval(IO(b.get))
-          .flatMap(b => if (b) Stream(()) else Stream.raiseError(new Err))
+          .flatMap(b => if (b) Stream(()) else Stream.raiseError[IO](new Err))
           .repeat
           .take(10000)
       }
@@ -189,7 +189,7 @@ class MergeJoinSpec extends Fs2Spec {
 
     "parJoin - outer-failed" in {
       an[Err] should be thrownBy {
-        runLog(Stream(Stream.sleep_[IO](1 minute), Stream.raiseError(new Err)).parJoinUnbounded)
+        runLog(Stream(Stream.sleep_[IO](1 minute), Stream.raiseError[IO](new Err)).parJoinUnbounded)
       }
     }
   }

--- a/core/jvm/src/test/scala/fs2/PipeSpec.scala
+++ b/core/jvm/src/test/scala/fs2/PipeSpec.scala
@@ -558,7 +558,7 @@ class PipeSpec extends Fs2Spec {
           s.get
             .covary[IO]
             .observe { _ =>
-              Stream.raiseError(new Err)
+              Stream.raiseError[IO](new Err)
             }
             .attempt
         }
@@ -568,7 +568,7 @@ class PipeSpec extends Fs2Spec {
           s.get
             .covary[IO]
             .observeAsync(2) { _ =>
-              Stream.raiseError(new Err)
+              Stream.raiseError[IO](new Err)
             }
             .attempt
         }

--- a/core/jvm/src/test/scala/fs2/ResourceSafetySpec.scala
+++ b/core/jvm/src/test/scala/fs2/ResourceSafetySpec.scala
@@ -16,7 +16,7 @@ class ResourceSafetySpec extends Fs2Spec with EventuallySupport {
 
     "pure fail" in {
       an[Err] should be thrownBy {
-        Stream.emit(0).flatMap(_ => Stream.raiseError(new Err)).toVector
+        Stream.emit(0).flatMap(_ => throw new Err).toVector
         ()
       }
     }
@@ -136,8 +136,8 @@ class ResourceSafetySpec extends Fs2Spec with EventuallySupport {
     }
 
     "asynchronous resource allocation (2a)" in forAll { (u: Unit) =>
-      val s1 = Stream.raiseError(new Err)
-      val s2 = Stream.raiseError(new Err)
+      val s1 = Stream.raiseError[IO](new Err)
+      val s2 = Stream.raiseError[IO](new Err)
       val c = new AtomicLong(0)
       val b1 = bracket(c)(s1)
       val b2 = s2: Stream[IO, Int]

--- a/core/jvm/src/test/scala/fs2/StreamPerformanceSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamPerformanceSpec.scala
@@ -147,12 +147,12 @@ class StreamPerformanceSpec extends Fs2Spec {
           val ok = new AtomicInteger(0)
           val bracketed = bracket(IO { open.incrementAndGet }) { _ =>
             IO { ok.incrementAndGet; open.decrementAndGet; () }
-          }.flatMap(_ => emit(1) ++ Stream.raiseError(FailWhale))
+          }.flatMap(_ => emit(1) ++ Stream.raiseError[IO](FailWhale))
           // left-associative handleErrorWith chains
           assert(throws(FailWhale) {
             List
               .fill(N)(bracketed)
-              .foldLeft(Stream.raiseError(FailWhale): Stream[IO, Int]) { (acc, hd) =>
+              .foldLeft(Stream.raiseError[IO](FailWhale): Stream[IO, Int]) { (acc, hd) =>
                 acc.handleErrorWith { _ =>
                   hd
                 }
@@ -165,7 +165,7 @@ class StreamPerformanceSpec extends Fs2Spec {
           assert(throws(FailWhale) {
             List
               .fill(N)(bracketed)
-              .foldLeft(Stream.raiseError(FailWhale): Stream[IO, Int]) { (tl, hd) =>
+              .foldLeft(Stream.raiseError[IO](FailWhale): Stream[IO, Int]) { (tl, hd) =>
                 hd.handleErrorWith { _ =>
                   tl
                 }

--- a/core/jvm/src/test/scala/fs2/StreamSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamSpec.scala
@@ -60,6 +60,15 @@ class StreamSpec extends Fs2Spec with Inside {
       runLog(s.get >> s2.get) shouldBe { runLog(s.get.flatMap(_ => s2.get)) }
     }
 
+    "fromEither" in forAll { either: Either[Throwable, Int] =>
+      val stream: Stream[IO, Int] = Stream.fromEither[IO](either)
+
+      either match {
+        case Left(_) ⇒ stream.compile.toList.attempt.unsafeRunSync() shouldBe either
+        case Right(_) ⇒ stream.compile.toList.unsafeRunSync() shouldBe either.right.toSeq.toList
+      }
+    }
+
     "fromIterator" in forAll { vec: Vector[Int] =>
       val iterator = vec.toIterator
       val stream = Stream.fromIterator[IO, Int](iterator)

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2394,6 +2394,25 @@ object Stream extends StreamLowPriority {
     now.flatMap(loop)
   }
 
+  final class PartiallyAppliedFromEither[F[_]] {
+    def apply[A](either: Either[Throwable, A])(
+        implicit ev: ApplicativeError[F, Throwable]): Stream[F, A] =
+      either.fold(Stream.raiseError[F], Stream.emit)
+  }
+
+  /**
+    * Lifts an Either[Throwable, A] to an effectful Stream.
+    *
+    * @example {{{
+    * scala> import cats.effect.IO, scala.util.Try
+    * scala> Stream.fromEither[IO](Right(42)).compile.toList.unsafeRunSync
+    * res0: List[Int] = List(42)
+    * scala> Try(Stream.fromEither[IO](Left(new RuntimeException)).compile.toList.unsafeRunSync)
+    * res1: Try[List[Nothing]] = Failure(java.lang.RuntimeException)
+    * }}}
+    */
+  def fromEither[F[_]] = new PartiallyAppliedFromEither[F]
+
   /**
     * Lifts an iterator into a Stream
     */

--- a/core/shared/src/test/scala/fs2/ErrorHandlingSpec.scala
+++ b/core/shared/src/test/scala/fs2/ErrorHandlingSpec.scala
@@ -62,13 +62,13 @@ class ErrorHandlingSpec extends Fs2Spec {
 
     "ex6" in {
       var i = 0
-      (Stream.range(0, 10).covary[IO] ++ Stream.raiseError(new Err)).handleErrorWith { t => i += 1; Stream.empty }.compile.drain.unsafeRunSync
+      (Stream.range(0, 10).covary[IO] ++ Stream.raiseError[IO](new Err)).handleErrorWith { t => i += 1; Stream.empty }.compile.drain.unsafeRunSync
       i shouldBe 1
     }
 
     "ex7" in {
       try {
-        (Stream.range(0, 3).covary[IO] ++ Stream.raiseError(new Err)).unchunk.pull.echo.stream.compile.drain.unsafeRunSync
+        (Stream.range(0, 3).covary[IO] ++ Stream.raiseError[IO](new Err)).unchunk.pull.echo.stream.compile.drain.unsafeRunSync
         fail("SHOULD NOT REACH")
       }
       catch { case e: Throwable => () }
@@ -76,7 +76,7 @@ class ErrorHandlingSpec extends Fs2Spec {
 
     "ex8" in {
       var i = 0
-      (Stream.range(0, 3).covary[IO] ++ Stream.raiseError(new Err)).unchunk.pull.echo.handleErrorWith { t => i += 1; println(i); Pull.done }.stream.compile.drain.unsafeRunSync
+      (Stream.range(0, 3).covary[IO] ++ Stream.raiseError[IO](new Err)).unchunk.pull.echo.handleErrorWith { t => i += 1; println(i); Pull.done }.stream.compile.drain.unsafeRunSync
       i shouldBe 1
     }
   }

--- a/core/shared/src/test/scala/fs2/TestUtil.scala
+++ b/core/shared/src/test/scala/fs2/TestUtil.scala
@@ -106,7 +106,7 @@ object TestUtil extends TestUtilPlatform {
 
   implicit def failingStreamArb: Arbitrary[Failure] = Arbitrary(
     Gen.oneOf[Failure](
-      Failure("pure-failure", Stream.raiseError(new Err)),
+      Failure("pure-failure", Stream.raiseError[IO](new Err)),
       Failure("failure-inside-effect", Stream.eval(IO(throw new Err))),
       Failure("failure-mid-effect", Stream.eval(IO.pure(()).flatMap(_ => throw new Err))),
       Failure("failure-in-pure-code", Stream.emit(42).map(_ => throw new Err)),

--- a/io/src/main/scala/fs2/io/tcp/Socket.scala
+++ b/io/src/main/scala/fs2/io/tcp/Socket.scala
@@ -178,9 +178,9 @@ protected[tcp] object Socket {
 
       go.handleErrorWith {
         case err: AsynchronousCloseException =>
-          if (sch.isOpen) Stream.raiseError(err)
+          if (sch.isOpen) Stream.raiseError[F](err)
           else Stream.empty
-        case err => Stream.raiseError(err)
+        case err => Stream.raiseError[F](err)
       }
     }
 


### PR DESCRIPTION
I [asked on gitter](https://gitter.im/functional-streams-for-scala/fs2?at=5b74a2b049932d4fe4e8ac65) whether there was any `Either[Throwable, A] ⇒ Stream[Pure, A]` method in fs2. After some discussion, the conclusion that it doesn't make sense to have a `Pure` version, but a `Stream.fromEither` constrained to an `F[_]` with an `ApplicativeError[F, Throwable]` was a good idea.

This PR is to constrain the methods already in fs2 in the same way, so we can add `Stream.fromEither`, either in an addition to this PR or in a subsequent PR.

Thanks to @SystemFw, @mpilquist, and @ChristopherDavenport for helping me figure out how to make the necessary changes and tweaking the initial question into something worth adding to fs2.