### PR TITLE
Add Stream.never

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2584,6 +2584,12 @@ object Stream extends StreamLowPriority {
     Stream.fromFreeC(Algebra.getScope[F, Scope[F], Scope[F]].flatMap(Algebra.output1(_)))
 
   /**
+    * A stream that never emits and never terminates.
+    */
+  def never[F[_]](implicit F: Async[F]): Stream[F, Nothing] =
+    Stream.eval_(F.never)
+
+  /**
     * Creates a stream that, when run, fails with the supplied exception.
     *
     * The `F` type must be explicitly provided (e.g., via `raiseError[IO]` or `raiseError[Fallible]`).


### PR DESCRIPTION
This is a convenience I've written a handful of times to hold a server application open.

Couldn't think of a test that adds to the type.