### PR TITLE
Implements fs2.concurrent.Topic with fs2.concurrent.Queue

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -560,12 +560,12 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
   /**
     * Debounce the stream with a minimum period of `d` between each element.
     *
-    * Use-case: if this is a stream of updates about external state, we may want to refresh (side-effectful) 
+    * Use-case: if this is a stream of updates about external state, we may want to refresh (side-effectful)
     * once every 'd' milliseconds, and every time we refresh we only care about the latest update.
     *
     * @return A stream whose values is an in-order, not necessarily strict subsequence of this stream,
     * and whose evaluation will force a delay `d` between emitting each element.
-    * The exact subsequence would depend on the chunk structure of this stream, and the timing they arrive. 
+    * The exact subsequence would depend on the chunk structure of this stream, and the timing they arrive.
     * There is no guarantee ta
     *
     * @example {{{


### PR DESCRIPTION
Implementation of the `fs2.concurrent.Topic` with  `fs2.concurrent.Queue` as subscriptions. Read more in this issue #1406 . 