### PR TITLE
Small Change: Ancestors need no F

### DIFF
--- a/core/shared/src/main/scala/fs2/internal/CompileScope.scala
+++ b/core/shared/src/main/scala/fs2/internal/CompileScope.scala
@@ -248,12 +248,12 @@ private[fs2] final class CompileScope[F[_], O] private (
     }
 
   /** Gets all ancestors of this scope, inclusive of root scope. **/
-  private def ancestors: F[Chain[CompileScope[F, O]]] = {
+  private def ancestors: Chain[CompileScope[F, O]] = {
     @tailrec
-    def go(curr: CompileScope[F, O], acc: Chain[CompileScope[F, O]]): F[Chain[CompileScope[F, O]]] =
+    def go(curr: CompileScope[F, O], acc: Chain[CompileScope[F, O]]): Chain[CompileScope[F, O]] =
       curr.parent match {
         case Some(parent) => go(parent, acc :+ parent)
-        case None         => F.pure(acc)
+        case None         => acc
       }
     go(self, Chain.empty)
   }
@@ -335,22 +335,20 @@ private[fs2] final class CompileScope[F[_], O] private (
       if (!s.open) F.pure(None)
       else {
         F.flatMap(Traverse[Chain].traverse(s.children :+ self)(_.resources)) { childResources =>
-          F.flatMap(ancestors) { anc =>
-            F.flatMap(Traverse[Chain].traverse(anc) { _.resources }) { ancestorResources =>
-              val allLeases = childResources.flatMap(identity) ++ ancestorResources
-                .flatMap(identity)
-              F.map(Traverse[Chain].traverse(allLeases) { r =>
-                r.lease
-              }) { leased =>
-                val allLeases = leased.collect {
-                  case Some(resourceLease) => resourceLease
-                }
-                val lease = new Scope.Lease[F] {
-                  def cancel: F[Either[Throwable, Unit]] =
-                    traverseError[Scope.Lease[F]](allLeases, _.cancel)
-                }
-                Some(lease)
+          F.flatMap(Traverse[Chain].traverse(ancestors) { _.resources }) { ancestorResources =>
+            val allLeases = childResources.flatMap(identity) ++ ancestorResources
+              .flatMap(identity)
+            F.map(Traverse[Chain].traverse(allLeases) { r =>
+              r.lease
+            }) { leased =>
+              val allLeases = leased.collect {
+                case Some(resourceLease) => resourceLease
               }
+              val lease = new Scope.Lease[F] {
+                def cancel: F[Either[Throwable, Unit]] =
+                  traverseError[Scope.Lease[F]](allLeases, _.cancel)
+              }
+              Some(lease)
             }
           }
         }


### PR DESCRIPTION
Some small code changes for the `CompileScope` class.
- The `ancestors` inner function, which runs through the chain of a scope's parents, is a pure function and  needs no `F` wrapper.
- We use functions from `cats.Traverse` and `cats.TraverseFilter`, for removing nested container layers.