### PR TITLE
Removed sync/async split in input stream methods

### DIFF
--- a/docs/ReadmeExample.md
+++ b/docs/ReadmeExample.md
@@ -98,7 +98,7 @@ There are a number of ways of interpreting the stream. In this case, we call `co
 
 ```scala
 scala> val task: IO[Unit] = written.compile.drain
-task: cats.effect.IO[Unit] = IO$1492455941
+task: cats.effect.IO[Unit] = IO$733618819
 ```
 
 We still haven't *done* anything yet. Effects only occur when we run the resulting task. We can run a `IO` by calling `unsafeRunSync()` -- the name is telling us that calling it performs effects and hence, it is not referentially transparent.

--- a/docs/migration-guide-1.0.md
+++ b/docs/migration-guide-1.0.md
@@ -136,3 +136,9 @@ object MyApp extends IOApp {
     myStream.compile.drain.as(ExitCode.Success)
 }
 ```
+
+### fs2.io Changes
+
+Methods in the `fs2.io` package that performed blocking I/O have been either removed or the blocking has been implemented via a call to `ContextSwitch[F].evalOn(blockingExecutionContext)(...)`. This ensures that a blocking call is not made from the same thread pool used for non-blocking tasks.
+
+For example, `fs2.io.readInputStream` now takes a blocking execution context argument, as well as an implicit `ContextShift[F]` argument. The `readInputStreamAsync` function was removed, as it was redundant with `readInputStream` once the blocking calls were shifted to a dedicated execution context.

--- a/docs/src/ReadmeExample.md
+++ b/docs/src/ReadmeExample.md
@@ -3,27 +3,28 @@
 This walks through the implementation of the example given in [the README](../README.md). This program opens a file, `fahrenheit.txt`, containing temperatures in degrees fahrenheit, one per line, and converts each temperature to celsius, incrementally writing to the file `celsius.txt`. Both files will be closed, regardless of whether any errors occur.
 
 ```tut:book
-object Converter {
-  import cats.effect.IO
-  import fs2.{io, text}
-  import java.nio.file.Paths
+import cats.effect.{ExitCode, IO, IOApp}
+import cats.implicits._
+import fs2.{io, text}
+import java.nio.file.Paths
 
-  def fahrenheitToCelsius(f: Double): Double =
-    (f - 32.0) * (5.0/9.0)
+object Converter extends IOApp {
+  def run(args: List[String]): IO[ExitCode] = {
+    def fahrenheitToCelsius(f: Double): Double =
+      (f - 32.0) * (5.0/9.0)
 
-  val converter: IO[Unit] =
-    io.file.readAll[IO](Paths.get("testdata/fahrenheit.txt"), 4096)
+    io.file.readAllAsync[IO](Paths.get("testdata/fahrenheit.txt"), 4096)
       .through(text.utf8Decode)
       .through(text.lines)
       .filter(s => !s.trim.isEmpty && !s.startsWith("//"))
       .map(line => fahrenheitToCelsius(line.toDouble).toString)
       .intersperse("\n")
       .through(text.utf8Encode)
-      .through(io.file.writeAll(Paths.get("testdata/celsius.txt")))
+      .through(io.file.writeAllAsync(Paths.get("testdata/celsius.txt")))
       .compile.drain
+      .as(ExitCode.Success)
+  }
 }
-
-Converter.converter.unsafeRunSync()
 ```
 
 Let's dissect this line by line.
@@ -35,17 +36,21 @@ Operations on `Stream` are defined for any choice of type constructor, not just 
 `fs2.io` has a number of helper functions for constructing or working with streams that talk to the outside world. `readAll` creates a stream of bytes from a file name (specified via a `java.nio.file.Path`). It encapsulates the logic for opening and closing the file, so that users of this stream do not need to remember to close the file when they are done or in the event of exceptions during processing of the stream.
 
 ```tut:silent
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import fs2.{io, text}
 import java.nio.file.Paths
-import Converter._
+
+implicit val cs: ContextShift[IO] = IO.contextShift(scala.concurrent.ExecutionContext.Implicits.global)
+
+def fahrenheitToCelsius(f: Double): Double =
+  (f - 32.0) * (5.0/9.0)
 ```
 
 ```tut
 import fs2.Stream
 
 val src: Stream[IO, Byte] =
-  io.file.readAll[IO](Paths.get("testdata/fahrenheit.txt"), 4096)
+  io.file.readAllAsync[IO](Paths.get("testdata/fahrenheit.txt"), 4096)
 ```
 
 A stream can be attached to a pipe, allowing for stateful transformations of the input values. Here, we attach the source stream to the `text.utf8Decode` pipe, which converts the stream of bytes to a stream of strings. We then attach the result to the `text.lines` pipe, which buffers strings and emits full lines. Pipes are expressed using the type `Pipe[F,I,O]`, which describes a pipe that can accept input values of type `I` and can output values of type `O`, potentially evaluating an effect periodically.
