### PR TITLE
Changed io.{udp,tcp} to require a ContextShift[F] to ensure shifting …

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -205,12 +205,10 @@ lazy val mimaSettings = Seq(
     // The following changes to the io package were all package private
     ProblemFilters
       .exclude[DirectMissingMethodProblem]("fs2.io.package.invokeCallback"),
-    ProblemFilters
-      .exclude[IncompatibleMethTypeProblem]("fs2.io.tcp.Socket.client"),
-    ProblemFilters
-      .exclude[IncompatibleMethTypeProblem]("fs2.io.tcp.Socket.server"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.tcp.Socket.client"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.tcp.Socket.server"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.tcp.Socket.mkSocket"),
-    ProblemFilters.exclude[IncompatibleMethTypeProblem]("fs2.io.udp.Socket.mkSocket")
+    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.udp.Socket.mkSocket")
   )
 )
 

--- a/io/src/main/scala/fs2/io/AsyncYield.scala
+++ b/io/src/main/scala/fs2/io/AsyncYield.scala
@@ -1,0 +1,36 @@
+package fs2.io
+
+import cats.implicits._
+import cats.effect._
+import cats.effect.concurrent.Deferred
+import cats.effect.implicits._
+
+/** Extension of `Async` which provides the `asyncYield` operation. */
+private[io] trait AsyncYield[F[_]] {
+
+  /**
+    * Like `Async.async` but execution is shifted back to the default
+    * execution context after the execution of the async operation.
+    */
+  def asyncYield[A](k: (Either[Throwable, A] => Unit) => Unit): F[A]
+}
+
+private[io] object AsyncYield {
+
+  implicit def fromAsyncAndContextShift[F[_]](implicit F: Async[F],
+                                              cs: ContextShift[F]): AsyncYield[F] =
+    new AsyncYield[F] {
+      def asyncYield[A](k: (Either[Throwable, A] => Unit) => Unit): F[A] =
+        F.async(k).guarantee(cs.shift)
+    }
+
+  implicit def fromConcurrentEffect[F[_]](implicit F: ConcurrentEffect[F]): AsyncYield[F] =
+    new AsyncYield[F] {
+      def asyncYield[A](k: (Either[Throwable, A] => Unit) => Unit): F[A] =
+        Deferred[F, Either[Throwable, A]].flatMap { d =>
+          val runner = F.async(k).start.flatMap(_.join).attempt.flatMap(d.complete)
+          F.delay(runner.runAsync(_ => IO.unit).unsafeRunSync) >> d.get.rethrow
+        }
+    }
+
+}

--- a/io/src/main/scala/fs2/io/io.scala
+++ b/io/src/main/scala/fs2/io/io.scala
@@ -1,6 +1,6 @@
 package fs2
 
-import cats.effect.{Concurrent, ConcurrentEffect, ContextShift, Sync}
+import cats.effect.{ConcurrentEffect, ContextShift, Sync}
 
 import cats.implicits._
 import java.io.{InputStream, OutputStream}
@@ -136,8 +136,4 @@ package object io {
     */
   def toInputStream[F[_]](implicit F: ConcurrentEffect[F]): Pipe[F, Byte, InputStream] =
     JavaInputOutputStream.toInputStream
-
-  /** Shifts execution to the default execution context for `F`. */
-  private[io] def yieldBack[F[_]](implicit F: Concurrent[F]): F[Unit] =
-    F.bracket(F.start(F.unit))(_.join)(_.cancel)
 }

