### PR TITLE
Fixed a bug in Chunk#toArray when the backing type is ByteBufferChunk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
   - sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 -Dfs2.test.verbose testJVM
   - sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 -Dfs2.test.verbose testJS
   - sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 doc mimaReportBinaryIssues
-  - (test $TRAVIS_SCALA_VERSION == "2.11.12" && sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 -J-Xms2g -J-Xmx2g docs/tut) || test $TRAVIS_SCALA_VERSION == "2.12.6"
+  - (test $TRAVIS_SCALA_VERSION == "2.11.12" && sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 -J-Xms2g -J-Xmx2g docs/tut) || test $TRAVIS_SCALA_VERSION == "2.12.7"
 
 after_success:
   - test $PUBLISH == "true" && test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "series/1.0" && sbt +publish

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -784,7 +784,7 @@ object Chunk {
       val bs = new Array[C](size)
       val b = duplicate(buf)
       b.position(offset)
-      get(buf, bs, 0, size)
+      get(b, bs, 0, size)
       bs.asInstanceOf[Array[O2]]
     }
 

--- a/core/shared/src/main/scala/fs2/concurrent/Queue.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Queue.scala
@@ -43,9 +43,9 @@ trait Dequeue1[F[_], A] {
   def dequeue1: F[A]
 
   /**
-   * Tries to dequeue a single element. Unlike `dequeue1`, this method does not semantically
-   * block until a chunk is available - instead, `None` is returned immediately.
-   */
+    * Tries to dequeue a single element. Unlike `dequeue1`, this method does not semantically
+    * block until a chunk is available - instead, `None` is returned immediately.
+    */
   def tryDequeue1: F[Option[A]]
 }
 
@@ -56,10 +56,10 @@ trait DequeueChunk1[F[_], G[_], A] {
   def dequeueChunk1(maxSize: Int): F[G[Chunk[A]]]
 
   /**
-   * Tries to dequeue a single chunk of no more than `max size` elements.
-   * Unlike `dequeueChunk1`, this method does not semantically block until a chunk is available -
-   * instead, `None` is returned immediately.
-   */
+    * Tries to dequeue a single chunk of no more than `max size` elements.
+    * Unlike `dequeueChunk1`, this method does not semantically block until a chunk is available -
+    * instead, `None` is returned immediately.
+    */
   def tryDequeueChunk1(maxSize: Int): F[Option[G[Chunk[A]]]]
 }
 

--- a/core/shared/src/test/scala/fs2/ChunkProps.scala
+++ b/core/shared/src/test/scala/fs2/ChunkProps.scala
@@ -33,8 +33,10 @@ object ChunkProps
   def propToArray[A: ClassTag: Arbitrary, C <: Chunk[A]: Arbitrary] =
     forAll { c: C =>
       c.toArray.toVector shouldBe c.toVector
+      // Do it twice to make sure the first time didn't mutate state
+      c.toArray.toVector shouldBe c.toVector
     }
-    
+
   def propCopyToArray[A: ClassTag: Arbitrary, C <: Chunk[A]: Arbitrary] =
     forAll { c: C =>
       val arr = new Array[A](c.size * 2)

--- a/io/src/main/scala/fs2/io/file/file.scala
+++ b/io/src/main/scala/fs2/io/file/file.scala
@@ -7,7 +7,6 @@ import scala.concurrent.duration._
 import java.nio.file.{Path, StandardOpenOption, WatchEvent}
 
 import cats.effect.{Concurrent, ContextShift, Resource, Sync}
-import cats.implicits._
 
 /** Provides support for working with files. */
 package object file {


### PR DESCRIPTION
Saw this when using http4s 0.19.0-M3:

```
"message":"Error writing body",
"logger_name":"org.http4s.server.blaze.Http1ServerStage$$anon$1",
"thread_name":"scala-execution-context-global-26",
"level":"ERROR",
"level_value":40000,
"stack_trace":"java.nio.BufferUnderflowException: null
at java.nio.HeapByteBuffer.get(HeapByteBuffer.java:151)
at fs2.Chunk$ByteBuffer.get(Chunk.scala:1035)
at fs2.Chunk$ByteBuffer.get(Chunk.scala:1021)
at fs2.Chunk$Buffer.toArray(Chunk.scala:787)
at fs2.compress$.$anonfun$_deflate_stream$2(compress.scala:36)
at fs2.compress$.$anonfun$_deflate_stream$2$adapted(compress.scala:34)
at fs2.Pull$.$anonfun$flatMap$1(Pull.scala:60)
at fs2.internal.FreeC.$anonfun$flatMap$1(FreeC.scala:35)
at fs2.internal.FreeC$ViewL$.$anonfun$mk$1(FreeC.scala:233)
at fs2.internal.FreeC$ViewL$.mk(FreeC.scala:231)
at fs2.internal.FreeC$ViewL$.apply(FreeC.scala:223)
at fs2.internal.FreeC.viewL(FreeC.scala:69)
at fs2.internal.Algebra$.go$1(Algebra.scala:238)
at fs2.internal.Algebra$.$anonfun$compileLoop$10(Algebra.scala:285)
at fs2.internal.Algebra$.$anonfun$compileLoop$1(Algebra.scala:254)
at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:137)
at cats.effect.internals.IORunLoop$RestartCallback.signal(IORunLoop.scala:336)
at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:357)
at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:303)
at cats.effect.internals.Callback$AsyncIdempotentCallback.run(Callback.scala:127)
at cats.effect.internals.Trampoline.cats$effect$internals$Trampoline$$immediateLoop(Trampoline.scala:70)
at cats.effect.internals.Trampoline.startLoop(Trampoline.scala:36)
at cats.effect.internals.TrampolineEC$JVMTrampoline.super$startLoop(TrampolineEC.scala:93)
at cats.effect.internals.TrampolineEC$JVMTrampoline.$anonfun$startLoop$1(TrampolineEC.scala:93)
at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:81)
at cats.effect.internals.TrampolineEC$JVMTrampoline.startLoop(TrampolineEC.scala:93)
```

This is caused by a bug in `Chunk#toArray` -- it erroneously passed the original `buf` instead of the duplicated `b` buffer to `get`. Hence, the internal state of `buf` is mutated by `get` resulting in an underflow when calling `toArray` a second time.