### PR TITLE
Fix parEvalMap getting stuck on exception

### DIFF
--- a/core/jvm/src/test/scala/fs2/PipeSpec.scala
+++ b/core/jvm/src/test/scala/fs2/PipeSpec.scala
@@ -183,6 +183,12 @@ class PipeSpec extends Fs2Spec {
       runLog(r) shouldBe runLog(s.get).map(f)
     }
 
+    "mapAsync.exception" in forAll { s: PureStream[Int] =>
+      val f = (_: Int) => IO.raiseError[Int](new RuntimeException)
+      val r = s.get.covary[IO].mapAsync(1)(f).attempt
+      runLog(r).size == 1
+    }
+
     "mapAsyncUnordered" in forAll { s: PureStream[Int] =>
       val f = (_: Int) + 1
       val r = s.get.covary[IO].mapAsyncUnordered(16)(i => IO(f(i)))

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1626,24 +1626,31 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
     */
   def parEvalMap[F2[x] >: F[x]: Concurrent, O2](maxConcurrent: Int)(
       f: O => F2[O2]): Stream[F2, O2] =
-    Stream
-      .eval(Queue.bounded[F2, Option[F2[Either[Throwable, O2]]]](maxConcurrent))
-      .flatMap { queue =>
-        queue.dequeue.unNoneTerminate
-          .evalMap(identity)
-          .rethrow
-          .concurrently {
-            evalMap { o =>
-              Deferred[F2, Either[Throwable, O2]].flatMap { value =>
-                queue.enqueue1(Some(value.get)).as {
-                  Stream.eval(f(o).attempt).evalMap(value.complete)
+    Stream.eval(Queue.bounded[F2, Option[F2[Either[Throwable, O2]]]](maxConcurrent)).flatMap {
+      queue =>
+        Stream.eval(Deferred[F2, Unit]).flatMap { dequeueDone =>
+          queue.dequeue.unNoneTerminate
+            .evalMap(identity)
+            .rethrow
+            .onFinalize(dequeueDone.complete(()))
+            .concurrently {
+              evalMap { o =>
+                Deferred[F2, Either[Throwable, O2]].flatMap { value =>
+                  val enqueue =
+                    queue.enqueue1(Some(value.get)).as {
+                      Stream.eval(f(o).attempt).evalMap(value.complete)
+                    }
+
+                  Concurrent[F2].race(dequeueDone.get, enqueue).map {
+                    case Left(())      => Stream.empty.covaryAll[F2, Unit]
+                    case Right(stream) => stream
+                  }
                 }
-              }
-            }.parJoin(maxConcurrent)
-              .drain
-              .onFinalize(queue.enqueue1(None))
-          }
-      }
+              }.parJoin(maxConcurrent)
+                .onFinalize(Concurrent[F2].race(dequeueDone.get, queue.enqueue1(None)).void)
+            }
+        }
+    }
 
   /**
     * Like [[Stream#evalMap]], but will evaluate effects in parallel, emitting the results


### PR DESCRIPTION
Fix #1297. Explanation is in https://github.com/functional-streams-for-scala/fs2/issues/1297#issuecomment-436666729.