### PR TITLE
Fix issue where switchMap could get stuck

### DIFF
--- a/core/jvm/src/test/scala/fs2/SwitchMapSpec.scala
+++ b/core/jvm/src/test/scala/fs2/SwitchMapSpec.scala
@@ -12,6 +12,15 @@ class SwitchMapSpec extends Fs2Spec with EventuallySupport {
 
   "switchMap" - {
 
+    "sanity check" in forAll { s: PureStream[Int] =>
+      runLog(
+        s.get
+          .covary[IO]
+          .switchMap(Stream.emit)
+          .last
+      ) shouldBe runLog(s.get.last)
+    }
+
     "flatMap equivalence when switching never occurs" in forAll { s: PureStream[Int] =>
       runLog(Stream.eval(Semaphore[IO](1)).flatMap { guard =>
         s.get


### PR DESCRIPTION
This fixes issue where `switchMap` could easily get stuck due to deadlocked semaphore.

minimum repro:
```scala
import cats.effect.IOApp

object Demo extends IOApp {

  import cats.implicits._
  import cats.effect._
  import fs2.Stream

  override def run(args: List[String]): IO[ExitCode] =
    Stream
      .range(1, 10)
      .covary[IO]
      .evalTap(i => IO(println(i)))
      .switchMap(Stream.emit)
      .compile
      .drain
      .as(ExitCode.Success)
}

// Output:
// 1
// 2
// 3
// 4
// ...no further output
```