### PR TITLE
Expands the ScalaDocs for the Stream class.

### DIFF
--- a/core/shared/src/main/scala/fs2/internal/CompileScope.scala
+++ b/core/shared/src/main/scala/fs2/internal/CompileScope.scala
@@ -336,9 +336,9 @@ private[fs2] final class CompileScope[F[_], O] private (
       else {
         val allScopes = (s.children :+ self) ++ ancestors
         F.flatMap(Traverse[Chain].flatTraverse(allScopes)(_.resources)) { allResources =>
-          F.map(TraverseFilter[Chain].traverseFilter(allResources){ r =>
+          F.map(TraverseFilter[Chain].traverseFilter(allResources) { r =>
             r.lease
-          }){ allLeases =>
+          }) { allLeases =>
             val lease = new Scope.Lease[F] {
               def cancel: F[Either[Throwable, Unit]] =
                 traverseError[Scope.Lease[F]](allLeases, _.cancel)


### PR DESCRIPTION
We extend the ScalaDocs description of the Stream class.

- We adds some descriptions for the notions of pull-based evaluation, and laziness. We show some special cases of Streams.
- We add a section describing the equivalence between some of the methods of the Stream class, and similar methods in the List class. This equivalences hold true for finite and pure streams.
- We add into the docs of some of methods a description of how the methods handles non-terminating streams.

Thanks to @SystemFw for clarifying some doubts and questions for this PR.