### PR TITLE
add FunctionK instances for Stream and Pull

### DIFF
--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -1,6 +1,7 @@
 package fs2
 
 import cats._
+import cats.arrow.FunctionK
 import cats.effect._
 import fs2.internal._
 
@@ -253,6 +254,18 @@ object Pull extends PullLowPriority {
             .syncInstance[Algebra[F, O, ?]]
             .bracketCase(acquire.get)(a => use(a).get)((a, c) => release(a, c).get))
     }
+
+  /**
+    * `FunctionK` instance for `F ~> Pull[F, INothing, ?]`
+    *
+    * @example {{{
+    * scala> import cats.Id
+    * scala> Pull.functionKInstance[Id](42).flatMap(Pull.output1).stream.compile.toList
+    * res0: cats.Id[List[Int]] = List(42)
+    * }}}
+    */
+  implicit def functionKInstance[F[_]]: F ~> Pull[F, INothing, ?] =
+    FunctionK.lift[F, Pull[F, INothing, ?]](Pull.eval)
 }
 
 private[fs2] trait PullLowPriority {

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1,6 +1,7 @@
 package fs2
 
 import cats._
+import cats.arrow.FunctionK
 import cats.data.{Chain, NonEmptyList}
 import cats.effect._
 import cats.effect.concurrent._
@@ -4334,6 +4335,18 @@ object Stream extends StreamLowPriority {
         pull(fa).stream
       }
     }
+
+  /**
+    * `FunctionK` instance for `F ~> Stream[F, ?]`
+    *
+    * @example {{{
+    * scala> import cats.Id
+    * scala> Stream.functionKInstance[Id](42).compile.toList
+    * res0: cats.Id[List[Int]] = List(42)
+    * }}}
+    */
+  implicit def functionKInstance[F[_]]: F ~> Stream[F, ?] =
+    FunctionK.lift[F, Stream[F, ?]](Stream.eval)
 
   implicit def monoidKInstance[F[_]]: MonoidK[Stream[F, ?]] =
     new MonoidK[Stream[F, ?]] {


### PR DESCRIPTION
I'm not sure if these are the right places for these functions, but it seemed like a good start. This PR was prompted by reading @gvolpe's TypeLevel blog post [“Tagless Final algebras and Streaming”](https://typelevel.org/blog/2018/05/09/tagless-final-streaming.html) and trying to implement an interpreter parameterized by `F[_], G[_]`. For example, given this algebra:

```scala
import cats._, cats.arrow.FunctionK, cats.effect.IO

trait FooAlg[F[_], G[_]] {
  def foo(): G[Int]
  def bar(): F[Int]
}
```

if I want to implement `foo()` in terms of `bar()` without fixing `G` as `Stream[F, ?]`, I think one must have an `F ~> G` available.

```scala
class FooImpl[F[_] : Applicative, G[_] : Monad](implicit FtoG: F ~> G) extends FooAlg[F, G] {
  def foo(): G[Int] = FtoG(bar()).flatMap(x => Applicative[G].pure(x)) // actually this strings together several consecutive functions in monadic fashion
  def bar(): F[Int] = Applicative[F].pure(42) // actually this does IO to call a remote service
}
```

```scala
scala> val foo = new FooImpl[IO, Stream[IO, ?]]
foo: FooImpl[cats.effect.IO,[β$0$]fs2.Stream[cats.effect.IO,β$0$]] = FooImpl@4ee2479d

scala> foo.foo()
res0: fs2.Stream[cats.effect.IO,Int] = Stream(..)

scala> foo.bar()
res1: cats.effect.IO[Int] = IO(42)

scala> foo.foo().compile.toList.unsafeRunSync
res2: List[Int] = List(42)
```

I'm mainly interested in the instance for `Stream`, but I thought I'd add the one for `Pull` too, for the sake of completion.

I didn't see any laws available for `FunctionK` in cats-laws, so I didn't add any tests beyond the doctests.