### PR TITLE
Removed Algebra.Release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -226,7 +226,9 @@ lazy val mimaSettings = Seq(
     ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.Stream.bracketFinalizer"),
     // Compiler#apply is private[fs2]
     ProblemFilters.exclude[IncompatibleMethTypeProblem]("fs2.Stream#Compiler.apply"),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.Stream#Compiler.apply")
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.Stream#Compiler.apply"),
+    // bracketWithToken was private[fs2]
+    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.Stream.bracketWithToken")
   )
 )
 

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -152,7 +152,7 @@ object Pull extends PullLowPriority {
         case None => Pull.raiseError[F](new RuntimeException("impossible"))
         case Some(((res, r), tl)) =>
           Pull.pure(Cancellable(Pull.eval(res.release(ExitCase.Canceled)).flatMap {
-            case Left(t)  => Pull.fromFreeC(Algebra.raiseError(t))
+            case Left(t)  => Pull.fromFreeC(Algebra.raiseError[F, INothing](t))
             case Right(r) => Pull.pure(r)
           }, r))
       }

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -145,12 +145,16 @@ object Pull extends PullLowPriority {
   def acquireCancellableCase[F[_]: RaiseThrowable, R](r: F[R])(
       cleanup: (R, ExitCase[Throwable]) => F[Unit]): Pull[F, INothing, Cancellable[F, R]] =
     Stream
-      .bracketWithToken(r)(cleanup)
+      .bracketWithResource(r)(cleanup)
       .pull
       .uncons1
       .flatMap {
-        case None                   => Pull.raiseError[F](new RuntimeException("impossible"))
-        case Some(((token, r), tl)) => Pull.pure(Cancellable(release(token), r))
+        case None => Pull.raiseError[F](new RuntimeException("impossible"))
+        case Some(((res, r), tl)) =>
+          Pull.pure(Cancellable(Pull.eval(res.release(ExitCase.Canceled)).flatMap {
+            case Left(t)  => Pull.fromFreeC(Algebra.raiseError(t))
+            case Right(r) => Pull.pure(r)
+          }, r))
       }
 
   /**
@@ -226,9 +230,6 @@ object Pull extends PullLowPriority {
     */
   def suspend[F[x] >: Pure[x], O, R](p: => Pull[F, O, R]): Pull[F, O, R] =
     fromFreeC(Algebra.suspend(p.get))
-
-  private def release[F[x] >: Pure[x]](token: Token): Pull[F, INothing, Unit] =
-    fromFreeC(Algebra.release[F, INothing](token))
 
   /** `Sync` instance for `Pull`. */
   implicit def syncInstance[F[_], O](

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2870,7 +2870,7 @@ object Stream extends StreamLowPriority {
     bracketWithResource(acquire)(release).map {
       case (res, r) =>
         (Stream.eval(res.release(ExitCase.Canceled)).flatMap {
-          case Left(t)  => Stream.fromFreeC(Algebra.raiseError(t))
+          case Left(t)  => Stream.fromFreeC(Algebra.raiseError[F, Unit](t))
           case Right(u) => Stream.emit(u)
         }, r)
     }

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -8,7 +8,7 @@ import cats.effect.implicits._
 import cats.implicits.{catsSyntaxEither => _, _}
 import fs2.concurrent._
 import fs2.internal.FreeC.Result
-import fs2.internal._
+import fs2.internal.{Resource => _, _}
 import java.io.PrintStream
 
 import scala.collection.compat._
@@ -1712,7 +1712,8 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
                     s.chunks
                       .evalMap { chunk =>
                         guard.acquire >>
-                          resultQ.enqueue1(Some(Stream.chunk(chunk).onFinalize(guard.release)))
+                          resultQ.enqueue1(
+                            Some(Stream.chunk(chunk).onFinalize(guard.release).scope))
                       }
                       .interruptWhen(interrupt.get.attempt)
                       .compile
@@ -2843,8 +2844,7 @@ object Stream extends StreamLowPriority {
   def bracketCase[F[x] >: Pure[x], R](acquire: F[R])(
       release: (R, ExitCase[Throwable]) => F[Unit]): Stream[F, R] =
     fromFreeC(Algebra.acquire[F, R, R](acquire, release).flatMap {
-      case (r, token) =>
-        Stream.emit(r).covary[F].get[F, R] >> Algebra.release(token)
+      case (r, token) => Stream.emit(r).covary[F].get[F, R]
     })
 
   /**
@@ -2867,20 +2867,23 @@ object Stream extends StreamLowPriority {
     */
   def bracketCaseCancellable[F[x] >: Pure[x], R](acquire: F[R])(
       release: (R, ExitCase[Throwable]) => F[Unit]): Stream[F, (Stream[F, Unit], R)] =
-    bracketWithToken(acquire)(release).map {
-      case (token, r) =>
-        (Stream.fromFreeC(Algebra.release[F, Unit](token)) ++ Stream.emit(()), r)
+    bracketWithResource(acquire)(release).map {
+      case (res, r) =>
+        (Stream.eval(res.release(ExitCase.Canceled)).flatMap {
+          case Left(t)  => Stream.fromFreeC(Algebra.raiseError(t))
+          case Right(u) => Stream.emit(u)
+        }, r)
     }
 
-  private[fs2] def bracketWithToken[F[x] >: Pure[x], R](acquire: F[R])(
-      release: (R, ExitCase[Throwable]) => F[Unit]): Stream[F, (Token, R)] =
-    fromFreeC(Algebra.acquire[F, (Token, R), R](acquire, release).flatMap {
-      case (r, token) =>
+  private[fs2] def bracketWithResource[F[x] >: Pure[x], R](acquire: F[R])(
+      release: (R, ExitCase[Throwable]) => F[Unit]): Stream[F, (fs2.internal.Resource[F], R)] =
+    fromFreeC(Algebra.acquire[F, (fs2.internal.Resource[F], R), R](acquire, release).flatMap {
+      case (r, res) =>
         Stream
           .emit(r)
           .covary[F]
-          .map(o => (token, o))
-          .get[F, (Token, R)] >> Algebra.release(token)
+          .map(o => (res, o))
+          .get[F, (fs2.internal.Resource[F], R)]
     })
 
   /**

--- a/core/shared/src/main/scala/fs2/internal/Resource.scala
+++ b/core/shared/src/main/scala/fs2/internal/Resource.scala
@@ -7,8 +7,7 @@ import fs2.Scope
 /**
   * Represents a resource acquired during stream interpretation.
   *
-  * A resource is acquired by `Algebra.Acquire` and then released by either `Algebra.Release` or
-  * `Algebra.CloseScope`.
+  * A resource is acquired by `Algebra.Acquire` and then released by `Algebra.CloseScope`.
   *
   * The acquisition of a resource has three steps:
   *
@@ -23,13 +22,11 @@ import fs2.Scope
   *
   * A resource may be released by any of the following methods:
   *
-  * (1) `Algebra.Release` is interpreted. In this case, the finalizer will be invoked if
-  *     the resource was successfully acquired (the `acquired` was evaluated) and resource was not leased to another scope.
-  * (2) The owning scope was closed by `Algebra.CloseScope`. This essentially evaluates `release` of
+  * (1) The owning scope was closed by `Algebra.CloseScope`. This essentially evaluates `release` of
   *     the `Resource` and acts like (1).
-  * (3) `acquired` was evaluated after scope was `released` by either (1) or (2). In this case,
+  * (2) `acquired` was evaluated after scope was `released` by either (1) or (2). In this case,
   *     finalizer will be invoked immediately if the resource is not leased.
-  * (4) `cancel` is invoked on a `Lease` for the resource. This will invoke the finalizer
+  * (3) `cancel` is invoked on a `Lease` for the resource. This will invoke the finalizer
   *     if the resource was already acquired and released and there are no other outstanding leases.
   *
   * Resources may be leased to other scopes. Each scope must lease with `lease` and  when the other
@@ -38,7 +35,7 @@ import fs2.Scope
   * Note that every method which may potentially call a resource finalizer returns `F[Either[Throwable, Unit]]`
   * instead of `F[Unit]`` to make sure any errors that occur when releasing the resource are properly handled.
   */
-private[internal] sealed abstract class Resource[F[_]] {
+private[fs2] sealed abstract class Resource[F[_]] {
 
   /**
     * Id of the resource

--- a/io/src/test/scala/fs2/io/tcp/SocketSpec.scala
+++ b/io/src/test/scala/fs2/io/tcp/SocketSpec.scala
@@ -48,6 +48,7 @@ class SocketSpec extends Fs2Spec with BeforeAndAfterAll {
                   .reads(1024)
                   .through(socket.writes())
                   .onFinalize(socket.endOfOutput)
+                  .scope
               }
           }
           .parJoinUnbounded
@@ -63,7 +64,8 @@ class SocketSpec extends Fs2Spec with BeforeAndAfterAll {
                   .chunk(message)
                   .through(socket.writes())
                   .drain
-                  .onFinalize(socket.endOfOutput) ++
+                  .onFinalize(socket.endOfOutput)
+                  .scope ++
                   socket.reads(1024, None).chunks.map(_.toArray)
               }
             }
@@ -102,6 +104,7 @@ class SocketSpec extends Fs2Spec with BeforeAndAfterAll {
                   .through(socket.writes())
                   .drain
                   .onFinalize(socket.endOfOutput)
+                  .scope
               })
           }
           .parJoinUnbounded


### PR DESCRIPTION
Prior to this PR, resources were released in two main ways:
1. `Algebra.Release` would release a specific resource
2. `Algebra.CloseScope` would close a scope, releasing all resources in that scope (and child scopes)

While working on the topic/tagless2 branch, I noticed that we hardly ever hit case (1) above. Almost all resources get released as a result of (2). I added instrumentation to the interpreter to track those conditions and ran our test suite with these results:

|Release Type|Pre PR|Post PR|
|-------------|-------|--------|
|Explicit|59465|0|
|Scope Closure| 1492331| 1545044|

Prior to this PR, over 96% of all release releases were due to scope closure.

In this PR, I removed the `Algebra.Release` constructor and changed `Stream.bracket` to no longer explicitly release the acquired resource. This broke `merge` due to an assumption on when a finalizer would be run, but that was easily fixed by explicit introduction of a scope (see the diff). Otherwise, all tests passed.

My motivations:
1. Simplify reasoning about resource finalization.
2. Performance & memory improvement as we avoid binding a `Release` node on every `bracket` which is typically not used.