### PR TITLE
Add fs2-cron to the list of projects using FS2

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ If you have a project you'd like to include in this list, either open a PR or le
 * [doobie](https://github.com/tpolecat/doobie): Pure functional JDBC built on fs2.
 * [fs2-blobstore](https://github.com/lendup/fs2-blobstore): Minimal, idiomatic, stream-based Scala interface for key/value store implementations.
 * [fs2-cassandra](https://github.com/Spinoco/fs2-cassandra): Cassandra bindings for fs2.
+* [fs2-cron](https://github.com/fthomas/fs2-cron): FS2 streams based on cron expressions.
 * [fs2-crypto](https://github.com/Spinoco/fs2-crypto): TLS support for fs2.
 * [fs2-elastic](https://github.com/amarrella/fs2-elastic): Simple client for Elasticsearch.
 * [fs2-grpc](https://github.com/fiadliel/fs2-grpc): gRPC implementation for FS2 / Cats Effect.


### PR DESCRIPTION
This adds [fs2-cron](https://github.com/fthomas/fs2-cron) to the list of projects using FS2. It is a small library that provides variants of `Stream.awakeEvery` and `Stream.sleep` that uses [Cron4s](https://github.com/alonsodomin/cron4s) cron expressions and the current date-time to determine the duration these streams will sleep.

Here is a simple example from the README:
```scala
import cats.effect.{IO, Timer}
import cron4s.Cron
import eu.timepit.fs2cron.awakeEveryCron
import fs2.Stream
import java.time.LocalTime
import scala.concurrent.ExecutionContext

implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)

val evenSeconds = Cron.unsafeParse("*/2 * * ? * *")
// evenSeconds: cron4s.expr.CronExpr = */2 * * ? * *

val printTime = Stream.eval(IO(println(LocalTime.now)))
// printTime: fs2.Stream[cats.effect.IO,Unit] = Stream(..)

val scheduled = awakeEveryCron[IO](evenSeconds) >> printTime
// scheduled: fs2.Stream[[x]cats.effect.IO[x],Unit] = Stream(..)

scheduled.take(3).compile.drain.unsafeRunSync
// 23:21:42.107
// 23:21:44.005
// 23:21:46.003
```