### PR TITLE
Remove the `O` parameter from CompileScope.

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2985,7 +2985,7 @@ object Stream extends StreamLowPriority {
     * This is a low-level method and generally should not be used by user code.
     */
   def getScope[F[x] >: Pure[x]]: Stream[F, Scope[F]] =
-    Stream.fromFreeC(Algebra.getScope[F, Scope[F], Scope[F]].flatMap(Algebra.output1(_)))
+    Stream.fromFreeC(Algebra.getScope[F, Scope[F]].flatMap(Algebra.output1(_)))
 
   /**
     * A stream that never emits and never terminates.
@@ -3633,7 +3633,7 @@ object Stream extends StreamLowPriority {
       */
     def stepLeg: Pull[F, INothing, Option[StepLeg[F, O]]] =
       Pull
-        .fromFreeC(Algebra.getScope[F, INothing, O])
+        .fromFreeC(Algebra.getScope[F, INothing])
         .flatMap { scope =>
           new StepLeg[F, O](Chunk.empty, scope.id, self.get).stepLeg
         }


### PR DESCRIPTION
This commit removes the type parameter `O`, which is usually associated to the output of a `Stream[F, O]`, from several internal classes and types, such as `CompileScope`, its internal `State`, the `InterruptContext, and the algebra operation `GetScope`. We also remove it from the definitions of several auxiliary methods.

It turns out that `CompileScope` is not really concerned itself with the emission of values of type `O`, but merely with the correct handling of the shared resources in a common scope. Removing the parameter `O` helps to make this fact clear.