### PR TITLE
Upgraded to latest cats-effect hash release

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/ConcurrentBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/ConcurrentBenchmark.scala
@@ -1,16 +1,19 @@
 package fs2
 package benchmark
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import org.openjdk.jmh.annotations.{Benchmark, Scope, State}
 
 @State(Scope.Thread)
 class ConcurrentBenchmark {
 
+  implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.Implicits.global)
+
   @GenerateN(1, 2, 4, 7, 16, 32, 64, 128, 256)
   @Benchmark
   def parJoin(N: Int): Int = {
+
     val each = Stream
       .segment(Segment.seq(0 to 1000).map(i => Stream.eval(IO.pure(i))))
       .covary[IO]

--- a/build.sbt
+++ b/build.sbt
@@ -52,10 +52,10 @@ lazy val commonSettings = Seq(
   javaOptions in (Test, run) ++= Seq("-Xms64m", "-Xmx64m"),
   libraryDependencies ++= Seq(
     compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.6"),
-    "org.typelevel" %%% "cats-core" % "1.1.0",
-    "org.typelevel" %%% "cats-laws" % "1.1.0" % "test",
-    "org.typelevel" %%% "cats-effect" % "1.0.0-RC2-78a795d",
-    "org.typelevel" %%% "cats-effect-laws" % "1.0.0-RC2-78a795d" % "test",
+    "org.typelevel" %%% "cats-core" % "1.2.0",
+    "org.typelevel" %%% "cats-laws" % "1.2.0" % "test",
+    "org.typelevel" %%% "cats-effect" % "1.0.0-RC2-3433449",
+    "org.typelevel" %%% "cats-effect-laws" % "1.0.0-RC2-3433449" % "test",
     "org.scalatest" %%% "scalatest" % "3.0.5" % "test",
     "org.scalacheck" %%% "scalacheck" % "1.13.5" % "test"
   ),

--- a/core/jvm/src/test/scala/fs2/async/TopicSpec.scala
+++ b/core/jvm/src/test/scala/fs2/async/TopicSpec.scala
@@ -5,8 +5,6 @@ import cats.effect.IO
 import fs2._
 import fs2.Stream._
 
-import TestUtil._
-
 import scala.concurrent.duration._
 
 class TopicSpec extends Fs2Spec {

--- a/core/shared/src/main/scala/fs2/Segment.scala
+++ b/core/shared/src/main/scala/fs2/Segment.scala
@@ -1,7 +1,7 @@
 package fs2
 
 import java.util.{LinkedList => JLinkedList}
-import cats._
+import cats.{Defer => _, _}
 import cats.implicits.{catsSyntaxEither => _, _}
 
 import Segment._

--- a/core/shared/src/main/scala/fs2/async/async.scala
+++ b/core/shared/src/main/scala/fs2/async/async.scala
@@ -4,7 +4,7 @@ import scala.concurrent.ExecutionContext
 
 import cats.Traverse
 import cats.implicits.{catsSyntaxEither => _, _}
-import cats.effect.{Concurrent, Effect, IO, Timer}
+import cats.effect.{Concurrent, ContextShift, Effect, IO}
 import cats.effect.concurrent.{Deferred, Ref}
 
 /** Provides utilities for asynchronous computations. */
@@ -128,6 +128,6 @@ package object async {
     * This method returns immediately after submitting execution to the execution context.
     */
   def unsafeRunAsync[F[_], A](fa: F[A])(
-      f: Either[Throwable, A] => IO[Unit])(implicit F: Effect[F], timer: Timer[F]): Unit =
-    F.runAsync(timer.shift *> fa)(f).unsafeRunSync
+      f: Either[Throwable, A] => IO[Unit])(implicit F: Effect[F], cs: ContextShift[F]): Unit =
+    F.runAsync(cs.shift *> fa)(f).unsafeRunSync
 }

--- a/core/shared/src/test/scala/fs2/CompilationTest.scala
+++ b/core/shared/src/test/scala/fs2/CompilationTest.scala
@@ -1,10 +1,11 @@
 package fs2
 
 import cats.{Applicative, Id}
-import cats.effect.IO
-import scala.concurrent.ExecutionContext.Implicits.global
+import cats.effect.{ContextShift, IO, Timer}
 
 object ThisModuleShouldCompile {
+  implicit val timerIO: Timer[IO] = IO.timer(scala.concurrent.ExecutionContext.Implicits.global)
+  implicit val contextShiftIO: ContextShift[IO] = IO.contextShift(scala.concurrent.ExecutionContext.Implicits.global)
 
   /* Some checks that `.pull` can be used without annotations */
   Stream(1,2,3,4) through (_.take(2))

--- a/core/shared/src/test/scala/fs2/Fs2Spec.scala
+++ b/core/shared/src/test/scala/fs2/Fs2Spec.scala
@@ -3,6 +3,8 @@ package fs2
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
+import cats.effect.{ContextShift, IO, Timer}
+
 import org.typelevel.discipline.Laws
 import org.scalatest.{ Args, AsyncFreeSpec, FreeSpec, Matchers, Status, Suite }
 import org.scalatest.concurrent.{ AsyncTimeLimitedTests, TimeLimitedTests }
@@ -27,6 +29,9 @@ trait Fs2SpecLike extends Suite
   with Matchers {
 
   implicit val timeout: FiniteDuration = 60.seconds
+
+  implicit val timerIO: Timer[IO] = IO.timer(TestUtil.executionContext)
+  implicit val contextShiftIO: ContextShift[IO] = IO.contextShift(TestUtil.executionContext)
 
   lazy val verbose: Boolean = sys.props.get("fs2.test.verbose").isDefined
 

--- a/core/shared/src/test/scala/fs2/TestUtil.scala
+++ b/core/shared/src/test/scala/fs2/TestUtil.scala
@@ -11,7 +11,7 @@ import cats.implicits._
 
 object TestUtil extends TestUtilPlatform {
 
-  def runLogF[A](s: Stream[IO,A]): Future[Vector[A]] = (IO.shift *> s.compile.toVector).unsafeToFuture
+  def runLogF[A](s: Stream[IO,A]): Future[Vector[A]] = (IO.shift(executionContext) *> s.compile.toVector).unsafeToFuture
 
   def spuriousFail(s: Stream[IO,Int], f: Failure): Stream[IO,Int] =
     s.flatMap { i => if (i % (math.random * 10 + 1).toInt == 0) f.get

--- a/core/shared/src/test/scala/fs2/async/OnceSpec.scala
+++ b/core/shared/src/test/scala/fs2/async/OnceSpec.scala
@@ -1,7 +1,7 @@
 package fs2
 package async
 
-import cats.effect.{IO, Timer}
+import cats.effect.IO
 import cats.effect.concurrent.Ref
 import cats.implicits._
 
@@ -17,7 +17,7 @@ class OnceSpec extends AsyncFs2Spec with EitherValues {
         ref <- Ref.of[IO, Int](42)
         act = ref.update(_ + 1)
         _ <- async.once(act)
-        _ <- Timer[IO].sleep(100.millis)
+        _ <- timerIO.sleep(100.millis)
         v <- ref.get
       } yield v
       t.unsafeToFuture.map(_ shouldBe 42)
@@ -48,7 +48,7 @@ class OnceSpec extends AsyncFs2Spec with EitherValues {
         memoized <- async.once(act)
         _ <- memoized.start
         x <- memoized
-        _ <- Timer[IO].sleep(100.millis)
+        _ <- timerIO.sleep(100.millis)
         v <- ref.get
       } yield (x, v)
       t.unsafeToFuture.map(_ shouldBe ((43, 43)))
@@ -65,7 +65,7 @@ class OnceSpec extends AsyncFs2Spec with EitherValues {
         act2 = async.once(act1).flatten
         _ <- Stream.repeatEval(act1).take(n).compile.drain.start
         _ <- Stream.repeatEval(act2).take(n).compile.drain.start
-        _ <- Timer[IO].sleep(200.millis)
+        _ <- timerIO.sleep(200.millis)
         v <- ref.get
       } yield v
       t.unsafeToFuture.map(_ shouldBe (42 + 2 * n))

--- a/io/src/main/scala/fs2/io/JavaInputOutputStream.scala
+++ b/io/src/main/scala/fs2/io/JavaInputOutputStream.scala
@@ -5,7 +5,7 @@ import scala.concurrent.{SyncVar, blocking}
 
 import java.io.{IOException, InputStream, OutputStream}
 
-import cats.effect.{ConcurrentEffect, ExitCase, IO, Sync, Timer}
+import cats.effect.{ConcurrentEffect, ContextShift, ExitCase, IO, Sync}
 import cats.implicits.{catsSyntaxEither => _, _}
 
 import fs2.Chunk.Bytes
@@ -58,7 +58,7 @@ private[io] object JavaInputOutputStream {
   }
 
   def toInputStream[F[_]](implicit F: ConcurrentEffect[F],
-                          timer: Timer[F]): Pipe[F, Byte, InputStream] = {
+                          cs: ContextShift[F]): Pipe[F, Byte, InputStream] = {
 
     /** See Implementation notes at the end of this code block **/
     /** state of the upstream, we only indicate whether upstream is done and if it failed **/

--- a/io/src/main/scala/fs2/io/file/FileHandle.scala
+++ b/io/src/main/scala/fs2/io/file/FileHandle.scala
@@ -5,7 +5,7 @@ package file
 import java.nio.ByteBuffer
 import java.nio.channels.{AsynchronousFileChannel, FileChannel, FileLock}
 
-import cats.effect.{Effect, Sync, Timer}
+import cats.effect.{ContextShift, Effect, Sync}
 import cats.implicits._
 
 /**
@@ -97,7 +97,7 @@ private[file] object FileHandle {
     * Uses a `java.nio.Channels.CompletionHandler` to handle callbacks from IO operations.
     */
   private[file] def fromAsynchronousFileChannel[F[_]](
-      chan: AsynchronousFileChannel)(implicit F: Effect[F], timer: Timer[F]): FileHandle[F] =
+      chan: AsynchronousFileChannel)(implicit F: Effect[F], cs: ContextShift[F]): FileHandle[F] =
     new FileHandle[F] {
       type Lock = FileLock
 

--- a/io/src/main/scala/fs2/io/file/pulls.scala
+++ b/io/src/main/scala/fs2/io/file/pulls.scala
@@ -6,7 +6,7 @@ import java.nio.channels._
 import java.nio.file._
 import java.util.concurrent.ExecutorService
 
-import cats.effect.{Effect, Sync, Timer}
+import cats.effect.{ContextShift, Effect, Sync}
 
 /** Provides various `Pull`s for working with files. */
 object pulls {
@@ -68,7 +68,7 @@ object pulls {
                           flags: Seq[OpenOption],
                           executorService: Option[ExecutorService] = None)(
       implicit F: Effect[F],
-      timer: Timer[F]): Pull[F, Nothing, Pull.Cancellable[F, FileHandle[F]]] = {
+      cs: ContextShift[F]): Pull[F, Nothing, Pull.Cancellable[F, FileHandle[F]]] = {
     import collection.JavaConverters._
     fromAsynchronousFileChannel(
       F.delay(AsynchronousFileChannel
@@ -93,7 +93,7 @@ object pulls {
     */
   def fromAsynchronousFileChannel[F[_]](channel: F[AsynchronousFileChannel])(
       implicit F: Effect[F],
-      timer: Timer[F]): Pull[F, Nothing, Pull.Cancellable[F, FileHandle[F]]] =
+      cs: ContextShift[F]): Pull[F, Nothing, Pull.Cancellable[F, FileHandle[F]]] =
     Pull
       .acquireCancellable(channel)(ch => F.delay(ch.close()))
       .map(_.map(FileHandle.fromAsynchronousFileChannel[F]))

--- a/io/src/main/scala/fs2/io/tcp/Socket.scala
+++ b/io/src/main/scala/fs2/io/tcp/Socket.scala
@@ -16,7 +16,7 @@ import java.nio.channels.{
 }
 import java.util.concurrent.TimeUnit
 
-import cats.effect.{ConcurrentEffect, IO, Resource, Timer}
+import cats.effect.{ConcurrentEffect, ContextShift, IO, Resource}
 import cats.effect.concurrent.{Ref, Semaphore}
 import cats.implicits._
 
@@ -102,7 +102,7 @@ protected[tcp] object Socket {
   )(
       implicit AG: AsynchronousChannelGroup,
       F: ConcurrentEffect[F],
-      timer: Timer[F]
+      cs: ContextShift[F]
   ): Resource[F, Socket[F]] = {
 
     def setup: F[AsynchronousSocketChannel] = F.delay {
@@ -139,7 +139,7 @@ protected[tcp] object Socket {
                    receiveBufferSize: Int)(
       implicit AG: AsynchronousChannelGroup,
       F: ConcurrentEffect[F],
-      timer: Timer[F]
+      cs: ContextShift[F]
   ): Stream[F, Either[InetSocketAddress, Resource[F, Socket[F]]]] = {
 
     val setup: F[AsynchronousServerSocketChannel] = F.delay {
@@ -194,7 +194,7 @@ protected[tcp] object Socket {
   }
 
   def mkSocket[F[_]](ch: AsynchronousSocketChannel)(implicit F: ConcurrentEffect[F],
-                                                    timer: Timer[F]): Resource[F, Socket[F]] = {
+                                                    cs: ContextShift[F]): Resource[F, Socket[F]] = {
     val socket = Semaphore(1).flatMap { readSemaphore =>
       Ref.of[F, ByteBuffer](ByteBuffer.allocate(0)).map { bufferRef =>
         // Reads data to remaining capacity of supplied ByteBuffer

--- a/io/src/main/scala/fs2/io/tcp/tcp.scala
+++ b/io/src/main/scala/fs2/io/tcp/tcp.scala
@@ -4,7 +4,7 @@ package io
 import java.net.InetSocketAddress
 import java.nio.channels.AsynchronousChannelGroup
 
-import cats.effect.{ConcurrentEffect, Resource, Timer}
+import cats.effect.{ConcurrentEffect, ContextShift, Resource}
 
 /** Provides support for TCP networking. */
 package object tcp {
@@ -30,7 +30,7 @@ package object tcp {
       noDelay: Boolean = false
   )(implicit AG: AsynchronousChannelGroup,
     F: ConcurrentEffect[F],
-    timer: Timer[F]): Resource[F, Socket[F]] =
+    cs: ContextShift[F]): Resource[F, Socket[F]] =
     Socket.client(to, reuseAddress, sendBufferSize, receiveBufferSize, keepAlive, noDelay)
 
   /**
@@ -59,7 +59,7 @@ package object tcp {
                    receiveBufferSize: Int = 256 * 1024)(
       implicit AG: AsynchronousChannelGroup,
       F: ConcurrentEffect[F],
-      timer: Timer[F]
+      cs: ContextShift[F]
   ): Stream[F, Resource[F, Socket[F]]] =
     serverWithLocalAddress(bind, maxQueued, reuseAddress, receiveBufferSize)
       .collect { case Right(s) => s }
@@ -75,7 +75,7 @@ package object tcp {
                                    receiveBufferSize: Int = 256 * 1024)(
       implicit AG: AsynchronousChannelGroup,
       F: ConcurrentEffect[F],
-      timer: Timer[F]
+      cs: ContextShift[F]
   ): Stream[F, Either[InetSocketAddress, Resource[F, Socket[F]]]] =
     Socket.server(bind, maxQueued, reuseAddress, receiveBufferSize)
 }

--- a/io/src/main/scala/fs2/io/udp/Socket.scala
+++ b/io/src/main/scala/fs2/io/udp/Socket.scala
@@ -7,7 +7,7 @@ import scala.concurrent.duration.FiniteDuration
 import java.net.{InetAddress, InetSocketAddress, NetworkInterface}
 import java.nio.channels.{ClosedChannelException, DatagramChannel}
 
-import cats.effect.{Effect, IO, Timer}
+import cats.effect.{ContextShift, Effect, IO}
 
 /**
   * Provides the ability to read/write from a UDP socket in the effect `F`.
@@ -100,7 +100,7 @@ private[udp] object Socket {
 
   private[fs2] def mkSocket[F[_]](channel: DatagramChannel)(implicit AG: AsynchronousSocketGroup,
                                                             F: Effect[F],
-                                                            timer: Timer[F]): F[Socket[F]] =
+                                                            cs: ContextShift[F]): F[Socket[F]] =
     F.delay {
       new Socket[F] {
         private val ctx = AG.register(channel)

--- a/io/src/main/scala/fs2/io/udp/udp.scala
+++ b/io/src/main/scala/fs2/io/udp/udp.scala
@@ -4,7 +4,7 @@ package io
 import java.net.{InetSocketAddress, NetworkInterface, ProtocolFamily, StandardSocketOptions}
 import java.nio.channels.DatagramChannel
 
-import cats.effect.{Effect, Resource, Timer}
+import cats.effect.{ContextShift, Effect, Resource}
 import cats.implicits._
 
 /** Provides support for UDP networking. */
@@ -33,7 +33,9 @@ package object udp {
       multicastInterface: Option[NetworkInterface] = None,
       multicastTTL: Option[Int] = None,
       multicastLoopback: Boolean = true
-  )(implicit AG: AsynchronousSocketGroup, F: Effect[F], timer: Timer[F]): Resource[F, Socket[F]] = {
+  )(implicit AG: AsynchronousSocketGroup,
+    F: Effect[F],
+    cs: ContextShift[F]): Resource[F, Socket[F]] = {
     val mkChannel = F.delay {
       val channel = protocolFamily
         .map { pf =>

--- a/io/src/test/scala/fs2/io/JavaInputOutputStreamSpec.scala
+++ b/io/src/test/scala/fs2/io/JavaInputOutputStreamSpec.scala
@@ -2,7 +2,6 @@ package fs2.io
 
 import cats.effect.IO
 import fs2.{Chunk, EventuallySupport, Fs2Spec, Stream}
-import fs2.TestUtil._
 import org.scalacheck.{Arbitrary, Gen}
 
 class JavaInputOutputStreamSpec extends Fs2Spec with EventuallySupport {

--- a/io/src/test/scala/fs2/io/tcp/SocketSpec.scala
+++ b/io/src/test/scala/fs2/io/tcp/SocketSpec.scala
@@ -13,8 +13,6 @@ import fs2.internal.ThreadFactories
 
 import org.scalatest.BeforeAndAfterAll
 
-import TestUtil._
-
 class SocketSpec extends Fs2Spec with BeforeAndAfterAll {
 
   implicit val tcpACG: AsynchronousChannelGroup = AsynchronousChannelProvider


### PR DESCRIPTION
This includes support for `ContextShift` (aka, the cats-effect version of `Linebacker`).

Note: in a separate PR, after this is merged, I am planning on getting rid of the synchronous/blocking versions of various `io` streams. E.g., deleting `fs2.io.stdout` and renaming `fs2.io.stdoutAsync` to `stdout`. The synchronous ones are dangerous and if we fix that by adding a blockingEC + `ContextShift[F]`, we've made them redundant with the async ones.

Similarly, we might want to do something similar with the `fs2.io.file` package, though there I can see keeping the synchronous ones, changing them to take the blocking ec + `ContextShift[F]`, and leaving the async ones use java.nio async file handle stuff.