### PR TITLE
Add isOpen to Socket Interface

### DIFF
--- a/io/src/main/scala/fs2/io/tcp/Socket.scala
+++ b/io/src/main/scala/fs2/io/tcp/Socket.scala
@@ -65,6 +65,8 @@ trait Socket[F[_]] {
   /** Indicates to peer, we are done writing. **/
   def endOfOutput: F[Unit]
 
+  def isOpen : F[Boolean]
+
   /** Closes the connection corresponding to this `Socket`. */
   def close: F[Unit]
 
@@ -338,6 +340,7 @@ protected[tcp] object Socket {
 
           def localAddress: F[SocketAddress] = F.delay(ch.getLocalAddress)
           def remoteAddress: F[SocketAddress] = F.delay(ch.getRemoteAddress)
+          def isOpen : F[Boolean] = F.delay(ch.isOpen)
           def close: F[Unit] = F.delay(ch.close())
           def endOfOutput: F[Unit] = F.delay { ch.shutdownOutput(); () }
           def endOfInput: F[Unit] = F.delay { ch.shutdownInput(); () }


### PR DESCRIPTION
I was trying to create a ConnectionPool for a client. However these sockets sitting somewhere may be dead whenever we come back to them, presently I have no way to tell which of a pool of sockets would be still active to be reused. This would hopefully restore my ability in this regard.