### PR TITLE
Replace *> with >> to avoid memory issues

### DIFF
--- a/core/jvm/src/test/scala/fs2/MergeJoinSpec.scala
+++ b/core/jvm/src/test/scala/fs2/MergeJoinSpec.scala
@@ -249,7 +249,7 @@ class MergeJoinSpec extends Fs2Spec {
         Stream
           .repeatEval[IO, Unit](IO.async[Unit] { cb =>
             cb(Right(()))
-          } *> IO.shift)
+          } >> IO.shift)
           .drain
 
       "merge" in {

--- a/core/jvm/src/test/scala/fs2/Pipe2Spec.scala
+++ b/core/jvm/src/test/scala/fs2/Pipe2Spec.scala
@@ -548,8 +548,8 @@ class Pipe2Spec extends Fs2Spec {
               .scan(0)((acc, _) => acc + 1)
               .evalMap { n =>
                 if (n % 2 != 0)
-                  pause.set(true) *> ((Stream.sleep_[IO](10.millis) ++ Stream.eval(
-                    pause.set(false))).compile.drain).start *> IO.pure(n)
+                  pause.set(true) >> ((Stream.sleep_[IO](10.millis) ++ Stream.eval(
+                    pause.set(false))).compile.drain).start >> IO.pure(n)
                 else IO.pure(n)
               }
               .take(5)

--- a/core/jvm/src/test/scala/fs2/ResourceSafetySpec.scala
+++ b/core/jvm/src/test/scala/fs2/ResourceSafetySpec.scala
@@ -93,7 +93,7 @@ class ResourceSafetySpec extends Fs2Spec with EventuallySupport {
             }
           }
           .flatMap(_ => s0.get ++ Stream.never[IO])
-      s.compile.drain.start.flatMap(f => IO.sleep(50.millis) *> f.cancel).unsafeRunSync
+      s.compile.drain.start.flatMap(f => IO.sleep(50.millis) >> f.cancel).unsafeRunSync
       c.get shouldBe 0L
       ecs.toList.foreach(ec => assert(ec == ExitCase.Canceled))
     }
