### PR TITLE
Cleaned up the implementation of JavaInputOutputStream

### DIFF
--- a/io/src/main/scala/fs2/io/JavaInputOutputStream.scala
+++ b/io/src/main/scala/fs2/io/JavaInputOutputStream.scala
@@ -28,7 +28,7 @@ private[io] object JavaInputOutputStream {
     def markUpstreamDone(queue: Queue[F, Either[Option[Throwable], Bytes]],
                          upState: SignallingRef[F, UpStreamState],
                          result: Option[Throwable]): F[Unit] =
-      upState.set(UpStreamState(done = true, err = result)) *> queue.enqueue1(Left(result))
+      upState.set(UpStreamState(done = true, err = result)) >> queue.enqueue1(Left(result))
 
     /**
       * Takes source and runs it through queue, interrupting when dnState signals stream is done.

--- a/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscriber.scala
+++ b/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscriber.scala
@@ -102,7 +102,7 @@ object StreamSubscriber {
         case Uninitialized                  => Idle(s) -> F.unit
         case o =>
           val err = new Error(s"received subscription in invalid state [$o]")
-          o -> F.delay(s.cancel) >> F.raiseError(err)
+          o -> (F.delay(s.cancel) >> F.raiseError(err))
       }
       case OnNext(a) => {
         case WaitingOnUpstream(s, r) => Idle(s) -> r.complete(a.some.asRight)
@@ -119,7 +119,7 @@ object StreamSubscriber {
       }
       case OnFinalize => {
         case WaitingOnUpstream(sub, r) =>
-          DownstreamCancellation -> F.delay(sub.cancel) >> r.complete(None.asRight)
+          DownstreamCancellation -> (F.delay(sub.cancel) >> r.complete(None.asRight))
         case Idle(sub) => DownstreamCancellation -> F.delay(sub.cancel)
         case o         => o -> F.unit
       }


### PR DESCRIPTION
When working on #1332, I noticed we could use some simple syntax cleanup in JavaInputOutputStream. No functional changes in this PR.