### PR TITLE
Removed dead code path in Stream.bracket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ z_local.sbt
 .tags
 .metaserver
 test-output
+.metals
+.bloop

--- a/build.sbt
+++ b/build.sbt
@@ -210,7 +210,8 @@ lazy val mimaSettings = Seq(
     ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.tcp.Socket.mkSocket"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.udp.Socket.mkSocket"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.Pipe.joinQueued"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.Pipe.joinAsync")
+    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.Pipe.joinAsync"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.Stream.bracketFinalizer")
   )
 )
 

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -236,7 +236,7 @@ object Pull extends PullLowPriority {
     fromFreeC(Algebra.suspend(p.get))
 
   private def release[F[x] >: Pure[x]](token: Token): Pull[F, INothing, Unit] =
-    fromFreeC[F, INothing, Unit](Algebra.release(token, None))
+    fromFreeC[F, INothing, Unit](Algebra.release(token))
 
   /** `Sync` instance for `Pull`. */
   implicit def syncInstance[F[_], O](


### PR DESCRIPTION
I noticed this when working on tagless branch -- the error handling case in `bracketFinalizer` could never be hit b/c it was only called immediately after a simple emit, which cannot fail with an exception.