@@ -80,7 +85,7 @@ val encodedBytes: Stream[IO, Byte] = withNewlines.through(text.utf8Encode)
 We then write the encoded bytes to a file. Note that nothing has happened at this point -- we are just constructing a description of a computation that, when interpreted, will incrementally consume the stream, sending converted values to the specified file.
 
 ```tut
-val written: Stream[IO, Unit] = encodedBytes.through(io.file.writeAll(Paths.get("testdata/celsius.txt")))
+val written: Stream[IO, Unit] = encodedBytes.through(io.file.writeAllAsync(Paths.get("testdata/celsius.txt")))
 ```
 
 There are a number of ways of interpreting the stream. In this case, we call `compile.drain`, which returns a val value of the effect type, `IO`. The output of the stream is ignored - we compile it solely for its effect.
@@ -89,8 +94,4 @@ There are a number of ways of interpreting the stream. In this case, we call `co
 val task: IO[Unit] = written.compile.drain
 ```
 
-We still haven't *done* anything yet. Effects only occur when we run the resulting task. We can run a `IO` by calling `unsafeRunSync()` -- the name is telling us that calling it performs effects and hence, it is not referentially transparent.
-
-```tut
-val result: Unit = task.unsafeRunSync()
-```
+We still haven't *done* anything yet. Effects only occur when we run the resulting task. We can run a `IO` by calling `unsafeRunSync()` -- the name is telling us that calling it performs effects and hence, it is not referentially transparent. In this example, we extended `IOApp`, which lets us express our overall program as an `IO[ExitCase]`. The `IOApp` class handles running the task and hooking it up to the application entry point.

--- a/io/src/main/scala/fs2/io/file/FileHandle.scala
+++ b/io/src/main/scala/fs2/io/file/FileHandle.scala
@@ -2,6 +2,8 @@ package fs2
 package io
 package file
 
+import scala.concurrent.{ExecutionContext, blocking}
+
 import java.nio.ByteBuffer
 import java.nio.channels.{AsynchronousFileChannel, FileChannel, FileLock}
 
