### PR TITLE
Printing sinks should take ContextShift + EC

### DIFF
--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -75,13 +75,21 @@ object text {
       doPull(Chunk.empty, in).stream
   }
 
+  /** Encodes a stream of `String` in to a stream of bytes using the given charset. */
+  def encode[F[_]](charset: Charset): Pipe[F, String, Byte] =
+    _.flatMap(s => Stream.chunk(Chunk.bytes(s.getBytes(charset))))
+
+  /** Encodes a stream of `String` in to a stream of `Chunk[Byte]` using the given charset. */
+  def encodeC[F[_]](charset: Charset): Pipe[F, String, Chunk[Byte]] =
+    _.map(s => Chunk.bytes(s.getBytes(charset)))
+
   /** Encodes a stream of `String` in to a stream of bytes using the UTF-8 charset. */
   def utf8Encode[F[_]]: Pipe[F, String, Byte] =
-    _.flatMap(s => Stream.chunk(Chunk.bytes(s.getBytes(utf8Charset))))
+    encode(utf8Charset)
 
   /** Encodes a stream of `String` in to a stream of `Chunk[Byte]` using the UTF-8 charset. */
   def utf8EncodeC[F[_]]: Pipe[F, String, Chunk[Byte]] =
-    _.map(s => Chunk.bytes(s.getBytes(utf8Charset)))
+    encodeC(utf8Charset)
 
   /** Transforms a stream of `String` such that each emitted `String` is a line from the input. */
   def lines[F[_]]: Pipe[F, String, String] = {


### PR DESCRIPTION
Add stdoutLines and stdinLines as commented in the issue https://github.com/functional-streams-for-scala/fs2/issues/1328