### PR TITLE
Fixed #1357

### DIFF
--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -281,8 +281,8 @@ abstract class Chunk[+O] extends Serializable { self =>
         val b = c.buf.asReadOnlyBuffer
         if (c.offset == 0 && b.position() == 0 && c.size == b.limit()) b
         else {
-          b.position(c.offset.toInt)
-          b.limit(c.offset.toInt + c.size)
+          (b: JBuffer).position(c.offset.toInt)
+          (b: JBuffer).limit(c.offset.toInt + c.size)
           b
         }
       case other =>
@@ -745,7 +745,7 @@ object Chunk {
       else if (n >= size) Chunk.empty
       else {
         val second = readOnly(buf)
-        second.position(n + offset)
+        (second: JBuffer).position(n + offset)
         buffer(second)
       }
 
@@ -754,14 +754,14 @@ object Chunk {
       else if (n >= size) this
       else {
         val first = readOnly(buf)
-        first.limit(n + offset)
+        (first: JBuffer).limit(n + offset)
         buffer(first)
       }
 
     def copyToArray[O2 >: C](xs: Array[O2], start: Int): Unit = {
       val b = readOnly(buf)
-      b.position(offset)
-      b.limit(offset + size)
+      (b: JBuffer).position(offset)
+      (b: JBuffer).limit(offset + size)
       if (xs.isInstanceOf[Array[C]]) {
         get(b, xs.asInstanceOf[Array[C]], start, size)
         ()
@@ -774,16 +774,16 @@ object Chunk {
 
     protected def splitAtChunk_(n: Int): (A, A) = {
       val first = readOnly(buf)
-      first.limit(n + offset)
+      (first: JBuffer).limit(n + offset)
       val second = readOnly(buf)
-      second.position(n + offset)
+      (second: JBuffer).position(n + offset)
       (buffer(first), buffer(second))
     }
 
     override def toArray[O2 >: C: ClassTag]: Array[O2] = {
       val bs = new Array[C](size)
       val b = duplicate(buf)
-      b.position(offset)
+      (b: JBuffer).position(offset)
       get(b, bs, 0, size)
       bs.asInstanceOf[Array[O2]]
     }
@@ -819,8 +819,8 @@ object Chunk {
     // Duplicated from superclass to work around Scala.js ClassCastException when using inherited version
     override def copyToArray[O2 >: Short](xs: Array[O2], start: Int): Unit = {
       val b = readOnly(buf)
-      b.position(offset)
-      b.limit(offset + size)
+      (b: JBuffer).position(offset)
+      (b: JBuffer).limit(offset + size)
       if (xs.isInstanceOf[Array[Short]]) {
         get(b, xs.asInstanceOf[Array[Short]], start, size)
         ()
@@ -895,8 +895,8 @@ object Chunk {
     // Duplicated from superclass to work around Scala.js ClassCastException when using inherited version
     override def copyToArray[O2 >: Double](xs: Array[O2], start: Int): Unit = {
       val b = readOnly(buf)
-      b.position(offset)
-      b.limit(offset + size)
+      (b: JBuffer).position(offset)
+      (b: JBuffer).limit(offset + size)
       if (xs.isInstanceOf[Array[Double]]) {
         get(b, xs.asInstanceOf[Array[Double]], start, size)
         ()
@@ -916,7 +916,7 @@ object Chunk {
       view(buf.duplicate().asReadOnlyBuffer)
 
     def view(buf: JFloatBuffer): FloatBuffer =
-      new FloatBuffer(buf, buf.position, buf.remaining)
+      new FloatBuffer(buf, (buf: JBuffer).position, buf.remaining)
   }
 
   final case class FloatBuffer(buf: JFloatBuffer, override val offset: Int, override val size: Int)
@@ -944,7 +944,7 @@ object Chunk {
       view(buf.duplicate().asReadOnlyBuffer)
 
     def view(buf: JIntBuffer): IntBuffer =
-      new IntBuffer(buf, buf.position, buf.remaining)
+      new IntBuffer(buf, (buf: JBuffer).position, buf.remaining)
   }
 
   final case class IntBuffer(buf: JIntBuffer, override val offset: Int, override val size: Int)
@@ -966,8 +966,8 @@ object Chunk {
     // Duplicated from superclass to work around Scala.js ClassCastException when using inherited version
     override def copyToArray[O2 >: Int](xs: Array[O2], start: Int): Unit = {
       val b = readOnly(buf)
-      b.position(offset)
-      b.limit(offset + size)
+      (b: JBuffer).position(offset)
+      (b: JBuffer).limit(offset + size)
       if (xs.isInstanceOf[Array[Int]]) {
         get(b, xs.asInstanceOf[Array[Int]], start, size)
         ()
@@ -987,7 +987,7 @@ object Chunk {
       view(buf.duplicate().asReadOnlyBuffer)
 
     def view(buf: JCharBuffer): CharBuffer =
-      new CharBuffer(buf, buf.position, buf.remaining)
+      new CharBuffer(buf, (buf: JBuffer).position, buf.remaining)
   }
 
   final case class CharBuffer(buf: JCharBuffer, override val offset: Int, override val size: Int)

--- a/io/src/main/scala/fs2/io/tcp/Socket.scala
+++ b/io/src/main/scala/fs2/io/tcp/Socket.scala
@@ -5,7 +5,7 @@ package tcp
 import scala.concurrent.duration._
 
 import java.net.{InetSocketAddress, SocketAddress, StandardSocketOptions}
-import java.nio.ByteBuffer
+import java.nio.{Buffer, ByteBuffer}
 import java.nio.channels.spi.AsynchronousChannelProvider
 import java.nio.channels.{
   AsynchronousChannelGroup,
@@ -300,8 +300,8 @@ object Socket {
               F.delay(ByteBuffer.allocate(sz)).flatTap(bufferRef.set)
             else
               F.delay {
-                buff.clear()
-                buff.limit(sz)
+                (buff: Buffer).clear()
+                (buff: Buffer).limit(sz)
                 buff
               }
           }
@@ -314,11 +314,11 @@ object Socket {
             if (read == 0) Chunk.bytes(Array.empty)
             else {
               val dest = new Array[Byte](read)
-              buff.flip()
+              (buff: Buffer).flip()
               buff.get(dest)
               Chunk.bytes(dest)
             }
-          buff.clear()
+          (buff: Buffer).clear()
           result
         }
 

--- a/io/src/main/scala/fs2/io/udp/AsynchronousSocketGroup.scala
+++ b/io/src/main/scala/fs2/io/udp/AsynchronousSocketGroup.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration.FiniteDuration
 
 import java.io.IOException
 import java.net.InetSocketAddress
-import java.nio.ByteBuffer
+import java.nio.{Buffer, ByteBuffer}
 import java.nio.channels.{
   CancelledKeyException,
   ClosedChannelException,
@@ -211,10 +211,10 @@ object AsynchronousSocketGroup {
         if (src eq null) {
           false
         } else {
-          readBuffer.flip
+          (readBuffer: Buffer).flip()
           val bytes = new Array[Byte](readBuffer.remaining)
           readBuffer.get(bytes)
-          readBuffer.clear
+          (readBuffer: Buffer).clear()
           reader(Right(new Packet(src, Chunk.bytes(bytes))))
           true
         }


### PR DESCRIPTION
```
env JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_192.jdk/Contents/Home amm
Loading...
Welcome to the Ammonite Repl 1.4.4
(Scala 2.12.7 Java 1.8.0_192)
If you like Ammonite, please support our development at www.patreon.com/lihaoyi
@ sys.props("java.version")
res0: String = "1.8.0_192"

@ import $ivy.`co.fs2::fs2-io:1.0.1`, fs2.Chunk
import $ivy.$                     , fs2.Chunk

@
Chunk.byteBuffer { val b = java.nio.ByteBuffer.allocate(10); b.position(2); b.limit(7); b }.toByteBuffer
java.lang.NoSuchMethodError: java.nio.ByteBuffer.position(I)Ljava/nio/ByteBuffer;
  fs2.Chunk.toByteBuffer(Chunk.scala:284)
  ammonite.$sess.cmd2$.<init>(cmd2.sc:1)
  ammonite.$sess.cmd2$.<clinit>(cmd2.sc)
```

After this PR:

```
env JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_192.jdk/Contents/Home amm                   [I]
Loading...
Welcome to the Ammonite Repl 1.4.4
(Scala 2.12.7 Java 1.8.0_192)
If you like Ammonite, please support our development at www.patreon.com/lihaoyi
@ sys.props("java.version")
res0: String = "1.8.0_192"

@ import $ivy.`co.fs2::fs2-io:1.0.2-SNAPSHOT`, fs2.Chunk
import $ivy.$                              , fs2.Chunk

@ Chunk.byteBuffer { val b = java.nio.ByteBuffer.allocate(10); b.position(2); b.limit(7); b }.toByteBuffer
res2: java.nio.ByteBuffer = java.nio.HeapByteBufferR[pos=2 lim=7 cap=10]
```