### PR TITLE
Interruptible eval

### DIFF
--- a/core/jvm/src/test/scala/fs2/Pipe2Spec.scala
+++ b/core/jvm/src/test/scala/fs2/Pipe2Spec.scala
@@ -495,7 +495,6 @@ class Pipe2Spec extends Fs2Spec {
     }
 
     "interrupt (19)" in {
-      pending
       // interruptible eval
 
       def prg =

--- a/core/jvm/src/test/scala/fs2/Pipe2Spec.scala
+++ b/core/jvm/src/test/scala/fs2/Pipe2Spec.scala
@@ -2,7 +2,7 @@ package fs2
 
 import scala.concurrent.duration._
 import cats.effect.IO
-import cats.effect.concurrent.Semaphore
+import cats.effect.concurrent.{Deferred, Semaphore}
 import cats.implicits._
 import org.scalacheck.Gen
 import TestUtil._
@@ -492,6 +492,26 @@ class Pipe2Spec extends Fs2Spec {
 
       runLog(prg) shouldBe Vector(5)
 
+    }
+
+    "interrupt (19)" in {
+      pending
+      // interruptible eval
+
+      def prg =
+        Deferred[IO, Unit]
+          .flatMap { latch =>
+            Stream
+              .eval {
+                latch.get.guarantee(latch.complete(()))
+              }
+              .interruptAfter(200.millis)
+              .compile
+              .drain >> latch.get.as(true)
+          }
+          .timeout(3.seconds)
+
+      prg.unsafeRunSync shouldBe true
     }
 
     "nested-interrupt (1)" in forAll { s1: PureStream[Int] =>

--- a/core/shared/src/main/scala/fs2/internal/CompileScope.scala
+++ b/core/shared/src/main/scala/fs2/internal/CompileScope.scala
@@ -382,7 +382,7 @@ private[fs2] final class CompileScope[F[_]] private (
       case Some(iCtx) =>
         F.map(
           iCtx.concurrent
-            .race(iCtx.deferred.get, F.attempt(iCtx.concurrent.uncancelable(f)))) {
+            .race(iCtx.deferred.get, F.attempt(f))) {
           case Right(result) => result.leftMap(Left(_))
           case Left(other)   => Left(other)
         }

--- a/core/shared/src/main/scala/fs2/internal/CompileScope.scala
+++ b/core/shared/src/main/scala/fs2/internal/CompileScope.scala
@@ -25,10 +25,6 @@ import fs2.internal.CompileScope.InterruptContext
   * For example, `s.chunks` is defined with `s.repeatPull` which in turn is defined with `Pull.loop(...).stream`.
   * In this case, a single scope is created as a result of the call to `.stream`.
   *
-  * The `root` scope is special in that it is closed by the top level compile loop, rather than by instructions in the
-  * Stream structure. This is to allow extending the lifetime of Stream when compiling to a `cats.effect.Resource`
-  *  (not to be confused with `fs2.internal.Resource`).
-  *
   * Scopes may also be opened and closed manually with `Stream#scope`. For the stream `s.scope`, a scope
   * is opened before evaluation of `s` and closed once `s` finishes evaluation.
   *
@@ -117,7 +113,7 @@ private[fs2] final class CompileScope[F[_]] private (
       val newScopeId = new Token
       self.interruptible match {
         case None =>
-          F.pure(InterruptContext.unsafeFromInteruptible(interruptible, newScopeId) -> newScopeId)
+          F.pure(InterruptContext.unsafeFromInterruptible(interruptible, newScopeId) -> newScopeId)
 
         case Some(parentICtx) =>
           F.map(parentICtx.childContext(interruptible, newScopeId))(Some(_) -> newScopeId)
@@ -518,7 +514,7 @@ private[fs2] object CompileScope {
       *                       continuation in case of interruption.
       * @param newScopeId     The id of the new scope.
       */
-    def unsafeFromInteruptible[F[_]](
+    def unsafeFromInterruptible[F[_]](
         interruptible: Option[Concurrent[F]],
         newScopeId: Token
     )(implicit F: Sync[F]): Option[InterruptContext[F]] =


### PR DESCRIPTION
This makes `eval` nodes properly interruptible. For this PR I decided to go with the least intrusive approach possible, there is plenty of (relatively) low hanging fruit to make things better, simply because they were designed without taking F interruption into account.
As a mitigating factor though, a lot of code which would naively be leaky is actually in an `F.start` section plus custom Stream interruption,  and that makes it unreachable for F interruption, which is why I believe we are not seeing problematic behaviour across the board.
In any case, I'll be auditing and fixing for this when time permits, but the problematic behaviour should be fixed as is