### PR TITLE
Avoid stackoverflow in Topic

### DIFF
--- a/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
+++ b/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
@@ -2,10 +2,17 @@ package fs2
 
 import scala.concurrent.ExecutionContext
 import cats.effect.{ContextShift, IO, Timer}
-import fs2.concurrent.{Queue, SignallingRef}
+import fs2.concurrent.{Queue, SignallingRef, Topic}
 
 // Sanity tests - not run as part of unit tests, but these should run forever
 // at constant memory.
+
+object TopicContinuousPublishSanityTest extends App {
+  implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.Implicits.global)
+  Topic[IO, Int](-1)
+    .flatMap(topic => Stream.repeatEval(topic.publish1(1)).compile.drain)
+    .unsafeRunSync()
+}
 
 object ResourceTrackerSanityTest extends App {
   val big = Stream.constant(1).flatMap { n =>

--- a/core/shared/src/main/scala/fs2/concurrent/Topic.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Topic.scala
@@ -168,7 +168,7 @@ object Topic {
         def publish(i: A, state: State[A]): State[A] =
           State(
             last = i,
-            subcribers = state.subcribers.mapValues(_ :+ i)
+            subcribers = state.subcribers.map { case (k, v) => (k, v :+ i) }
           )
 
         def get(selector: (Token, Int), state: State[A]): (State[A], Option[ScalaQueue[A]]) =


### PR DESCRIPTION
During some stress testing of my app i encountered a stackoverflow in [Topic](https://github.com/functional-streams-for-scala/fs2/blob/ff319f2310ef94d6c8781b5de46203f5dfdda47f/core/shared/src/main/scala/fs2/concurrent/Topic.scala#L166). The problem seems to be the use of `mapValues` in `publish` since it only wraps the `Map` in `MappedValues` ([known issue](https://github.com/scala/bug/issues/9499)). So if `accepts` is called after a lot of successive `publish` calls it blows up with a stackoverflow.

After applying this patch i did not encounter any stackoverflows anymore.

