### PR TITLE
Scalafix for replacing Sink with Pipe

### DIFF
--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -30,7 +30,8 @@ lazy val rules = project.settings(
 lazy val input = project.settings(
   skip in publish := true,
   libraryDependencies ++= Seq(
-    "co.fs2" %% "fs2-core" % "0.10.6"
+    "co.fs2" %% "fs2-core" % "0.10.6",
+    "com.typesafe.akka" %% "akka-stream" % "2.5.21"
   )
 )
 

--- a/scalafix/input/src/main/scala/fix/AkkaSink.scala
+++ b/scalafix/input/src/main/scala/fix/AkkaSink.scala
@@ -1,0 +1,10 @@
+/*
+rule = v1
+*/
+package fix
+
+import akka.stream.scaladsl.Sink
+
+object AkkaSink {
+  val s: Sink[Int, Unit] = ???
+}

--- a/scalafix/input/src/main/scala/fix/Fs2sinkremoval.scala
+++ b/scalafix/input/src/main/scala/fix/Fs2sinkremoval.scala
@@ -1,0 +1,16 @@
+/*
+rule = v1
+*/
+package fix
+
+import fs2._
+import fs2.{Pipe, Sink, Stream}
+import fs2.{Sink => X, Stream}
+
+object Fs2sinkremoval {
+
+  private def foo[F[_], A](s: Stream[F, A], sink: Sink[F, A]): Stream[F, Unit] =
+    s.to(sink)
+
+  def bar[F[_], A, B](): Pipe[F, A, B] = ???
+}

--- a/scalafix/input/src/main/scala/fix/Fs2sinkremoval.scala
+++ b/scalafix/input/src/main/scala/fix/Fs2sinkremoval.scala
@@ -13,4 +13,6 @@ object Fs2sinkremoval {
     s.to(sink)
 
   def bar[F[_], A, B](): Sink[F, A] = ???
+
+  def baz[F[_], A, B](): X[F, A] = ???
 }

--- a/scalafix/input/src/main/scala/fix/Fs2sinkremoval.scala
+++ b/scalafix/input/src/main/scala/fix/Fs2sinkremoval.scala
@@ -12,5 +12,5 @@ object Fs2sinkremoval {
   private def foo[F[_], A](s: Stream[F, A], sink: Sink[F, A]): Stream[F, Unit] =
     s.to(sink)
 
-  def bar[F[_], A, B](): Pipe[F, A, B] = ???
+  def bar[F[_], A, B](): Sink[F, A] = ???
 }

--- a/scalafix/output/src/main/scala/fix/AkkaSink.scala
+++ b/scalafix/output/src/main/scala/fix/AkkaSink.scala
@@ -1,0 +1,7 @@
+package fix
+
+import akka.stream.scaladsl.Sink
+
+object AkkaSink {
+  val s: Sink[Int, Unit] = ???
+}

--- a/scalafix/output/src/main/scala/fix/Fs2sinkremoval.scala
+++ b/scalafix/output/src/main/scala/fix/Fs2sinkremoval.scala
@@ -1,0 +1,13 @@
+package fix
+
+import fs2._
+import fs2.{Pipe, Stream}
+import fs2.{Pipe => X, Stream}
+
+object Fs2sinkremoval {
+
+  private def foo[F[_], A](s: Stream[F, A], sink: Pipe[F, A, Unit]): Stream[F, Unit] =
+    s.through(sink)
+
+  def bar[F[_], A, B](): Pipe[F, A, B] = ???
+}

--- a/scalafix/output/src/main/scala/fix/Fs2sinkremoval.scala
+++ b/scalafix/output/src/main/scala/fix/Fs2sinkremoval.scala
@@ -9,5 +9,5 @@ object Fs2sinkremoval {
   private def foo[F[_], A](s: Stream[F, A], sink: Pipe[F, A, Unit]): Stream[F, Unit] =
     s.through(sink)
 
-  def bar[F[_], A, B](): Pipe[F, A, B] = ???
+  def bar[F[_], A, B](): Pipe[F, A, Unit] = ???
 }

--- a/scalafix/output/src/main/scala/fix/Fs2sinkremoval.scala
+++ b/scalafix/output/src/main/scala/fix/Fs2sinkremoval.scala
@@ -10,4 +10,6 @@ object Fs2sinkremoval {
     s.through(sink)
 
   def bar[F[_], A, B](): Pipe[F, A, Unit] = ???
+
+  def baz[F[_], A, B](): X[F, A, Unit] = ???
 }

--- a/scalafix/rules/src/main/scala/fix/v1.scala
+++ b/scalafix/rules/src/main/scala/fix/v1.scala
@@ -511,7 +511,9 @@ object UsabilityRenameRules {
 }
 
 object SinkToPipeRules {
-  val toMethodMatcher = SymbolMatcher.exact("fs2/Stream.InvariantOps#to().")
+  val pre102ToMethodMatcher = SymbolMatcher.exact("fs2/Stream#to().")
+  val post102ToMethodMatcher = SymbolMatcher.exact("fs2/Stream.InvariantOps#to().")
+  val toMethodMatcher = pre102ToMethodMatcher + post102ToMethodMatcher
 
   def isFs2SinkImported(t: Tree): Boolean =
     t.collect {

--- a/scalafix/rules/src/main/scala/fix/v1.scala
+++ b/scalafix/rules/src/main/scala/fix/v1.scala
@@ -538,11 +538,12 @@ object SinkToPipeRules {
         }
 
         case sink @ Type.Apply(sinkMatcher(name), List(f, a)) =>
-          if (name.toString == "Sink") {
-            Patch.replaceTree(sink, s"Pipe[$f, $a, Unit]")
-          } else {
-            val typeName = name.toString
-            Patch.replaceTree(sink, s"$typeName[$f, $a, Unit]")
+          name match {
+            case t"Sink" => Patch.replaceTree(sink, s"Pipe[$f, $a, Unit]")
+            case _ => {
+              val typeName = name.toString
+              Patch.replaceTree(sink, s"$typeName[$f, $a, Unit]")
+            }
           }
 
         case sink @ Importee.Rename(Name("Sink"), rename) =>

--- a/scalafix/rules/src/main/scala/fix/v1.scala
+++ b/scalafix/rules/src/main/scala/fix/v1.scala
@@ -540,10 +540,7 @@ object SinkToPipeRules {
         case sink @ Type.Apply(sinkMatcher(name), List(f, a)) =>
           name match {
             case t"Sink" => Patch.replaceTree(sink, s"Pipe[$f, $a, Unit]")
-            case _ => {
-              val typeName = name.toString
-              Patch.replaceTree(sink, s"$typeName[$f, $a, Unit]")
-            }
+            case _ => Patch.addRight(a, ", Unit")
           }
 
         case sink @ Importee.Rename(Name("Sink"), rename) =>

--- a/scalafix/rules/src/main/scala/fix/v1.scala
+++ b/scalafix/rules/src/main/scala/fix/v1.scala
@@ -530,13 +530,20 @@ object SinkToPipeRules {
   ).asPatch
 
   def apply(t: Tree)(implicit doc: SemanticDocument): List[Patch] = {
+    //println("Tree.structureLabeled: " + doc.tree.structureLabeled)
+    //val sinkMatcher = SymbolMatcher.normalized("fs2.Sink")
+    val sinkMatcher = SymbolMatcher.exact("fs2/Sink.")
     if (isFs2SinkImported(t)) {
       t.collect {
         case toMethodMatcher(t @ Term.Apply(Term.Select(obj, _), args)) => {
           Patch.replaceTree(t, Term.Apply(Term.Select(obj, Term.Name("through")), args).toString)
         }
 
-        case sink @ Type.Apply(Type.Name("Sink"), List(f, a)) =>
+        //case sink @ Type.Apply(Type.Name("Sink"), List(f, a)) =>
+        //case sink @ sinkMatcher(name @ Type.Apply(Type.Name(_), List(f, a))) =>
+        case sink @ Type.Apply(sinkMatcher(name), List(f, a)) =>
+        //case sink @ sinkMatcher(name) =>
+          println(s"Matched: $name")
           Patch.replaceTree(sink, s"Pipe[$f, $a, Unit]")
 
         case sink @ Importee.Rename(Name("Sink"), rename) =>


### PR DESCRIPTION
One possible issue with this PR is that there are 2 input and output files associated with this scalafix rule.  Would it be preferred that they be combined into one?