### PR TITLE
Remove the EitherSyntax class

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -196,6 +196,7 @@ lazy val mimaSettings = Seq(
     organization.value % (normalizedName.value + "_" + scalaBinaryVersion.value) % pv
   }.toSet,
   mimaBinaryIssueFilters ++= Seq(
+    ProblemFilters.exclude[Problem]("fs2.package*EitherSyntax*"),
     ProblemFilters.exclude[Problem]("fs2.internal.*"),
     ProblemFilters.exclude[Problem]("fs2.Stream#StepLeg.this"),
     ProblemFilters.exclude[Problem]("fs2.concurrent.Publish.*"),

--- a/core/jvm/src/test/scala/fs2/PipeSpec.scala
+++ b/core/jvm/src/test/scala/fs2/PipeSpec.scala
@@ -569,7 +569,7 @@ class PipeSpec extends Fs2Spec {
             .attempt
         }
         r1 should have size (1)
-        r1.head.swap.toOption.get shouldBe an[Err]
+        r1.head.swap.right.get shouldBe an[Err]
         val r2 = runLog {
           s.get
             .covary[IO]
@@ -579,7 +579,7 @@ class PipeSpec extends Fs2Spec {
             .attempt
         }
         r2 should have size (1)
-        r2.head.swap.toOption.get shouldBe an[Err]
+        r2.head.swap.right.get shouldBe an[Err]
       }
     }
 
@@ -592,7 +592,7 @@ class PipeSpec extends Fs2Spec {
             .attempt
         }
         r1 should have size (1)
-        r1.head.swap.toOption.get shouldBe an[Err]
+        r1.head.swap.right.get shouldBe an[Err]
         val r2 = runLog {
           f.get
             .covary[IO]
@@ -600,7 +600,7 @@ class PipeSpec extends Fs2Spec {
             .attempt
         }
         r2 should have size (1)
-        r2.head.swap.toOption.get shouldBe an[Err]
+        r2.head.swap.right.get shouldBe an[Err]
       }
     }
 

--- a/core/jvm/src/test/scala/fs2/PipeSpec.scala
+++ b/core/jvm/src/test/scala/fs2/PipeSpec.scala
@@ -569,7 +569,7 @@ class PipeSpec extends Fs2Spec {
             .attempt
         }
         r1 should have size (1)
-        r1.head.swap.right.get shouldBe an[Err]
+        r1.head.left.get shouldBe an[Err]
         val r2 = runLog {
           s.get
             .covary[IO]
@@ -579,7 +579,7 @@ class PipeSpec extends Fs2Spec {
             .attempt
         }
         r2 should have size (1)
-        r2.head.swap.right.get shouldBe an[Err]
+        r2.head.left.get shouldBe an[Err]
       }
     }
 
@@ -592,7 +592,7 @@ class PipeSpec extends Fs2Spec {
             .attempt
         }
         r1 should have size (1)
-        r1.head.swap.right.get shouldBe an[Err]
+        r1.head.left.get shouldBe an[Err]
         val r2 = runLog {
           f.get
             .covary[IO]
@@ -600,7 +600,7 @@ class PipeSpec extends Fs2Spec {
             .attempt
         }
         r2 should have size (1)
-        r2.head.swap.right.get shouldBe an[Err]
+        r2.head.left.get shouldBe an[Err]
       }
     }
 

--- a/core/jvm/src/test/scala/fs2/ResourceSafetySpec.scala
+++ b/core/jvm/src/test/scala/fs2/ResourceSafetySpec.scala
@@ -353,9 +353,9 @@ class ResourceSafetySpec extends Fs2Spec with EventuallySupport {
       val s2 = Stream.bracket(IO("a"))(_ => IO.raiseError(new Err))
 
       val r1 = s1.zip(s2).compile.drain.attempt.unsafeRunSync()
-      r1.swap.right.get shouldBe an[Err]
+      r1.left.get shouldBe an[Err]
       val r2 = s2.zip(s1).compile.drain.attempt.unsafeRunSync()
-      r2.swap.right.get shouldBe an[Err]
+      r2.left.get shouldBe an[Err]
     }
 
     def bracket[A](c: AtomicLong)(s: Stream[IO, A]): Stream[IO, A] =

