### PR TITLE
Compile a Stream down to a Resource

### DIFF
--- a/core/jvm/src/test/scala/fs2/ResourceCompilationSpec.scala
+++ b/core/jvm/src/test/scala/fs2/ResourceCompilationSpec.scala
@@ -1,6 +1,78 @@
 package fs2
 
+import cats.implicits._
 import cats.effect.{IO, Resource}
+import cats.effect.concurrent.{Deferred, Ref}
+import scala.concurrent.duration._
+
+class ResourceCompilationSpec extends AsyncFs2Spec {
+
+  "compile.toResource - concurrently" in {
+    pending
+    val prog: Resource[IO, IO[Unit]] =
+      Stream
+        .eval(Deferred[IO, Unit].product(Deferred[IO, Unit]))
+        .flatMap {
+          case (startCondition, waitForStream) =>
+            val worker = Stream.eval(startCondition.get) ++ Stream.eval(waitForStream.complete(()))
+            val result = startCondition.complete(()) >> waitForStream.get
+
+            Stream.emit(result).concurrently(worker)
+        }
+        .compile
+        .toResource
+        .lastOrError
+
+    prog.use(x => x).timeout(5.seconds).unsafeToFuture
+  }
+
+  "compile.toResource - onFinalise" in {
+    pending
+    val expected = List(
+      "stream - start",
+      "stream - done",
+      "io - done",
+      "io - start",
+      "resource - start",
+      "resource - done"
+    )
+
+    Ref[IO]
+      .of(List.empty[String])
+      .flatMap { st =>
+        def record(s: String): IO[Unit] = st.update(_ :+ s)
+
+        def stream =
+          Stream
+            .emit("stream - start")
+            .onFinalize(record("stream - done"))
+            .evalMap(x => record(x))
+            .compile
+            .lastOrError
+
+        def io =
+          Stream
+            .emit("io - start")
+            .onFinalize(record("io - done"))
+            .compile
+            .lastOrError
+            .flatMap(x => record(x))
+
+        def resource =
+          Stream
+            .emit("resource - start")
+            .onFinalize(record("resource - done"))
+            .compile
+            .toResource
+            .lastOrError
+            .use(x => record(x))
+
+        stream >> io >> resource >> st.get
+      }
+      .unsafeToFuture
+      .map(_ shouldBe expected)
+  }
+}
 
 object ResourceCompilationSpec {
 

--- a/core/jvm/src/test/scala/fs2/ResourceCompilationSpec.scala
+++ b/core/jvm/src/test/scala/fs2/ResourceCompilationSpec.scala
@@ -1,0 +1,11 @@
+package fs2
+
+import cats.effect.{IO, Resource}
+
+object ResourceCompilationSpec {
+
+  /** This should compile */
+  val pure: List[Int] = Stream.range(0, 5).compile.toList
+  val io: IO[List[Int]] = Stream.range(0, 5).covary[IO].compile.toList
+  val resource: Resource[IO, List[Int]] = Stream.range(0, 5).covary[IO].compile.toResource.toList
+}

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3711,8 +3711,7 @@ object Stream extends StreamLowPriority {
   }
 
   object Compiler extends LowPrioCompiler {
-    // TOOD make this private once the Resource compiler is properly implemented
-    private[Stream] def compile[F[_], O, B](stream: FreeC[Algebra[F, O, ?], Unit], init: B)(
+    private def compile[F[_], O, B](stream: FreeC[Algebra[F, O, ?], Unit], init: B)(
         f: (B, Chunk[O]) => B)(implicit F: Sync[F]): F[B] =
       F.bracketCase(CompileScope.newRoot[F])(scope =>
         Algebra.compile[F, O, B](stream, scope, init)(f))((scope, ec) => scope.close(ec).rethrow)
@@ -3912,7 +3911,7 @@ object Stream extends StreamLowPriority {
       to[List]
 
     /** TODO scaladoc **/
-    def toResource(implicit compiler: Stream.Compiler[G, Resource[G, ?]])
+    def resource(implicit compiler: Stream.Compiler[G, Resource[G, ?]])
       : Stream.CompileOps[G, Resource[G, ?], O] =
       new Stream.CompileOps[G, Resource[G, ?], O](free)
 

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3692,7 +3692,12 @@ object Stream extends StreamLowPriority {
                                                                        finalize: B => C): G[C]
   }
 
-  object Compiler {
+  trait LowPrioCompiler {
+    implicit def resourceInstance[F[_]](implicit F: Sync[F]): Compiler[F, Resource[F, ?]] = ???
+
+  }
+
+  object Compiler extends LowPrioCompiler {
     implicit def syncInstance[F[_]](implicit F: Sync[F]): Compiler[F, F] = new Compiler[F, F] {
       def apply[O, B, C](s: Stream[F, O], init: () => B)(foldChunk: (B, Chunk[O]) => B,
                                                          finalize: B => C): F[C] =
@@ -3886,6 +3891,11 @@ object Stream extends StreamLowPriority {
       */
     def toList: G[List[O]] =
       to[List]
+
+    /** TODO scaladoc **/
+    def toResource(implicit compiler: Stream.Compiler[G, Resource[G, ?]])
+      : Stream.CompileOps[G, Resource[G, ?], O] =
+      new Stream.CompileOps[G, Resource[G, ?], O](free)
 
     /**
       * Compiles this stream in to a value of the target effect type `F` by logging

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3700,7 +3700,6 @@ object Stream extends StreamLowPriority {
           Resource
             .makeCase(CompileScope.newRoot[F])((scope, ec) => scope.close(ec).rethrow)
             .flatMap { scope =>
-              println("correct interpreter")
               Resource.liftF {
                 F.delay(init())
                   .flatMap(i => Algebra.compile(s.get, scope, i)(foldChunk))

--- a/core/shared/src/main/scala/fs2/internal/Algebra.scala
+++ b/core/shared/src/main/scala/fs2/internal/Algebra.scala
@@ -170,8 +170,8 @@ private[fs2] object Algebra {
   /** Left-folds the output of a stream. */
   def compile[F[_], O, B](stream: FreeC[Algebra[F, O, ?], Unit], init: B)(f: (B, Chunk[O]) => B)(
       implicit F: Sync[F]): F[B] =
-    F.bracketCase(F.delay(CompileScope.newRoot[F]))(scope =>
-      compileScope[F, O, B](scope, stream, init)(f))((scope, ec) => scope.close(ec).rethrow)
+    F.bracketCase(CompileScope.newRoot[F])(scope => compileScope[F, O, B](scope, stream, init)(f))(
+      (scope, ec) => scope.close(ec).rethrow)
 
   private[this] def compileScope[F[_], O, B](
       scope: CompileScope[F],

--- a/core/shared/src/main/scala/fs2/internal/CompileScope.scala
+++ b/core/shared/src/main/scala/fs2/internal/CompileScope.scala
@@ -25,7 +25,7 @@ import fs2.internal.CompileScope.InterruptContext
   * For example, `s.chunks` is defined with `s.repeatPull` which in turn is defined with `Pull.loop(...).stream`.
   * In this case, a single scope is created as a result of the call to `.stream`.
   *
-  * The `root` scope is special is that is closed by the top level compile loop, rather than by instructions in the
+  * The `root` scope is special in that it is closed by the top level compile loop, rather than by instructions in the
   * Stream structure. This is to allow extending the lifetime of Stream when compiling to a `cats.effect.Resource`
   *  (not to be confused with `fs2.internal.Resource`).
   *

--- a/core/shared/src/main/scala/fs2/internal/CompileScope.scala
+++ b/core/shared/src/main/scala/fs2/internal/CompileScope.scala
@@ -408,8 +408,8 @@ private[fs2] final class CompileScope[F[_]] private (
 private[internal] object CompileScope {
 
   /** Creates a new root scope. */
-  def newRoot[F[_]: Sync]: CompileScope[F] =
-    new CompileScope[F](new Token(), None, None)
+  def newRoot[F[_]: Sync]: F[CompileScope[F]] =
+    Sync[F].delay(new CompileScope[F](new Token(), None, None))
 
   /**
     * State of a scope.

--- a/core/shared/src/main/scala/fs2/internal/CompileScope.scala
+++ b/core/shared/src/main/scala/fs2/internal/CompileScope.scala
@@ -405,7 +405,7 @@ private[fs2] final class CompileScope[F[_]] private (
     s"RunFoldScope(id=$id,interruptible=${interruptible.nonEmpty})"
 }
 
-private[internal] object CompileScope {
+private[fs2] object CompileScope {
 
   /** Creates a new root scope. */
   def newRoot[F[_]: Sync]: F[CompileScope[F]] =

--- a/core/shared/src/main/scala/fs2/internal/CompileScope.scala
+++ b/core/shared/src/main/scala/fs2/internal/CompileScope.scala
@@ -25,6 +25,10 @@ import fs2.internal.CompileScope.InterruptContext
   * For example, `s.chunks` is defined with `s.repeatPull` which in turn is defined with `Pull.loop(...).stream`.
   * In this case, a single scope is created as a result of the call to `.stream`.
   *
+  * The `root` scope is special is that is closed by the top level compile loop, rather than by instructions in the
+  * Stream structure. This is to allow extending the lifetime of Stream when compiling to a `cats.effect.Resource`
+  *  (not to be confused with `fs2.internal.Resource`).
+  *
   * Scopes may also be opened and closed manually with `Stream#scope`. For the stream `s.scope`, a scope
   * is opened before evaluation of `s` and closed once `s` finishes evaluation.
   *
@@ -86,9 +90,20 @@ private[fs2] final class CompileScope[F[_]] private (
     * Invoked when a resource is released during the scope's lifetime.
     * When the action returns, the resource may not be released yet, as
     * it may have been `leased` to other scopes.
+    *
+    * Note:
+    *
+    * This method is a no-op for the `root` scope, because we want to
+    * close it through the toplevel compile loop, rather than by
+    * instructions in the stream structure.
+    *
+    * This is to allow extending the lifetime of Stream when compiling
+    * to a `cats.effect.Resource` (not to be confused with
+    * `fs2.internal.Resource`).
+    *
     */
   def releaseResource(id: Token, ec: ExitCase[Throwable]): F[Either[Throwable, Unit]] =
-    if (!parent.isEmpty) { // TODO comment to explain this
+    if (!parent.isEmpty) {
       F.flatMap(state.modify { _.unregisterResource(id) }) {
         case Some(resource) => resource.release(ec)
         case None           => F.pure(Right(())) // resource does not exist in scope any more.

--- a/core/shared/src/main/scala/fs2/internal/CompileScope.scala
+++ b/core/shared/src/main/scala/fs2/internal/CompileScope.scala
@@ -88,10 +88,12 @@ private[fs2] final class CompileScope[F[_]] private (
     * it may have been `leased` to other scopes.
     */
   def releaseResource(id: Token, ec: ExitCase[Throwable]): F[Either[Throwable, Unit]] =
-    F.flatMap(state.modify { _.unregisterResource(id) }) {
-      case Some(resource) => resource.release(ec)
-      case None           => F.pure(Right(())) // resource does not exist in scope any more.
-    }
+    if (!parent.isEmpty) { // TODO comment to explain this
+      F.flatMap(state.modify { _.unregisterResource(id) }) {
+        case Some(resource) => resource.release(ec)
+        case None           => F.pure(Right(())) // resource does not exist in scope any more.
+      }
+    } else F.pure(Right(()))
 
   /**
     * Opens a child scope.


### PR DESCRIPTION
Motivation: be able to return a `Resource` instead of a singleton Stream, for an abstraction whose constructor uses Stream concurrency combinators.

What we can do today:
- Return a singleton stream. Example:
    ```scala
    def hold[F2[x] >: F[x], O2 >: O](initial: O2)(
      implicit F: Concurrent[F2]): Stream[F2, Signal[F2, O2]] =
    Stream.eval(SignallingRef[F2, O2](initial)).flatMap { sig =>
      Stream(sig).concurrently(evalMap(sig.set))
    }
  ```

- Fall back to use `start` + `Fiber` directly. Way more error prone and lower level.

Status: I thought using `Resource` to manage the top level scope is enough, but it's not.

Look at the `basic` test for the gist of the behaviour I want to enable.