@@ -144,44 +146,50 @@ private[file] object FileHandle {
   /**
     * Creates a `FileHandle[F]` from a `java.nio.channels.FileChannel`.
     */
-  private[file] def fromFileChannel[F[_]](chan: FileChannel)(implicit F: Sync[F]): FileHandle[F] =
+  private[file] def fromFileChannel[F[_]](chan: FileChannel,
+                                          blockingExecutionContext: ExecutionContext)(
+      implicit F: Sync[F],
+      cs: ContextShift[F]): FileHandle[F] =
     new FileHandle[F] {
       type Lock = FileLock
 
+      private def doBlocking[A](a: => A): F[A] =
+        cs.evalOn(blockingExecutionContext)(F.delay(blocking(a)))
+
       override def force(metaData: Boolean): F[Unit] =
-        F.delay(chan.force(metaData))
+        doBlocking(chan.force(metaData))
 
       override def lock: F[Lock] =
-        F.delay(chan.lock)
+        doBlocking(chan.lock)
 
       override def lock(position: Long, size: Long, shared: Boolean): F[Lock] =
-        F.delay(chan.lock(position, size, shared))
+        doBlocking(chan.lock(position, size, shared))
 
       override def read(numBytes: Int, offset: Long): F[Option[Chunk[Byte]]] =
-        F.delay(ByteBuffer.allocate(numBytes)).flatMap { buf =>
-          F.delay(chan.read(buf, offset)).map { len =>
-            if (len < 0) None
-            else if (len == 0) Some(Chunk.empty)
-            else Some(Chunk.bytes(buf.array, 0, len))
-          }
+        doBlocking {
+          val buf = ByteBuffer.allocate(numBytes)
+          val len = chan.read(buf, offset)
+          if (len < 0) None
+          else if (len == 0) Some(Chunk.empty)
+          else Some(Chunk.bytes(buf.array, 0, len))
         }
 
       override def size: F[Long] =
-        F.delay(chan.size)
+        doBlocking(chan.size)
 
       override def truncate(size: Long): F[Unit] =
-        F.delay { chan.truncate(size); () }
+        doBlocking { chan.truncate(size); () }
 
       override def tryLock: F[Option[Lock]] =
-        F.delay(Option(chan.tryLock()))
+        doBlocking(Option(chan.tryLock()))
 
       override def tryLock(position: Long, size: Long, shared: Boolean): F[Option[Lock]] =
-        F.delay(Option(chan.tryLock(position, size, shared)))
+        doBlocking(Option(chan.tryLock(position, size, shared)))
 
       override def unlock(f: Lock): F[Unit] =
-        F.delay(f.release())
+        doBlocking(f.release())
 
       override def write(bytes: Chunk[Byte], offset: Long): F[Int] =
-        F.delay(chan.write(bytes.toBytes.toByteBuffer, offset))
+        doBlocking(chan.write(bytes.toBytes.toByteBuffer, offset))
     }
 }

--- a/io/src/main/scala/fs2/io/io.scala
+++ b/io/src/main/scala/fs2/io/io.scala
@@ -1,66 +1,28 @@
 package fs2
 
+import cats.effect.{ConcurrentEffect, ContextShift, Sync}
+import cats.implicits._
 import java.io.{InputStream, OutputStream}
-
-import cats.effect.{Async, ConcurrentEffect, ContextShift, Sync}
-
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, blocking}
 
 /** Provides various ways to work with streams that perform IO. */
 package object io {
-  import JavaInputOutputStream._
 
   /**
     * Reads all bytes from the specified `InputStream` with a buffer size of `chunkSize`.
     * Set `closeAfterUse` to false if the `InputStream` should not be closed after use.
-    *
-    * Blocks on read operations from the input stream.
     */
-  def readInputStream[F[_]](fis: F[InputStream], chunkSize: Int, closeAfterUse: Boolean = true)(
-      implicit F: Sync[F]): Stream[F, Byte] =
-    readInputStreamGeneric(fis,
-                           F.delay(new Array[Byte](chunkSize)),
-                           readBytesFromInputStream[F],
-                           closeAfterUse)
-
-  /**
-    * Reads all bytes from the specified `InputStream` with a buffer size of `chunkSize`.
-    * Set `closeAfterUse` to false if the `InputStream` should not be closed after use.
-    *
-    * Like `readInputStream` but each read operation is performed on the supplied execution
-    * context. Reads are blocking so the execution context should be configured appropriately.
-    */
-  def readInputStreamAsync[F[_]](
+  def readInputStream[F[_]](
       fis: F[InputStream],
       chunkSize: Int,
       blockingExecutionContext: ExecutionContext,
-      closeAfterUse: Boolean = true)(implicit F: Async[F], cs: ContextShift[F]): Stream[F, Byte] =
+      closeAfterUse: Boolean = true)(implicit F: Sync[F], cs: ContextShift[F]): Stream[F, Byte] =
     readInputStreamGeneric(
       fis,
       F.delay(new Array[Byte](chunkSize)),
-      (is, buf) => cs.evalOn(blockingExecutionContext)(readBytesFromInputStream(is, buf)),
+      blockingExecutionContext,
       closeAfterUse
     )
-
-  /**
-    * Reads all bytes from the specified `InputStream` with a buffer size of `chunkSize`.
-    * Set `closeAfterUse` to false if the `InputStream` should not be closed after use.
-    *
-    * Recycles an underlying input buffer for performance. It is safe to call
-    * this as long as whatever consumes this `Stream` does not store the `Chunk`
-    * returned or pipe it to a combinator that does (e.g., `buffer`). Use
-    * `readInputStream` for a safe version.
-    *
-    * Blocks on read operations from the input stream.
-    */
-  def unsafeReadInputStream[F[_]](
-      fis: F[InputStream],
-      chunkSize: Int,
-      closeAfterUse: Boolean = true)(implicit F: Sync[F]): Stream[F, Byte] =
-    readInputStreamGeneric(fis,
-                           F.pure(new Array[Byte](chunkSize)),
-                           readBytesFromInputStream[F],
-                           closeAfterUse)
 
   /**
     * Reads all bytes from the specified `InputStream` with a buffer size of `chunkSize`.
@@ -74,27 +36,47 @@ package object io {
     * returned or pipe it to a combinator that does (e.g. `buffer`). Use
     * `readInputStream` for a safe version.
     */
-  def unsafeReadInputStreamAsync[F[_]](
+  def unsafeReadInputStream[F[_]](
       fis: F[InputStream],
       chunkSize: Int,
       blockingExecutionContext: ExecutionContext,
-      closeAfterUse: Boolean = true)(implicit F: Async[F], cs: ContextShift[F]): Stream[F, Byte] =
+      closeAfterUse: Boolean = true)(implicit F: Sync[F], cs: ContextShift[F]): Stream[F, Byte] =
     readInputStreamGeneric(
       fis,
       F.pure(new Array[Byte](chunkSize)),
-      (is, buf) => cs.evalOn(blockingExecutionContext)(readBytesFromInputStream(is, buf)),
+      blockingExecutionContext,
       closeAfterUse
     )
 
-  /**
-    * Writes all bytes to the specified `OutputStream`. Set `closeAfterUse` to false if
-    * the `OutputStream` should not be closed after use.
-    *
-    * Blocks on write operations to the input stream.
-    */
-  def writeOutputStream[F[_]: Sync](fos: F[OutputStream],
-                                    closeAfterUse: Boolean = true): Sink[F, Byte] =
-    writeOutputStreamGeneric(fos, closeAfterUse, writeBytesToOutputStream[F])
+  private def readBytesFromInputStream[F[_]](is: InputStream,
+                                             buf: Array[Byte],
+                                             blockingExecutionContext: ExecutionContext)(
+      implicit F: Sync[F],
+      cs: ContextShift[F]): F[Option[Chunk[Byte]]] =
+    cs.evalOn(blockingExecutionContext)(F.delay(blocking(is.read(buf)))).map { numBytes =>
+      if (numBytes < 0) None
+      else if (numBytes == 0) Some(Chunk.empty)
+      else if (numBytes < buf.size) Some(Chunk.bytes(buf.slice(0, numBytes)))
+      else Some(Chunk.bytes(buf))
+    }
+
+  private def readInputStreamGeneric[F[_]](
+      fis: F[InputStream],
+      buf: F[Array[Byte]],
+      blockingExecutionContext: ExecutionContext,
+      closeAfterUse: Boolean)(implicit F: Sync[F], cs: ContextShift[F]): Stream[F, Byte] = {
+    def useIs(is: InputStream) =
+      Stream
+        .eval(buf.flatMap(b => readBytesFromInputStream(is, b, blockingExecutionContext)))
+        .repeat
+        .unNoneTerminate
+        .flatMap(c => Stream.chunk(c))
+
+    if (closeAfterUse)
+      Stream.bracket(fis)(is => F.delay(is.close())).flatMap(useIs)
+    else
+      Stream.eval(fis).flatMap(useIs)
+  }
 
   /**
     * Writes all bytes to the specified `OutputStream`. Set `closeAfterUse` to false if
@@ -103,37 +85,40 @@ package object io {
     * Each write operation is performed on the supplied execution context. Writes are
     * blocking so the execution context should be configured appropriately.
     */
-  def writeOutputStreamAsync[F[_]](
+  def writeOutputStream[F[_]](
       fos: F[OutputStream],
       blockingExecutionContext: ExecutionContext,
-      closeAfterUse: Boolean = true)(implicit F: Async[F], cs: ContextShift[F]): Sink[F, Byte] =
-    writeOutputStreamGeneric(
-      fos,
-      closeAfterUse,
-      (os, buf) => cs.evalOn(blockingExecutionContext)(writeBytesToOutputStream(os, buf)))
+      closeAfterUse: Boolean = true)(implicit F: Sync[F], cs: ContextShift[F]): Sink[F, Byte] =
+    s => {
+      def useOs(os: OutputStream): Stream[F, Unit] =
+        s.chunks.evalMap(c => writeBytesToOutputStream(os, c, blockingExecutionContext))
+
+      if (closeAfterUse)
+        Stream.bracket(fos)(os => F.delay(os.close())).flatMap(useOs)
+      else
+        Stream.eval(fos).flatMap(useOs)
+    }
+
+  private def writeBytesToOutputStream[F[_]](os: OutputStream,
+                                             bytes: Chunk[Byte],
+                                             blockingExecutionContext: ExecutionContext)(
+      implicit F: Sync[F],
+      cs: ContextShift[F]): F[Unit] =
+    cs.evalOn(blockingExecutionContext)(F.delay(blocking(os.write(bytes.toArray))))
 
   //
   // STDIN/STDOUT Helpers
 
-  /** Stream of bytes read from standard input. */
-  def stdin[F[_]](bufSize: Int)(implicit F: Sync[F]): Stream[F, Byte] =
-    readInputStream(F.delay(System.in), bufSize, false)
-
   /** Stream of bytes read asynchronously from standard input. */
-  def stdinAsync[F[_]](bufSize: Int, blockingExecutionContext: ExecutionContext)(
-      implicit F: Async[F],
+  def stdin[F[_]](bufSize: Int, blockingExecutionContext: ExecutionContext)(
+      implicit F: Sync[F],
       cs: ContextShift[F]): Stream[F, Byte] =
-    readInputStreamAsync(F.delay(System.in), bufSize, blockingExecutionContext, false)
-
-  /** Sink of bytes that writes emitted values to standard output. */
-  def stdout[F[_]](implicit F: Sync[F]): Sink[F, Byte] =
-    writeOutputStream(F.delay(System.out), false)
+    readInputStream(F.delay(System.in), bufSize, blockingExecutionContext, false)
 
   /** Sink of bytes that writes emitted values to standard output asynchronously. */
-  def stdoutAsync[F[_]](blockingExecutionContext: ExecutionContext)(
-      implicit F: Async[F],
-      cs: ContextShift[F]): Sink[F, Byte] =
-    writeOutputStreamAsync(F.delay(System.out), blockingExecutionContext, false)
+  def stdout[F[_]](blockingExecutionContext: ExecutionContext)(implicit F: Sync[F],
+                                                               cs: ContextShift[F]): Sink[F, Byte] =
+    writeOutputStream(F.delay(System.out), blockingExecutionContext, false)
 
   /**
     * Pipe that converts a stream of bytes to a stream that will emits a single `java.io.InputStream`,

--- a/io/src/test/scala/fs2/io/IoSpec.scala
+++ b/io/src/test/scala/fs2/io/IoSpec.scala
@@ -9,31 +9,14 @@ class IoSpec extends Fs2Spec {
   "readInputStream" - {
     "non-buffered" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
       val is: InputStream = new ByteArrayInputStream(bytes)
-      val stream = readInputStream(IO(is), chunkSize.get)
+      val stream = readInputStream(IO(is), chunkSize.get, executionContext)
       val example = stream.compile.toVector.unsafeRunSync.toArray
       example shouldBe bytes
     }
 
     "buffered" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
       val is: InputStream = new ByteArrayInputStream(bytes)
-      val stream = readInputStream(IO(is), chunkSize.get)
-      val example =
-        stream.buffer(chunkSize.get * 2).compile.toVector.unsafeRunSync.toArray
-      example shouldBe bytes
-    }
-  }
-
-  "readInputStreamAsync" - {
-    "non-buffered" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
-      val is: InputStream = new ByteArrayInputStream(bytes)
-      val stream = readInputStreamAsync(IO(is), chunkSize.get, executionContext)
-      val example = stream.compile.toVector.unsafeRunSync.toArray
-      example shouldBe bytes
-    }
-
-    "buffered" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
-      val is: InputStream = new ByteArrayInputStream(bytes)
-      val stream = readInputStreamAsync(IO(is), chunkSize.get, executionContext)
+      val stream = readInputStream(IO(is), chunkSize.get, executionContext)
       val example =
         stream.buffer(chunkSize.get * 2).compile.toVector.unsafeRunSync.toArray
       example shouldBe bytes
@@ -43,19 +26,9 @@ class IoSpec extends Fs2Spec {
   "unsafeReadInputStream" - {
     "non-buffered" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
       val is: InputStream = new ByteArrayInputStream(bytes)
-      val stream = unsafeReadInputStream(IO(is), chunkSize.get)
+      val stream = unsafeReadInputStream(IO(is), chunkSize.get, executionContext)
       val example = stream.compile.toVector.unsafeRunSync.toArray
       example shouldBe bytes
     }
   }
-
-  "unsafeReadInputStreamAsync" - {
-    "non-buffered" in forAll { (bytes: Array[Byte], chunkSize: SmallPositive) =>
-      val is: InputStream = new ByteArrayInputStream(bytes)
-      val stream = unsafeReadInputStreamAsync(IO(is), chunkSize.get, executionContext)
-      val example = stream.compile.toVector.unsafeRunSync.toArray
-      example shouldBe bytes
-    }
-  }
-
 }


### PR DESCRIPTION
Consolidated the sync/async versions of methods that deal with input and output streams. The sync versions were dangerous and when their signatures were corrected to use a blocking execution context, the async ones became redundant.

Similar PR coming for `file` package.