--- a/core/jvm/src/test/scala/fs2/ResourceSafetySpec.scala
+++ b/core/jvm/src/test/scala/fs2/ResourceSafetySpec.scala
@@ -353,9 +353,9 @@ class ResourceSafetySpec extends Fs2Spec with EventuallySupport {
       val s2 = Stream.bracket(IO("a"))(_ => IO.raiseError(new Err))
 
       val r1 = s1.zip(s2).compile.drain.attempt.unsafeRunSync()
-      r1.swap.toOption.get shouldBe an[Err]
+      r1.swap.right.get shouldBe an[Err]
       val r2 = s2.zip(s1).compile.drain.attempt.unsafeRunSync()
-      r2.swap.toOption.get shouldBe an[Err]
+      r2.swap.right.get shouldBe an[Err]
     }
 
     def bracket[A](c: AtomicLong)(s: Stream[IO, A]): Stream[IO, A] =

--- a/core/jvm/src/test/scala/fs2/StreamSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamSpec.scala
@@ -121,7 +121,7 @@ class StreamSpec extends Fs2Spec with Inside {
         .compile
         .toVector
         .unsafeRunSync()
-      r.foreach(_.swap.toOption.get shouldBe an[Err])
+      r.foreach(_.swap.right.get shouldBe an[Err])
     }
 
     "handleErrorWith (5)" in {

--- a/core/jvm/src/test/scala/fs2/StreamSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamSpec.scala
@@ -121,7 +121,7 @@ class StreamSpec extends Fs2Spec with Inside {
         .compile
         .toVector
         .unsafeRunSync()
-      r.foreach(_.swap.right.get shouldBe an[Err])
+      r.foreach(_.left.get shouldBe an[Err])
     }
 
     "handleErrorWith (5)" in {

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1968,10 +1968,10 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
                                  rt: RaiseThrowable[F2]): Stream[F2, O2] = {
     val _ = ev // Convince scalac that ev is used
     this.asInstanceOf[Stream[F, Either[Throwable, O2]]].chunks.flatMap { c =>
-      val firstError = c.find(_.isLeft)
+      val firstError = c.collectFirst { case Left(err) => err }
       firstError match {
         case None    => Stream.chunk(c.collect { case Right(i) => i })
-        case Some(h) => Stream.raiseError[F2](h.swap.right.get)
+        case Some(h) => Stream.raiseError[F2](h)
       }
     }
   }

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1971,7 +1971,7 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
       val firstError = c.find(_.isLeft)
       firstError match {
         case None    => Stream.chunk(c.collect { case Right(i) => i })
-        case Some(h) => Stream.raiseError[F2](h.swap.toOption.get)
+        case Some(h) => Stream.raiseError[F2](h.swap.right.get)
       }
     }
   }

--- a/core/shared/src/main/scala/fs2/fs2.scala
+++ b/core/shared/src/main/scala/fs2/fs2.scala
@@ -33,21 +33,4 @@ package object fs2 {
     * Alias for `Nothing` which works better with type inference.
     */
   type INothing <: Nothing
-
-  // Trick to get right-biased syntax for Either in 2.11 while retaining source compatibility with 2.12 and leaving
-  // -Xfatal-warnings and -Xwarn-unused-imports enabled. Delete when no longer supporting 2.11.
-  private[fs2] implicit class EitherSyntax[L, R](private val self: Either[L, R]) extends AnyVal {
-    def map[R2](f: R => R2): Either[L, R2] = self match {
-      case Right(r)    => Right(f(r))
-      case l @ Left(_) => l.asInstanceOf[Either[L, R2]]
-    }
-    def flatMap[R2](f: R => Either[L, R2]): Either[L, R2] = self match {
-      case Right(r)    => f(r)
-      case l @ Left(_) => l.asInstanceOf[Either[L, R2]]
-    }
-    def toOption: Option[R] = self match {
-      case Right(r)    => Some(r)
-      case l @ Left(_) => None
-    }
-  }
 }


### PR DESCRIPTION
We remove the `EitherSyntax` implicit class. 

This implicit class was introduced to provide a Right-biased `flatMap` for the `Either` type when compiling with `Scala 2.11`. However, although `fs2` still supports Scala 2.11, the special right-biased `flatMap` was used nowhere in `fs2`. The only method being used was the `toOption`; and since that is was followed with `Option.get`, we can just use `.right.get` instead by way of the `Either.RightProjection` class.