--- a/io/src/main/scala/fs2/io/tcp/Socket.scala
+++ b/io/src/main/scala/fs2/io/tcp/Socket.scala
@@ -17,8 +17,7 @@ import java.nio.channels.{
 import java.util.concurrent.TimeUnit
 
 import cats.implicits._
-import cats.effect.implicits._
-import cats.effect.{Concurrent, Resource}
+import cats.effect.{Concurrent, ContextShift, Resource}
 import cats.effect.concurrent.{Ref, Semaphore}
 
 import fs2.Stream._
@@ -113,7 +112,22 @@ object Socket {
       noDelay: Boolean = false
   )(
       implicit AG: AsynchronousChannelGroup,
-      F: Concurrent[F]
+      F: Concurrent[F],
+      CS: ContextShift[F]
+  ): Resource[F, Socket[F]] =
+    mkClient(to, reuseAddress, sendBufferSize, receiveBufferSize, keepAlive, noDelay)
+
+  private[tcp] def mkClient[F[_]](
+      to: InetSocketAddress,
+      reuseAddress: Boolean = true,
+      sendBufferSize: Int = 256 * 1024,
+      receiveBufferSize: Int = 256 * 1024,
+      keepAlive: Boolean = false,
+      noDelay: Boolean = false
+  )(
+      implicit AG: AsynchronousChannelGroup,
+      F: Concurrent[F],
+      Y: AsyncYield[F]
   ): Resource[F, Socket[F]] = {
 
     def setup: F[AsynchronousSocketChannel] = F.delay {
@@ -128,19 +142,18 @@ object Socket {
     }
 
     def connect(ch: AsynchronousSocketChannel): F[AsynchronousSocketChannel] =
-      F.async[AsynchronousSocketChannel] { cb =>
-          ch.connect(
-            to,
-            null,
-            new CompletionHandler[Void, Void] {
-              def completed(result: Void, attachment: Void): Unit =
-                cb(Right(ch))
-              def failed(rsn: Throwable, attachment: Void): Unit =
-                cb(Left(rsn))
-            }
-          )
-        }
-        .guarantee(yieldBack)
+      Y.asyncYield[AsynchronousSocketChannel] { cb =>
+        ch.connect(
+          to,
+          null,
+          new CompletionHandler[Void, Void] {
+            def completed(result: Void, attachment: Void): Unit =
+              cb(Right(ch))
+            def failed(rsn: Throwable, attachment: Void): Unit =
+              cb(Left(rsn))
+          }
+        )
+      }
 
     Resource.liftF(setup.flatMap(connect)).flatMap(Socket(_))
   }
@@ -170,7 +183,8 @@ object Socket {
                    reuseAddress: Boolean = true,
                    receiveBufferSize: Int = 256 * 1024)(
       implicit AG: AsynchronousChannelGroup,
-      F: Concurrent[F]
+      F: Concurrent[F],
+      CS: ContextShift[F]
   ): Stream[F, Resource[F, Socket[F]]] =
     serverWithLocalAddress(address, maxQueued, reuseAddress, receiveBufferSize)
       .collect { case Right(s) => s }
@@ -185,7 +199,18 @@ object Socket {
                                    reuseAddress: Boolean = true,
                                    receiveBufferSize: Int = 256 * 1024)(
       implicit AG: AsynchronousChannelGroup,
-      F: Concurrent[F]
+      F: Concurrent[F],
+      CS: ContextShift[F]
+  ): Stream[F, Either[InetSocketAddress, Resource[F, Socket[F]]]] =
+    mkServerWithLocalAddress(address, maxQueued, reuseAddress, receiveBufferSize)
+
+  private[tcp] def mkServerWithLocalAddress[F[_]](address: InetSocketAddress,
+                                                  maxQueued: Int = 0,
+                                                  reuseAddress: Boolean = true,
+                                                  receiveBufferSize: Int = 256 * 1024)(
+      implicit AG: AsynchronousChannelGroup,
+      F: Concurrent[F],
+      Y: AsyncYield[F]
   ): Stream[F, Either[InetSocketAddress, Resource[F, Socket[F]]]] = {
 
     val setup: F[AsynchronousServerSocketChannel] = F.delay {
@@ -204,18 +229,17 @@ object Socket {
     def acceptIncoming(sch: AsynchronousServerSocketChannel): Stream[F, Resource[F, Socket[F]]] = {
       def go: Stream[F, Resource[F, Socket[F]]] = {
         def acceptChannel: F[AsynchronousSocketChannel] =
-          F.async[AsynchronousSocketChannel] { cb =>
-              sch.accept(
-                null,
-                new CompletionHandler[AsynchronousSocketChannel, Void] {
-                  def completed(ch: AsynchronousSocketChannel, attachment: Void): Unit =
-                    cb(Right(ch))
-                  def failed(rsn: Throwable, attachment: Void): Unit =
-                    cb(Left(rsn))
-                }
-              )
-            }
-            .guarantee(yieldBack)
+          Y.asyncYield[AsynchronousSocketChannel] { cb =>
+            sch.accept(
+              null,
+              new CompletionHandler[AsynchronousSocketChannel, Void] {
+                def completed(ch: AsynchronousSocketChannel, attachment: Void): Unit =
+                  cb(Right(ch))
+                def failed(rsn: Throwable, attachment: Void): Unit =
+                  cb(Left(rsn))
+              }
+            )
+          }
 
         eval(acceptChannel.attempt).flatMap {
           case Left(err)       => Stream.empty[F]
@@ -241,31 +265,31 @@ object Socket {
   }
 
   private def apply[F[_]](ch: AsynchronousSocketChannel)(
-      implicit F: Concurrent[F]): Resource[F, Socket[F]] = {
+      implicit F: Concurrent[F],
+      Y: AsyncYield[F]): Resource[F, Socket[F]] = {
     val socket = Semaphore[F](1).flatMap { readSemaphore =>
       Ref.of[F, ByteBuffer](ByteBuffer.allocate(0)).map { bufferRef =>
         // Reads data to remaining capacity of supplied ByteBuffer
         // Also measures time the read took returning this as tuple
         // of (bytes_read, read_duration)
         def readChunk(buff: ByteBuffer, timeoutMs: Long): F[(Int, Long)] =
-          F.async[(Int, Long)] { cb =>
-              val started = System.currentTimeMillis()
-              ch.read(
-                buff,
-                timeoutMs,
-                TimeUnit.MILLISECONDS,
-                (),
-                new CompletionHandler[Integer, Unit] {
-                  def completed(result: Integer, attachment: Unit): Unit = {
-                    val took = System.currentTimeMillis() - started
-                    cb(Right((result, took)))
-                  }
-                  def failed(err: Throwable, attachment: Unit): Unit =
-                    cb(Left(err))
+          Y.asyncYield[(Int, Long)] { cb =>
+            val started = System.currentTimeMillis()
+            ch.read(
+              buff,
+              timeoutMs,
+              TimeUnit.MILLISECONDS,
+              (),
+              new CompletionHandler[Integer, Unit] {
+                def completed(result: Integer, attachment: Unit): Unit = {
+                  val took = System.currentTimeMillis() - started
+                  cb(Right((result, took)))
                 }
-              )
-            }
-            .guarantee(yieldBack)
+                def failed(err: Throwable, attachment: Unit): Unit =
+                  cb(Left(err))
+              }
+            )
+          }
 
         // gets buffer of desired capacity, ready for the first read operation
         // If the buffer does not have desired capacity it is resized (recreated)
@@ -335,7 +359,7 @@ object Socket {
 
         def write0(bytes: Chunk[Byte], timeout: Option[FiniteDuration]): F[Unit] = {
           def go(buff: ByteBuffer, remains: Long): F[Unit] =
-            F.async[Option[Long]] { cb =>
+            Y.asyncYield[Option[Long]] { cb =>
                 val start = System.currentTimeMillis()
                 ch.write(
                   buff,
@@ -354,7 +378,6 @@ object Socket {
                   }
                 )
               }
-              .guarantee(yieldBack)
               .flatMap {
                 case None       => F.pure(())
                 case Some(took) => go(buff, (remains - took).max(0))

--- a/io/src/main/scala/fs2/io/tcp/tcp.scala
+++ b/io/src/main/scala/fs2/io/tcp/tcp.scala
@@ -18,7 +18,7 @@ package object tcp {
       keepAlive: Boolean = false,
       noDelay: Boolean = false
   )(implicit AG: AsynchronousChannelGroup, F: ConcurrentEffect[F]): Resource[F, Socket[F]] =
-    Socket.client(to, reuseAddress, sendBufferSize, receiveBufferSize, keepAlive, noDelay)
+    Socket.mkClient(to, reuseAddress, sendBufferSize, receiveBufferSize, keepAlive, noDelay)
 
   @deprecated("Use fs2.io.tcp.Socket.server", "1.0.1")
   def server[F[_]](bind: InetSocketAddress,
@@ -28,7 +28,8 @@ package object tcp {
       implicit AG: AsynchronousChannelGroup,
       F: ConcurrentEffect[F]
   ): Stream[F, Resource[F, Socket[F]]] =
-    serverWithLocalAddress(bind, maxQueued, reuseAddress, receiveBufferSize)
+    Socket
+      .mkServerWithLocalAddress(bind, maxQueued, reuseAddress, receiveBufferSize)
       .collect { case Right(s) => s }
 
   @deprecated("Use fs2.io.tcp.Socket.serverWithLocalAddress", "1.0.1")
@@ -39,5 +40,5 @@ package object tcp {
       implicit AG: AsynchronousChannelGroup,
       F: ConcurrentEffect[F]
   ): Stream[F, Either[InetSocketAddress, Resource[F, Socket[F]]]] =
-    Socket.serverWithLocalAddress(bind, maxQueued, reuseAddress, receiveBufferSize)
+    Socket.mkServerWithLocalAddress(bind, maxQueued, reuseAddress, receiveBufferSize)
 }

--- a/io/src/main/scala/fs2/io/udp/udp.scala
+++ b/io/src/main/scala/fs2/io/udp/udp.scala
@@ -20,14 +20,14 @@ package object udp {
       multicastTTL: Option[Int] = None,
       multicastLoopback: Boolean = true
   )(implicit AG: AsynchronousSocketGroup, F: ConcurrentEffect[F]): Resource[F, Socket[F]] =
-    Socket(address,
-           reuseAddress,
-           sendBufferSize,
-           receiveBufferSize,
-           allowBroadcast,
-           protocolFamily,
-           multicastInterface,
-           multicastTTL,
-           multicastLoopback)
+    Socket.mk(address,
+              reuseAddress,
+              sendBufferSize,
+              receiveBufferSize,
+              allowBroadcast,
+              protocolFamily,
+              multicastInterface,
+              multicastTTL,
+              multicastLoopback)
 
 }


### PR DESCRIPTION
…occurs after callbacks