### PR TITLE
groupWithin leak

### DIFF
--- a/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
+++ b/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
@@ -6,6 +6,20 @@ import fs2.concurrent.{Queue, SignallingRef, Topic}
 
 // Sanity tests - not run as part of unit tests, but these should run forever
 // at constant memory.
+object GroupWithinSanityTest extends App {
+  implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+  implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
+
+  import scala.concurrent.duration._
+
+  Stream
+    .eval(IO.never)
+    .covary[IO]
+    .groupWithin(Int.MaxValue, 1.millis)
+    .compile
+    .drain
+    .unsafeRunSync()
+}
 
 object TopicContinuousPublishSanityTest extends App {
   implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.Implicits.global)

--- a/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
+++ b/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
@@ -21,6 +21,22 @@ object GroupWithinSanityTest extends App {
     .unsafeRunSync()
 }
 
+object GroupWithinSanityTest2 extends App {
+  implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+  implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
+
+  import scala.concurrent.duration._
+
+  val a: Stream[IO, Chunk[Int]] = Stream
+    .eval(IO.never)
+    .covary[IO]
+    .groupWithin(Int.MaxValue, 1.second)
+    .interruptAfter(100.millis) ++ a
+
+  a.compile.drain
+    .unsafeRunSync()
+}
+
 object TopicContinuousPublishSanityTest extends App {
   implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.Implicits.global)
   Topic[IO, Int](-1)

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1113,9 +1113,11 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
     Stream
       .eval(Queue.synchronousNoneTerminated[F2, Either[Token, Chunk[O]]])
       .flatMap { q =>
-        def startTimeout: Stream[F2, Token] =
-          Stream.eval(F.delay(new Token)).flatTap { t =>
-            Stream.supervise { timer.sleep(d) *> q.enqueue1(t.asLeft.some) }
+        import cats.effect.implicits._
+        def startTimeout: Stream[F2, (Token, CancelToken[F2])] =
+          Stream.eval(F.delay(new Token)).evalMap { t =>
+            val fiber = (timer.sleep(d) *> q.enqueue1(t.asLeft.some)).start
+            fiber.map(f => t -> f.cancel)
           }
 
         def producer = this.chunks.map(_.asRight.some).to(q.enqueue).onFinalize(q.enqueue1(None))
@@ -1131,30 +1133,37 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
             resize(rest, s ++ Stream.emit(unit))
           }
 
-        def go(acc: Chain[Chunk[O]], elems: Int, currentTimeout: Token): Stream[F2, Chunk[O]] =
+        def go(acc: Chain[Chunk[O]],
+               elems: Int,
+               currentTimeout: Token,
+               cancelCurrentTimeout: CancelToken[F2]): Stream[F2, Chunk[O]] =
           Stream.eval(q.dequeue1).flatMap {
             case None => emitNonEmpty(acc)
             case Some(e) =>
               e match {
                 case Left(t) if t == currentTimeout =>
-                  emitNonEmpty(acc) ++ startTimeout.flatMap { newTimeout =>
-                    go(Chain.empty, 0, newTimeout)
+                  emitNonEmpty(acc) ++ startTimeout.flatMap {
+                    case (newTimeout, newCancel) =>
+                      go(Chain.empty, 0, newTimeout, newCancel)
                   }
-                case Left(t) if t != currentTimeout => go(acc, elems, currentTimeout)
+                case Left(t) if t != currentTimeout =>
+                  go(acc, elems, currentTimeout, cancelCurrentTimeout)
                 case Right(c) if elems + c.size >= n =>
                   val totalChunk = Chunk.concat((acc :+ c).toList)
                   val (toEmit, rest) = resize(totalChunk, Stream.empty)
 
-                  toEmit ++ startTimeout.flatMap { newTimeout =>
-                    go(Chain.one(rest), rest.size, newTimeout)
+                  toEmit ++ Stream.eval_(cancelCurrentTimeout) ++ startTimeout.flatMap {
+                    case (newTimeout, newCancel) =>
+                      go(Chain.one(rest), rest.size, newTimeout, newCancel)
                   }
                 case Right(c) if elems + c.size < n =>
-                  go(acc :+ c, elems + c.size, currentTimeout)
+                  go(acc :+ c, elems + c.size, currentTimeout, cancelCurrentTimeout)
               }
           }
 
-        startTimeout.flatMap { t =>
-          go(Chain.empty, 0, t).concurrently(producer)
+        startTimeout.flatMap {
+          case (t, c) =>
+            go(Chain.empty, 0, t, c).concurrently(producer)
         }
       }
 

--- a/core/shared/src/main/scala/fs2/internal/Resource.scala
+++ b/core/shared/src/main/scala/fs2/internal/Resource.scala
@@ -97,7 +97,7 @@ private[internal] object Resource {
       open: Boolean,
       finalizer: Option[ExitCase[Throwable] => F[Either[Throwable, Unit]]],
       leases: Int
-  ){
+  ) {
     /* The `isFinished` predicate indicates that the finalizer can be run at the present state:
       which happens IF it is closed, AND there are no acquired leases pending to be released. */
     @inline def isFinished: Boolean = !open && leases == 0


### PR DESCRIPTION
Attempts to fix #1303

In particular, it definitely fixes the original leak, and it appears to not leak outstanding timeouts either, but I'm not 100% sure about how airtight the resource safety on that timeout being canceled is. 
It kinda relies on `onFinalise` not running until the `finaliser` in the `bracket` in `startTimeout` has completed. Ideas welcome