### PR TITLE
Add repeatN combinator to Stream and a spec for repeat and repeatN

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2058,6 +2058,22 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
     this ++ repeat
 
   /**
+    * Repeat this stream a given number of times.
+    *
+    * `s.repeatN(n) == s ++ s ++ s ++ ... (n times)`
+    *
+    * @example {{{
+    * scala> Stream(1,2,3).repeatN(3).take(100).toList
+    * res0: List[Int] = List(1, 2, 3, 1, 2, 3, 1, 2, 3)
+    * }}}
+    */
+  def repeatN(n: Long): Stream[F, O] = {
+    require(n > 0, "n must be > 0") // same behaviour as sliding
+    if (n > 1) this ++ repeatN(n - 1)
+    else this
+  }
+
+  /**
     * Converts a `Stream[F,Either[Throwable,O]]` to a `Stream[F,O]`, which emits right values and fails upon the first `Left(t)`.
     * Preserves chunkiness.
     *

--- a/core/shared/src/test/scala/fs2/RepeatSpec.scala
+++ b/core/shared/src/test/scala/fs2/RepeatSpec.scala
@@ -1,0 +1,25 @@
+package fs2
+import org.scalacheck.Gen
+
+class RepeatSpec extends Fs2Spec {
+
+  // avoid running on huge streams
+  val smallPositiveInt: Gen[Int] = Gen.chooseNum(1, 200)
+  val nonEmptyIntList: Gen[List[Int]] = Gen.nonEmptyListOf(smallPositiveInt)
+
+  "Stream" - {
+    "repeat" in {
+      forAll(smallPositiveInt, nonEmptyIntList) { (length: Int, testValues: List[Int]) =>
+        val stream = Stream.emits(testValues)
+        stream.repeat.take(length).compile.toList shouldBe List.fill(length / testValues.size + 1)(testValues).flatten.take(length)
+      }
+    }
+
+    "repeatN" in {
+      forAll(smallPositiveInt, nonEmptyIntList) { (n: Int, testValues: List[Int]) =>
+        val stream = Stream.emits(testValues)
+        stream.repeatN(n).compile.toList shouldBe List.fill(n)(testValues).flatten
+      }
+    }
+  }
+}

--- a/site/src/guide.md
+++ b/site/src/guide.md
@@ -73,6 +73,7 @@ Stream(None,Some(2),Some(3)).collect { case Some(i) => i }.toList
 Stream.range(0,5).intersperse(42).toList
 Stream(1,2,3).flatMap(i => Stream(i,i)).toList
 Stream(1,2,3).repeat.take(9).toList
+Stream(1,2,3).repeatN(2).toList
 ```
 
 Of these, only `flatMap` is primitive, the rest are built using combinations of various other primitives. We'll take a look at how that works shortly.


### PR DESCRIPTION
Lately, I found myself several times in the need of repeating a `Stream` a specific number of times and I don't see a good way of doing this with the existing combinators - one can do `repeat.take(n * s)` for a `Stream` of known size `s`, but that usually doesn't help as the length is unknown. Also added a scalacheck spec for testing `repeat` and `repeatN` on simple, pure streams.

Maybe not worth being added, but as there's a chance others need this as well, I wanted to give it a try ;)
Questions and/or comments welcome!