### PR TITLE
Make all Algebra subclasses private.

### DIFF
--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -180,15 +180,7 @@ object Pull extends PullLowPriority {
     r => using(r).flatMap { _.map(loop(using)).getOrElse(Pull.pure(None)) }
 
   private def mapOutput[F[_], O, O2, R](p: Pull[F, O, R])(f: O => O2): Pull[F, O2, R] =
-    Pull.fromFreeC(
-      p.get[F, O, R]
-        .translate(new (Algebra[F, O, ?] ~> Algebra[F, O2, ?]) {
-          def apply[X](in: Algebra[F, O, X]): Algebra[F, O2, X] = in match {
-            case o: Algebra.Output[F, O] => Algebra.Output(o.values.map(f))
-            case other                   => other.asInstanceOf[Algebra[F, O2, X]]
-          }
-        })
-    )
+    Pull.fromFreeC(p.get[F, O, R].translate(Algebra.mapOutput(f)))
 
   /** Outputs a single value. */
   def output1[F[x] >: Pure[x], O](o: O): Pull[F, O, Unit] =

--- a/core/shared/src/main/scala/fs2/internal/Algebra.scala
+++ b/core/shared/src/main/scala/fs2/internal/Algebra.scala
@@ -115,7 +115,7 @@ private[fs2] object Algebra {
       implicit F: Concurrent[F]): FreeC[Algebra[F, O, ?], Unit] =
     scope0(s, Some(F))
 
-  private[fs2] def openScope[F[_], O](
+  private[this] def openScope[F[_], O](
       interruptible: Option[Concurrent[F]]): FreeC[Algebra[F, O, ?], Token] =
     FreeC.Eval[Algebra[F, O, ?], Token](OpenScope(interruptible))
 
@@ -173,7 +173,7 @@ private[fs2] object Algebra {
     F.bracketCase(F.delay(CompileScope.newRoot[F]))(scope =>
       compileScope[F, O, B](scope, stream, init)(f))((scope, ec) => scope.close(ec).rethrow)
 
-  private[fs2] def compileScope[F[_], O, B](
+  private[this] def compileScope[F[_], O, B](
       scope: CompileScope[F],
       stream: FreeC[Algebra[F, O, ?], Unit],
       init: B)(g: (B, Chunk[O]) => B)(implicit F: Sync[F]): F[B] =
@@ -208,7 +208,7 @@ private[fs2] object Algebra {
    *
    */
 
-  private[fs2] def compileLoop[F[_], O](
+  private[this] def compileLoop[F[_], O](
       scope: CompileScope[F],
       stream: FreeC[Algebra[F, O, ?], Unit]
   )(implicit F: Sync[F]): F[Option[(Chunk[O], CompileScope[F], FreeC[Algebra[F, O, ?], Unit])]] = {

--- a/core/shared/src/main/scala/fs2/internal/Algebra.scala
+++ b/core/shared/src/main/scala/fs2/internal/Algebra.scala
@@ -19,34 +19,37 @@ private[fs2] sealed trait Algebra[F[_], +O, R]
 
 private[fs2] object Algebra {
 
-  final case class Output[F[_], O](values: Chunk[O]) extends Algebra[F, O, Unit]
+  private[this] final case class Output[F[_], O](values: Chunk[O]) extends Algebra[F, O, Unit]
 
-  final case class Step[F[_], X, O](
+  private[this] final case class Step[F[_], X, O](
       stream: FreeC[Algebra[F, X, ?], Unit],
       scope: Option[Token]
   ) extends Algebra[F, O, Option[(Chunk[X], Token, FreeC[Algebra[F, X, ?], Unit])]]
 
   /* The `AlgEffect` trait is for operations on the `F` effect that create no `O` output.
    * They are related to resources and scopes. */
-  sealed trait AlgEffect[F[_], R] extends Algebra[F, INothing, R]
+  private[this] sealed trait AlgEffect[F[_], R] extends Algebra[F, INothing, R]
 
-  final case class Eval[F[_], R](value: F[R]) extends AlgEffect[F, R]
+  private[this] final case class Eval[F[_], R](value: F[R]) extends AlgEffect[F, R]
 
-  final case class Acquire[F[_], R](resource: F[R], release: (R, ExitCase[Throwable]) => F[Unit])
+  private[this] final case class Acquire[F[_], R](resource: F[R],
+                                                  release: (R, ExitCase[Throwable]) => F[Unit])
       extends AlgEffect[F, (R, Token)]
 
-  final case class Release[F[_]](token: Token) extends AlgEffect[F, Unit]
+  private[this] final case class Release[F[_]](token: Token) extends AlgEffect[F, Unit]
 
-  final case class OpenScope[F[_]](interruptible: Option[Concurrent[F]]) extends AlgEffect[F, Token]
+  private[this] final case class OpenScope[F[_]](interruptible: Option[Concurrent[F]])
+      extends AlgEffect[F, Token]
 
   // `InterruptedScope` contains id of the scope currently being interrupted
   // together with any errors accumulated during interruption process
-  final case class CloseScope[F[_]](scopeId: Token,
-                                    interruptedScope: Option[(Token, Option[Throwable])],
-                                    exitCase: ExitCase[Throwable])
+  private[this] final case class CloseScope[F[_]](
+      scopeId: Token,
+      interruptedScope: Option[(Token, Option[Throwable])],
+      exitCase: ExitCase[Throwable])
       extends AlgEffect[F, Unit]
 
-  final case class GetScope[F[_]]() extends AlgEffect[F, CompileScope[F]]
+  private[this] final case class GetScope[F[_]]() extends AlgEffect[F, CompileScope[F]]
 
   def output[F[_], O](values: Chunk[O]): FreeC[Algebra[F, O, ?], Unit] =
     FreeC.Eval[Algebra[F, O, ?], Unit](Output(values))
@@ -65,6 +68,14 @@ private[fs2] object Algebra {
   def release[F[_], O](token: Token): FreeC[Algebra[F, O, ?], Unit] =
     FreeC.Eval[Algebra[F, O, ?], Unit](Release(token))
 
+  def mapOutput[F[_], A, B](fun: A => B): Algebra[F, A, ?] ~> Algebra[F, B, ?] =
+    new (Algebra[F, A, ?] ~> Algebra[F, B, ?]) {
+      def apply[R](alg: Algebra[F, A, R]): Algebra[F, B, R] = alg match {
+        case o: Output[F, A] => Output[F, B](o.values.map(fun))
+        case _               => alg.asInstanceOf[Algebra[F, B, R]]
+      }
+    }
+
   /**
     * Steps through the stream, providing either `uncons` or `stepLeg`.
     * Yields to head in form of chunk, then id of the scope that was active after step evaluated and tail of the `stream`.
@@ -78,7 +89,7 @@ private[fs2] object Algebra {
   ): FreeC[Algebra[F, X, ?], Option[(Chunk[O], Token, FreeC[Algebra[F, O, ?], Unit])]] =
     FreeC
       .Eval[Algebra[F, X, ?], Option[(Chunk[O], Token, FreeC[Algebra[F, O, ?], Unit])]](
-        Algebra.Step[F, O, X](stream, scopeId))
+        Step[F, O, X](stream, scopeId))
 
   def stepLeg[F[_], O](
       leg: Stream.StepLeg[F, O]): FreeC[Algebra[F, Nothing, ?], Option[Stream.StepLeg[F, O]]] =
@@ -238,12 +249,12 @@ private[fs2] object Algebra {
             }
 
           view.step match {
-            case output: Algebra.Output[F, X] =>
+            case output: Output[F, X] =>
               interruptGuard(scope)(
                 F.pure(Out(output.values, scope, view.next(FreeC.Result.Pure(()))))
               )
 
-            case u: Algebra.Step[F, y, X] =>
+            case u: Step[F, y, X] =>
               // if scope was specified in step, try to find it, otherwise use the current scope.
               F.flatMap(u.scope.fold[F[Option[CompileScope[F]]]](F.pure(Some(scope))) { scopeId =>
                 scope.findStepScope(scopeId)
@@ -274,7 +285,7 @@ private[fs2] object Algebra {
                       s"Fail to find scope for next step: current: ${scope.id}, step: $u"))
               }
 
-            case eval: Algebra.Eval[F, r] =>
+            case eval: Eval[F, r] =>
               F.flatMap(scope.interruptibleEval(eval.value)) {
                 case Right(r)           => go[X](scope, view.next(Result.pure(r)))
                 case Left(Left(err))    => go[X](scope, view.next(Result.raiseError(err)))
@@ -282,22 +293,22 @@ private[fs2] object Algebra {
 
               }
 
-            case acquire: Algebra.Acquire[F, r] =>
+            case acquire: Acquire[F, r] =>
               interruptGuard(scope) {
                 F.flatMap(scope.acquireResource(acquire.resource, acquire.release)) { r =>
                   go[X](scope, view.next(Result.fromEither(r)))
                 }
               }
 
-            case release: Algebra.Release[F] =>
+            case release: Release[F] =>
               F.flatMap(scope.releaseResource(release.token, ExitCase.Completed)) { r =>
                 go[X](scope, view.next(Result.fromEither(r)))
               }
 
-            case _: Algebra.GetScope[F] =>
+            case _: GetScope[F] =>
               F.suspend(go(scope, view.next(Result.pure(scope.asInstanceOf[y]))))
 
-            case open: Algebra.OpenScope[F] =>
+            case open: OpenScope[F] =>
               interruptGuard(scope) {
                 F.flatMap(scope.open(open.interruptible)) {
                   case Left(err) =>
@@ -307,7 +318,7 @@ private[fs2] object Algebra {
                 }
               }
 
-            case close: Algebra.CloseScope[F] =>
+            case close: CloseScope[F] =>
               def closeAndGo(toClose: CompileScope[F], ec: ExitCase[Throwable]) =
                 F.flatMap(toClose.close(ec)) { r =>
                   F.flatMap(toClose.openAncestor) { ancestor =>
@@ -394,7 +405,7 @@ private[fs2] object Algebra {
 
       case view: ViewL.View[Algebra[F, O, ?], _, Unit] =>
         view.step match {
-          case close: Algebra.CloseScope[F] =>
+          case close: CloseScope[F] =>
             Algebra
               .closeScope(close.scopeId, Some((interruptedScope, interruptedError)), close.exitCase) // assumes it is impossible so the `close` will be already from interrupted stream
               .transformWith(view.next)
@@ -423,7 +434,7 @@ private[fs2] object Algebra {
 
       case view: ViewL.View[Algebra[F, X, ?], y, Unit] =>
         view.step match {
-          case output: Algebra.Output[F, X] =>
+          case output: Output[F, X] =>
             Algebra.output[G, X](output.values).transformWith {
               case r @ Result.Pure(v) =>
                 // Cast is safe here, as at this point the evaluation of this Step will end
@@ -438,10 +449,10 @@ private[fs2] object Algebra {
               case r @ Result.Interrupted(_, _) => translateStep(fK, view.next(r), concurrent)
             }
 
-          case step: Algebra.Step[F, x, X] =>
+          case step: Step[F, x, X] =>
             FreeC
               .Eval[Algebra[G, X, ?], Option[(Chunk[x], Token, FreeC[Algebra[G, x, ?], Unit])]](
-                Algebra.Step[G, x, X](
+                Step[G, x, X](
                   stream = translateStep[F, G, x](fK, step.stream, concurrent),
                   scope = step.scope
                 ))
@@ -449,7 +460,7 @@ private[fs2] object Algebra {
                 translateStep[F, G, X](fK, view.next(r.asInstanceOf[Result[y]]), concurrent)
               }
 
-          case alg: Algebra.AlgEffect[F, r] =>
+          case alg: AlgEffect[F, r] =>
             FreeC
               .Eval[Algebra[G, X, ?], r](translateAlgEffect(alg, concurrent, fK))
               .transformWith(r => translateStep(fK, view.next(r), concurrent))
@@ -475,15 +486,15 @@ private[fs2] object Algebra {
 
       case view: ViewL.View[Algebra[F, O, ?], y, Unit] =>
         view.step match {
-          case output: Algebra.Output[F, O] =>
+          case output: Output[F, O] =>
             Algebra.output[G, O](output.values).transformWith { r =>
               translate0(fK, view.next(r), concurrent)
             }
 
-          case step: Algebra.Step[F, x, O] =>
+          case step: Step[F, x, O] =>
             FreeC
               .Eval[Algebra[G, O, ?], Option[(Chunk[x], Token, FreeC[Algebra[G, x, ?], Unit])]](
-                Algebra.Step[G, x, O](
+                Step[G, x, O](
                   stream = translateStep[F, G, x](fK, step.stream, concurrent),
                   scope = step.scope
                 ))
@@ -491,7 +502,7 @@ private[fs2] object Algebra {
                 translate0(fK, view.next(r.asInstanceOf[Result[y]]), concurrent)
               }
 
-          case alg: Algebra.AlgEffect[F, r] =>
+          case alg: AlgEffect[F, r] =>
             FreeC
               .Eval[Algebra[G, O, ?], r](translateAlgEffect(alg, concurrent, fK))
               .transformWith(r => translate0(fK, view.next(r), concurrent))


### PR DESCRIPTION
This PR modifies the Algebra object, to hide all the sub-classes of that algebra. Thus, the implementation are not visible outside it, and only in the algebra are those constructed/deconstructed.

To allow this, we cut from the implementation of `Pull.mapOutput` the part that  generates a natural transformation, to a new `Algebra.mapOutput` operation.