@@ -275,7 +275,7 @@ class ResourceSafetySpec extends Fs2Spec with EventuallySupport {
       forAll { (s: PureStream[PureStream[Int]]) =>
         val signal = SignallingRef[IO, Boolean](false).unsafeRunSync()
         val c = new AtomicLong(0)
-        (IO.shift *> IO { Thread.sleep(20L) } *> signal.set(true))
+        (IO.shift >> IO { Thread.sleep(20L) } >> signal.set(true))
           .unsafeRunSync()
         runLog {
           s.get.evalMap { inner =>
@@ -300,7 +300,7 @@ class ResourceSafetySpec extends Fs2Spec with EventuallySupport {
       val s = Stream(Stream(1))
       val signal = SignallingRef[IO, Boolean](false).unsafeRunSync()
       val c = new AtomicLong(0)
-      (IO.shift *> IO { Thread.sleep(50L) } *> signal.set(true)).start
+      (IO.shift >> IO { Thread.sleep(50L) } >> signal.set(true)).start
         .unsafeRunSync() // after 50 ms, interrupt
       runLog {
         s.evalMap { inner =>

--- a/core/jvm/src/test/scala/fs2/StreamCancelationSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamCancelationSpec.scala
@@ -8,7 +8,7 @@ import fs2.concurrent.Queue
 
 class StreamCancelationSpec extends AsyncFs2Spec {
   def startAndCancelSoonAfter[A](fa: IO[A]): IO[Unit] =
-    fa.start.flatMap(fiber => timerIO.sleep(1000.milliseconds) *> fiber.cancel)
+    fa.start.flatMap(fiber => timerIO.sleep(1000.milliseconds) >> fiber.cancel)
 
   def testCancelation[A](s: Stream[IO, A]): Future[Unit] =
     startAndCancelSoonAfter(s.compile.drain).unsafeToFuture

--- a/core/jvm/src/test/scala/fs2/StreamSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamSpec.scala
@@ -407,7 +407,7 @@ class StreamSpec extends Fs2Spec with Inside {
       val t =
         emitAndSleep.zip(Stream.duration[IO]).drop(1).map(_._2).compile.toVector
 
-      (IO.shift *> t).unsafeToFuture.collect {
+      (IO.shift >> t).unsafeToFuture.collect {
         case Vector(d) => assert(d.toMillis >= delay.toMillis - 5)
       }
     }
@@ -440,7 +440,7 @@ class StreamSpec extends Fs2Spec with Inside {
         .take(draws.toInt)
         .through(durationSinceLastTrue)
 
-      (IO.shift *> durationsSinceSpike.compile.toVector).unsafeToFuture().map { result =>
+      (IO.shift >> durationsSinceSpike.compile.toVector).unsafeToFuture().map { result =>
         val (head :: tail) = result.toList
         withClue("every always emits true first") { assert(head._1) }
         withClue("true means the delay has passed: " + tail) {

--- a/core/jvm/src/test/scala/fs2/StreamTimerSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamTimerSpec.scala
@@ -17,7 +17,7 @@ class StreamTimerSpec extends AsyncFs2Spec {
       val t =
         emitAndSleep.zip(Stream.duration[IO]).drop(1).map(_._2).compile.toVector
 
-      (IO.shift *> t).unsafeToFuture().collect {
+      (IO.shift >> t).unsafeToFuture().collect {
         case Vector(d) => assert(d >= delay)
       }
     }

--- a/core/jvm/src/test/scala/fs2/SwitchMapSpec.scala
+++ b/core/jvm/src/test/scala/fs2/SwitchMapSpec.scala
@@ -29,8 +29,8 @@ class SwitchMapSpec extends Fs2Spec with EventuallySupport {
             if (!released) Stream.raiseError[IO](new Err)
             else
               Stream
-                .eval(ref.set(false) *> IO.sleep(20.millis))
-                .onFinalize(IO.sleep(100.millis) *> ref.set(true))
+                .eval(ref.set(false) >> IO.sleep(20.millis))
+                .onFinalize(IO.sleep(100.millis) >> ref.set(true))
           }
         }
       }

--- a/core/jvm/src/test/scala/fs2/concurrent/QueueSpec.scala
+++ b/core/jvm/src/test/scala/fs2/concurrent/QueueSpec.scala
@@ -82,9 +82,9 @@ class QueueSpec extends Fs2Spec {
         Queue
           .unbounded[IO, Int]
           .flatMap { q =>
-            q.dequeue.interruptAfter(1.second).compile.drain *>
-              q.enqueue1(1) *>
-              q.enqueue1(2) *>
+            q.dequeue.interruptAfter(1.second).compile.drain >>
+              q.enqueue1(1) >>
+              q.enqueue1(2) >>
               q.dequeue1
           }
           .unsafeRunSync shouldBe 1
@@ -96,9 +96,9 @@ class QueueSpec extends Fs2Spec {
         Queue
           .unbounded[IO, Int]
           .flatMap { q =>
-            q.dequeue1.timeout(1.second).attempt *>
-              q.enqueue1(1) *>
-              q.enqueue1(2) *>
+            q.dequeue1.timeout(1.second).attempt >>
+              q.enqueue1(1) >>
+              q.enqueue1(2) >>
               q.dequeue1
           }
           .unsafeRunSync shouldBe 1

--- a/core/jvm/src/test/scala/fs2/concurrent/SignalSpec.scala
+++ b/core/jvm/src/test/scala/fs2/concurrent/SignalSpec.scala
@@ -25,7 +25,7 @@ class SignalSpec extends Fs2Spec {
         }
         val s = SignallingRef[IO, Long](0L).unsafeRunSync()
         val r = new AtomicLong(0)
-        (IO.shift *> s.discrete.map(r.set).compile.drain).unsafeToFuture()
+        (IO.shift >> s.discrete.map(r.set).compile.drain).unsafeToFuture()
         assert(vs.forall { v =>
           s.set(v).unsafeRunSync()
           while (s.get.unsafeRunSync() != v) {} // wait for set to arrive
@@ -44,7 +44,7 @@ class SignalSpec extends Fs2Spec {
         val vs = v0 :: vsTl
         val s = SignallingRef[IO, Long](0L).unsafeRunSync()
         val r = new AtomicLong(0)
-        (IO.shift *> s.discrete
+        (IO.shift >> s.discrete
           .map { i =>
             Thread.sleep(10); r.set(i)
           }

--- a/core/shared/src/test/scala/fs2/TestUtil.scala
+++ b/core/shared/src/test/scala/fs2/TestUtil.scala
@@ -12,7 +12,7 @@ import cats.implicits._
 
 object TestUtil extends TestUtilPlatform {
 
-  def runLogF[A](s: Stream[IO,A]): Future[Vector[A]] = (IO.shift(executionContext) *> s.compile.toVector).unsafeToFuture
+  def runLogF[A](s: Stream[IO,A]): Future[Vector[A]] = (IO.shift(executionContext) >> s.compile.toVector).unsafeToFuture
 
   def spuriousFail(s: Stream[IO,Int], f: Failure): Stream[IO,Int] =
     s.flatMap { i => if (i % (math.random * 10 + 1).toInt == 0) f.get

--- a/io/src/main/scala/fs2/io/JavaInputOutputStream.scala
+++ b/io/src/main/scala/fs2/io/JavaInputOutputStream.scala
@@ -175,7 +175,7 @@ private[io] object JavaInputOutputStream {
                       .update(setDone(None))
                       .as(-1) // update we are done, next read won't succeed
                   case Left(Some(err)) => // update we are failed, next read won't succeed
-                    dnState.update(setDone(err.some)) *> F.raiseError[Int](
+                    dnState.update(setDone(err.some)) >> F.raiseError[Int](
                       new IOException("UpStream failed", err))
                   case Right(bytes) =>
                     val (copy, maybeKeep) =
@@ -186,7 +186,7 @@ private[io] object JavaInputOutputStream {
                       }
                     F.delay {
                       Array.copy(copy.values, 0, dest, off, copy.size)
-                    } *> (maybeKeep match {
+                    } >> (maybeKeep match {
                       case Some(rem) if rem.size > 0 =>
                         dnState.set(Ready(rem.some)).as(copy.size)
                       case _ => copy.size.pure[F]

--- a/io/src/main/scala/fs2/io/file/Watcher.scala
+++ b/io/src/main/scala/fs2/io/file/Watcher.scala
@@ -158,7 +158,7 @@ object Watcher {
       registrations
         .update(_.updated(key, r))
         .as {
-          F.delay(key.cancel) *> registrations.modify { s =>
+          F.delay(key.cancel) >> registrations.modify { s =>
             (s - key) -> s.get(key).map(_.cleanup).getOrElse(F.unit)
           }.flatten
         }
@@ -263,7 +263,7 @@ object Watcher {
                     .update(
                       m =>
                         m.get(key)
-                          .map(r => m.updated(key, r.copy(cleanup = r.cleanup *> cancelAll)))
+                          .map(r => m.updated(key, r.copy(cleanup = r.cleanup >> cancelAll)))
                           .getOrElse(m))
                     .void
                   updateRegistration.as(events.flatten)

--- a/io/src/test/scala/fs2/io/file/WatcherSpec.scala
+++ b/io/src/test/scala/fs2/io/file/WatcherSpec.scala
@@ -45,7 +45,7 @@ class WatcherSpec extends BaseFileSpec {
           tempDirectory.flatMap { dir =>
             val a = dir.resolve("a")
             val b = a.resolve("b")
-            Stream.eval(IO(Files.createDirectory(a)) *> IO(Files.write(b, Array[Byte]()))) *>
+            Stream.eval(IO(Files.createDirectory(a)) >> IO(Files.write(b, Array[Byte]()))) >>
               (file
                 .watch[IO](dir, modifiers = modifiers)
                 .takeWhile({
@@ -66,7 +66,7 @@ class WatcherSpec extends BaseFileSpec {
                 case Watcher.Event.Created(b, _) => false; case _ => true
               })
               .concurrently(smallDelay ++ Stream.eval(
-                IO(Files.createDirectory(a)) *> IO(Files.write(b, Array[Byte]()))))
+                IO(Files.createDirectory(a)) >> IO(Files.write(b, Array[Byte]()))))
           }
         }
       }

--- a/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscriber.scala
+++ b/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscriber.scala
@@ -102,7 +102,7 @@ object StreamSubscriber {
         case Uninitialized                  => Idle(s) -> F.unit
         case o =>
           val err = new Error(s"received subscription in invalid state [$o]")
-          o -> F.delay(s.cancel) *> F.raiseError(err)
+          o -> F.delay(s.cancel) >> F.raiseError(err)
       }
       case OnNext(a) => {
         case WaitingOnUpstream(s, r) => Idle(s) -> r.complete(a.some.asRight)
@@ -119,7 +119,7 @@ object StreamSubscriber {
       }
       case OnFinalize => {
         case WaitingOnUpstream(sub, r) =>
-          DownstreamCancellation -> F.delay(sub.cancel) *> r.complete(None.asRight)
+          DownstreamCancellation -> F.delay(sub.cancel) >> r.complete(None.asRight)
         case Idle(sub) => DownstreamCancellation -> F.delay(sub.cancel)
         case o         => o -> F.unit
       }
@@ -142,7 +142,7 @@ object StreamSubscriber {
         def onFinalize: F[Unit] = nextState(OnFinalize)
         def dequeue1: F[Either[Throwable, Option[A]]] =
           Deferred[F, Out].flatMap { p =>
-            ref.modify(step(OnDequeue(p))).flatten *> p.get
+            ref.modify(step(OnDequeue(p))).flatten >> p.get
           }
       }
     }

--- a/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscription.scala
+++ b/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscription.scala
@@ -25,8 +25,8 @@ private[reactivestreams] final class StreamSubscription[F[_], A](
   import StreamSubscription._
 
   // We want to make sure `cancelled` is set _before_ signalling the subscriber
-  def onError(e: Throwable) = cancelled.set(true) *> F.delay(sub.onError(e))
-  def onComplete = cancelled.set(true) *> F.delay(sub.onComplete)
+  def onError(e: Throwable) = cancelled.set(true) >> F.delay(sub.onError(e))
+  def onComplete = cancelled.set(true) >> F.delay(sub.onComplete)
 
   def unsafeStart(): Unit = {
     def subscriptionPipe: Pipe[F, A, A] =

--- a/reactive-streams/src/test/scala/fs2/interop/reactivestreams/SubscriberSpec.scala
+++ b/reactive-streams/src/test/scala/fs2/interop/reactivestreams/SubscriberSpec.scala
@@ -87,7 +87,7 @@ final class SubscriberBlackboxSpec
 
   override def triggerRequest(s: Subscriber[_ >: Int]): Unit = {
     val req = s.asInstanceOf[StreamSubscriber[IO, Int]].sub.dequeue1
-    (Stream.eval(timer.sleep(100.milliseconds) *> req)).compile.drain.unsafeRunAsync(_ => ())
+    (Stream.eval(timer.sleep(100.milliseconds) >> req)).compile.drain.unsafeRunAsync(_ => ())
   }
 
   def createElement(i: Int): Int = counter.incrementAndGet()


### PR DESCRIPTION
`*>` has potential memory problems due to strictness, from the known stackoverflows issues on recursion to weirder cases like https://github.com/typelevel/cats-effect/issues/401#issuecomment-440750872

