### PR TITLE
Removed ConcurrentEffect from tcp/udp packages - NOT FOR MERGE

### DIFF
--- a/core/shared/src/main/scala/fs2/internal/CompileScope.scala
+++ b/core/shared/src/main/scala/fs2/internal/CompileScope.scala
@@ -336,9 +336,9 @@ private[fs2] final class CompileScope[F[_], O] private (
       else {
         val allScopes = (s.children :+ self) ++ ancestors
         F.flatMap(Traverse[Chain].flatTraverse(allScopes)(_.resources)) { allResources =>
-          F.map(TraverseFilter[Chain].traverseFilter(allResources){ r =>
+          F.map(TraverseFilter[Chain].traverseFilter(allResources) { r =>
             r.lease
-          }){ allLeases =>
+          }) { allLeases =>
             val lease = new Scope.Lease[F] {
               def cancel: F[Either[Throwable, Unit]] =
                 traverseError[Scope.Lease[F]](allLeases, _.cancel)

--- a/io/src/main/scala/fs2/io/io.scala
+++ b/io/src/main/scala/fs2/io/io.scala
@@ -1,6 +1,6 @@
 package fs2
 
-import cats.effect.{ConcurrentEffect, ContextShift, IO, Sync}
+import cats.effect.{ConcurrentEffect, ContextShift, Sync}
 
 import cats.implicits._
 import java.io.{InputStream, OutputStream}
@@ -136,8 +136,4 @@ package object io {
     */
   def toInputStream[F[_]](implicit F: ConcurrentEffect[F]): Pipe[F, Byte, InputStream] =
     JavaInputOutputStream.toInputStream
-
-  private[io] def invokeCallback[F[_]](f: => Unit)(implicit F: ConcurrentEffect[F]): Unit =
-    F.runAsync(F.start(F.delay(f)).flatMap(_.join))(_ => IO.unit).unsafeRunSync
-
 }

--- a/io/src/main/scala/fs2/io/tcp/tcp.scala
+++ b/io/src/main/scala/fs2/io/tcp/tcp.scala
@@ -4,7 +4,7 @@ package io
 import java.net.InetSocketAddress
 import java.nio.channels.AsynchronousChannelGroup
 
-import cats.effect.{ConcurrentEffect, Resource}
+import cats.effect.{Concurrent, ContextShift, Resource}
 
 /** Provides support for TCP networking. */
 package object tcp {
@@ -28,7 +28,9 @@ package object tcp {
       receiveBufferSize: Int = 256 * 1024,
       keepAlive: Boolean = false,
       noDelay: Boolean = false
-  )(implicit AG: AsynchronousChannelGroup, F: ConcurrentEffect[F]): Resource[F, Socket[F]] =
+  )(implicit AG: AsynchronousChannelGroup,
+    F: Concurrent[F],
+    cs: ContextShift[F]): Resource[F, Socket[F]] =
     Socket.client(to, reuseAddress, sendBufferSize, receiveBufferSize, keepAlive, noDelay)
 
   /**
@@ -56,7 +58,8 @@ package object tcp {
                    reuseAddress: Boolean = true,
                    receiveBufferSize: Int = 256 * 1024)(
       implicit AG: AsynchronousChannelGroup,
-      F: ConcurrentEffect[F]
+      F: Concurrent[F],
+      cs: ContextShift[F]
   ): Stream[F, Resource[F, Socket[F]]] =
     serverWithLocalAddress(bind, maxQueued, reuseAddress, receiveBufferSize)
       .collect { case Right(s) => s }
@@ -71,7 +74,8 @@ package object tcp {
                                    reuseAddress: Boolean = true,
                                    receiveBufferSize: Int = 256 * 1024)(
       implicit AG: AsynchronousChannelGroup,
-      F: ConcurrentEffect[F]
+      F: Concurrent[F],
+      cs: ContextShift[F]
   ): Stream[F, Either[InetSocketAddress, Resource[F, Socket[F]]]] =
     Socket.server(bind, maxQueued, reuseAddress, receiveBufferSize)
 }

--- a/io/src/main/scala/fs2/io/udp/udp.scala
+++ b/io/src/main/scala/fs2/io/udp/udp.scala
@@ -4,7 +4,7 @@ package io
 import java.net.{InetSocketAddress, NetworkInterface, ProtocolFamily, StandardSocketOptions}
 import java.nio.channels.DatagramChannel
 
-import cats.effect.{ConcurrentEffect, Resource}
+import cats.effect.{Async, ContextShift, Resource}
 import cats.implicits._
 
 /** Provides support for UDP networking. */
@@ -33,7 +33,9 @@ package object udp {
       multicastInterface: Option[NetworkInterface] = None,
       multicastTTL: Option[Int] = None,
       multicastLoopback: Boolean = true
-  )(implicit AG: AsynchronousSocketGroup, F: ConcurrentEffect[F]): Resource[F, Socket[F]] = {
+  )(implicit AG: AsynchronousSocketGroup,
+    F: Async[F],
+    cs: ContextShift[F]): Resource[F, Socket[F]] = {
     val mkChannel = F.delay {
       val channel = protocolFamily
         .map { pf =>


### PR DESCRIPTION
This is a proof of concept PR which removes `ConcurrentEffect` from the `tcp` and `udp` packages. I'd like to also remove it from `JavaInputOutputStream` if possible. Assuming we're good with this approach, I'll figure out how to update this PR to preserve binary compatibility.

cc @tpolecat 