### PR TITLE
Add dual constructors for fs2.concurrent datatypes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -230,7 +230,13 @@ lazy val mimaSettings = Seq(
     ProblemFilters.exclude[IncompatibleMethTypeProblem]("fs2.Stream#Compiler.apply"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.Stream#Compiler.apply"),
     // bracketWithToken was private[fs2]
-    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.Stream.bracketWithToken")
+    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.Stream.bracketWithToken"),
+    //forStrategy/NoneTerminated were private[fs2]
+    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.concurrent.Queue.forStrategy"),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "fs2.concurrent.Queue.forStrategyNoneTerminated"),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "fs2.concurrent.InspectableQueue.forStrategy")
   )
 )
 

--- a/core/shared/src/main/scala/fs2/concurrent/PubSub.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/PubSub.scala
@@ -98,207 +98,223 @@ private[fs2] object PubSub {
   )
 
   def apply[F[_]: Concurrent, I, O, QS, Selector](
-      strategy: PubSub.Strategy[I, O, QS, Selector]): F[PubSub[F, I, O, Selector]] = {
+      strategy: PubSub.Strategy[I, O, QS, Selector]): F[PubSub[F, I, O, Selector]] =
+    in[F].from(strategy)
 
-    type PS = PubSubState[F, I, O, QS, Selector]
+  final class InPartiallyApplied[G[_]](val G: Sync[G]) extends AnyVal {
+    def from[F[_]: Concurrent, I, O, QS, Selector](
+        strategy: PubSub.Strategy[I, O, QS, Selector]): G[PubSub[F, I, O, Selector]] = {
 
-    def initial: PS = PubSubState(strategy.initial, ScalaQueue.empty, ScalaQueue.empty)
+      type PS = PubSubState[F, I, O, QS, Selector]
 
-    // runs all subscribers
-    // yields to None, if no subscriber was completed
-    // yields to Some(nextPS, completeAction) whenever at least one subscriber completes
-    // before this finishes this always tries to consume all subscribers in order they have been
-    // registered unless strategy signals it is empty.
-    def consumeSubscribers(ps: PS): (PS, Option[F[Unit]]) = {
-      @tailrec
-      def go(queue: QS,
-             remains: ScalaQueue[Subscriber[F, O, Selector]],
-             keep: ScalaQueue[Subscriber[F, O, Selector]],
-             acc: Option[F[Unit]]): (PS, Option[F[Unit]]) =
-        remains.headOption match {
-          case None =>
-            (ps.copy(queue = queue, subscribers = keep), acc)
+      def initial: PS = PubSubState(strategy.initial, ScalaQueue.empty, ScalaQueue.empty)
 
-          case Some(sub) =>
-            strategy.get(sub.selector, queue) match {
-              case (queue, None) =>
-                go(queue, remains.tail, keep :+ sub, acc)
-              case (queue, Some(chunk)) =>
-                def action = acc.map(_ >> sub.complete(chunk)).getOrElse(sub.complete(chunk))
-                if (!strategy.empty(queue)) go(queue, remains.tail, keep, Some(action))
-                else (ps.copy(queue = queue, subscribers = keep ++ remains.tail), Some(action))
-            }
-        }
-      go(ps.queue, ps.subscribers, ScalaQueue.empty, None)
-    }
+      // runs all subscribers
+      // yields to None, if no subscriber was completed
+      // yields to Some(nextPS, completeAction) whenever at least one subscriber completes
+      // before this finishes this always tries to consume all subscribers in order they have been
+      // registered unless strategy signals it is empty.
+      def consumeSubscribers(ps: PS): (PS, Option[F[Unit]]) = {
+        @tailrec
+        def go(queue: QS,
+               remains: ScalaQueue[Subscriber[F, O, Selector]],
+               keep: ScalaQueue[Subscriber[F, O, Selector]],
+               acc: Option[F[Unit]]): (PS, Option[F[Unit]]) =
+          remains.headOption match {
+            case None =>
+              (ps.copy(queue = queue, subscribers = keep), acc)
 
-    // tries to publish all publishers awaiting
-    // yields to None if no single publisher published
-    // yields to Some(nextPS, publishSignal) if at least one publisher was publishing to the queue
-    // always tries to publish all publishers reminaing in single cycle, even when one publisher succeeded
-    def publishPublishers(ps: PS): (PS, Option[F[Unit]]) = {
-      @tailrec
-      def go(queue: QS,
-             remains: ScalaQueue[Publisher[F, I]],
-             keep: ScalaQueue[Publisher[F, I]],
-             acc: Option[F[Unit]]): (PS, Option[F[Unit]]) =
-        remains.headOption match {
-          case None =>
-            (ps.copy(queue = queue, publishers = keep), acc)
-
-          case Some(pub) =>
-            if (strategy.accepts(pub.i, queue)) {
-              val queue1 = strategy.publish(pub.i, queue)
-              def action = acc.map(_ >> pub.complete).getOrElse(pub.complete)
-              go(queue1, remains.tail, keep, Some(action))
-            } else {
-              go(queue, remains.tail, keep :+ pub, acc)
-            }
-        }
-      go(ps.queue, ps.publishers, ScalaQueue.empty, None)
-    }
-
-    /*
-     * Central loop. This is consulted always to make sure there are not any not-satisfied publishers // subscribers
-     * since last publish/get op
-     * this tries to satisfy publishers/subscribers interchangeably until
-     * there was no successful publish // subscription in the last loop
-     */
-    @tailrec
-    def loop(ps: PS, action: F[Unit]): (PS, F[Unit]) =
-      publishPublishers(ps) match {
-        case (ps, resultPublish) =>
-          consumeSubscribers(ps) match {
-            case (ps, resultConsume) =>
-              if (resultConsume.isEmpty && resultPublish.isEmpty) (ps, action)
-              else {
-                def nextAction =
-                  resultConsume.map(action >> _).getOrElse(action) >>
-                    resultPublish.getOrElse(Applicative[F].unit)
-                loop(ps, nextAction)
+            case Some(sub) =>
+              strategy.get(sub.selector, queue) match {
+                case (queue, None) =>
+                  go(queue, remains.tail, keep :+ sub, acc)
+                case (queue, Some(chunk)) =>
+                  def action = acc.map(_ >> sub.complete(chunk)).getOrElse(sub.complete(chunk))
+                  if (!strategy.empty(queue)) go(queue, remains.tail, keep, Some(action))
+                  else (ps.copy(queue = queue, subscribers = keep ++ remains.tail), Some(action))
               }
           }
+        go(ps.queue, ps.subscribers, ScalaQueue.empty, None)
       }
 
-    def tryGet_(selector: Selector, ps: PS): (PS, Option[O]) =
-      strategy.get(selector, ps.queue) match {
-        case (queue, result) =>
-          (ps.copy(queue = queue), result)
+      // tries to publish all publishers awaiting
+      // yields to None if no single publisher published
+      // yields to Some(nextPS, publishSignal) if at least one publisher was publishing to the queue
+      // always tries to publish all publishers reminaing in single cycle, even when one publisher succeeded
+      def publishPublishers(ps: PS): (PS, Option[F[Unit]]) = {
+        @tailrec
+        def go(queue: QS,
+               remains: ScalaQueue[Publisher[F, I]],
+               keep: ScalaQueue[Publisher[F, I]],
+               acc: Option[F[Unit]]): (PS, Option[F[Unit]]) =
+          remains.headOption match {
+            case None =>
+              (ps.copy(queue = queue, publishers = keep), acc)
+
+            case Some(pub) =>
+              if (strategy.accepts(pub.i, queue)) {
+                val queue1 = strategy.publish(pub.i, queue)
+                def action = acc.map(_ >> pub.complete).getOrElse(pub.complete)
+                go(queue1, remains.tail, keep, Some(action))
+              } else {
+                go(queue, remains.tail, keep :+ pub, acc)
+              }
+          }
+        go(ps.queue, ps.publishers, ScalaQueue.empty, None)
       }
 
-    def publish_(i: I, ps: PS): PS =
-      ps.copy(queue = strategy.publish(i, ps.queue))
-
-    Ref.of[F, PS](initial).map { state =>
-      def update[X](f: PS => (PS, F[X])): F[X] =
-        state.modify { ps =>
-          val (ps1, result) = f(ps)
-          val (ps2, action) = loop(ps1, Applicative[F].unit)
-          (ps2, action >> result)
-        }.flatten
-
-      def clearPublisher(token: Token)(exitCase: ExitCase[Throwable]): F[Unit] = exitCase match {
-        case ExitCase.Completed => Applicative[F].unit
-        case ExitCase.Error(_) | ExitCase.Canceled =>
-          state.update { ps =>
-            ps.copy(publishers = ps.publishers.filterNot(_.token == token))
-          }
-      }
-
-      def clearSubscriber(token: Token): F[Unit] =
-        state.update { ps =>
-          ps.copy(subscribers = ps.subscribers.filterNot(_.token == token))
-        }
-
-      def clearSubscriberOnCancel(token: Token)(exitCase: ExitCase[Throwable]): F[Unit] =
-        exitCase match {
-          case ExitCase.Completed                    => Applicative[F].unit
-          case ExitCase.Error(_) | ExitCase.Canceled => clearSubscriber(token)
-        }
-
-      new PubSub[F, I, O, Selector] {
-        def publish(i: I): F[Unit] =
-          update { ps =>
-            if (strategy.accepts(i, ps.queue)) {
-
-              val ps1 = publish_(i, ps)
-              (ps1, Applicative[F].unit)
-            } else {
-              val publisher = Publisher(new Token, i, Deferred.unsafe[F, Unit])
-
-              def awaitCancellable =
-                Sync[F].guaranteeCase(publisher.signal.get)(clearPublisher(publisher.token))
-
-              (ps.copy(publishers = ps.publishers :+ publisher), awaitCancellable)
-            }
-          }
-
-        def tryPublish(i: I): F[Boolean] =
-          update { ps =>
-            if (!strategy.accepts(i, ps.queue)) (ps, Applicative[F].pure(false))
-            else {
-              val ps1 = publish_(i, ps)
-              (ps1, Applicative[F].pure(true))
-            }
-          }
-
-        def get(selector: Selector): F[O] =
-          update { ps =>
-            tryGet_(selector, ps) match {
-              case (ps, None) =>
-                val token = new Token
-
-                val sub =
-                  Subscriber(token, selector, Deferred.unsafe[F, O])
-
-                def cancellableGet =
-                  Sync[F].guaranteeCase(sub.signal.get)(clearSubscriberOnCancel(token))
-
-                (ps.copy(subscribers = ps.subscribers :+ sub), cancellableGet)
-              case (ps, Some(o)) =>
-                (ps, Applicative[F].pure(o))
-            }
-          }
-
-        def getStream(selector: Selector): Stream[F, O] =
-          Stream.bracket(Sync[F].delay(new Token))(clearSubscriber).flatMap { token =>
-            def get_ =
-              update { ps =>
-                tryGet_(selector, ps) match {
-                  case (ps, None) =>
-                    val sub =
-                      Subscriber(token, selector, Deferred.unsafe[F, O])
-
-                    (ps.copy(subscribers = ps.subscribers :+ sub), sub.signal.get)
-
-                  case (ps, Some(o)) =>
-                    (ps, Applicative[F].pure(o))
+      /*
+       * Central loop. This is consulted always to make sure there are not any not-satisfied publishers // subscribers
+       * since last publish/get op
+       * this tries to satisfy publishers/subscribers interchangeably until
+       * there was no successful publish // subscription in the last loop
+       */
+      @tailrec
+      def loop(ps: PS, action: F[Unit]): (PS, F[Unit]) =
+        publishPublishers(ps) match {
+          case (ps, resultPublish) =>
+            consumeSubscribers(ps) match {
+              case (ps, resultConsume) =>
+                if (resultConsume.isEmpty && resultPublish.isEmpty) (ps, action)
+                else {
+                  def nextAction =
+                    resultConsume.map(action >> _).getOrElse(action) >>
+                      resultPublish.getOrElse(Applicative[F].unit)
+                  loop(ps, nextAction)
                 }
+            }
+        }
+
+      def tryGet_(selector: Selector, ps: PS): (PS, Option[O]) =
+        strategy.get(selector, ps.queue) match {
+          case (queue, result) =>
+            (ps.copy(queue = queue), result)
+        }
+
+      def publish_(i: I, ps: PS): PS =
+        ps.copy(queue = strategy.publish(i, ps.queue))
+
+      implicit val SyncG: Sync[G] = G
+      Ref.in[G, F, PS](initial).map { state =>
+        def update[X](f: PS => (PS, F[X])): F[X] =
+          state.modify { ps =>
+            val (ps1, result) = f(ps)
+            val (ps2, action) = loop(ps1, Applicative[F].unit)
+            (ps2, action >> result)
+          }.flatten
+
+        def clearPublisher(token: Token)(exitCase: ExitCase[Throwable]): F[Unit] = exitCase match {
+          case ExitCase.Completed => Applicative[F].unit
+          case ExitCase.Error(_) | ExitCase.Canceled =>
+            state.update { ps =>
+              ps.copy(publishers = ps.publishers.filterNot(_.token == token))
+            }
+        }
+
+        def clearSubscriber(token: Token): F[Unit] =
+          state.update { ps =>
+            ps.copy(subscribers = ps.subscribers.filterNot(_.token == token))
+          }
+
+        def clearSubscriberOnCancel(token: Token)(exitCase: ExitCase[Throwable]): F[Unit] =
+          exitCase match {
+            case ExitCase.Completed                    => Applicative[F].unit
+            case ExitCase.Error(_) | ExitCase.Canceled => clearSubscriber(token)
+          }
+
+        new PubSub[F, I, O, Selector] {
+          def publish(i: I): F[Unit] =
+            update { ps =>
+              if (strategy.accepts(i, ps.queue)) {
+
+                val ps1 = publish_(i, ps)
+                (ps1, Applicative[F].unit)
+              } else {
+                val publisher = Publisher(new Token, i, Deferred.unsafe[F, Unit])
+
+                def awaitCancellable =
+                  Sync[F].guaranteeCase(publisher.signal.get)(clearPublisher(publisher.token))
+
+                (ps.copy(publishers = ps.publishers :+ publisher), awaitCancellable)
               }
+            }
 
-            Stream.repeatEval(get_)
-          }
+          def tryPublish(i: I): F[Boolean] =
+            update { ps =>
+              if (!strategy.accepts(i, ps.queue)) (ps, Applicative[F].pure(false))
+              else {
+                val ps1 = publish_(i, ps)
+                (ps1, Applicative[F].pure(true))
+              }
+            }
 
-        def tryGet(selector: Selector): F[Option[O]] =
-          update { ps =>
-            val (ps1, result) = tryGet_(selector, ps)
-            (ps1, Applicative[F].pure(result))
-          }
+          def get(selector: Selector): F[O] =
+            update { ps =>
+              tryGet_(selector, ps) match {
+                case (ps, None) =>
+                  val token = new Token
 
-        def subscribe(selector: Selector): F[Boolean] =
-          update { ps =>
-            val (queue, success) = strategy.subscribe(selector, ps.queue)
-            (ps.copy(queue = queue), Applicative[F].pure(success))
-          }
+                  val sub =
+                    Subscriber(token, selector, Deferred.unsafe[F, O])
 
-        def unsubscribe(selector: Selector): F[Unit] =
-          update { ps =>
-            (ps.copy(queue = strategy.unsubscribe(selector, ps.queue)), Applicative[F].unit)
-          }
+                  def cancellableGet =
+                    Sync[F].guaranteeCase(sub.signal.get)(clearSubscriberOnCancel(token))
+
+                  (ps.copy(subscribers = ps.subscribers :+ sub), cancellableGet)
+                case (ps, Some(o)) =>
+                  (ps, Applicative[F].pure(o))
+              }
+            }
+
+          def getStream(selector: Selector): Stream[F, O] =
+            Stream.bracket(Sync[F].delay(new Token))(clearSubscriber).flatMap { token =>
+              def get_ =
+                update { ps =>
+                  tryGet_(selector, ps) match {
+                    case (ps, None) =>
+                      val sub =
+                        Subscriber(token, selector, Deferred.unsafe[F, O])
+
+                      (ps.copy(subscribers = ps.subscribers :+ sub), sub.signal.get)
+
+                    case (ps, Some(o)) =>
+                      (ps, Applicative[F].pure(o))
+                  }
+                }
+
+              Stream.repeatEval(get_)
+            }
+
+          def tryGet(selector: Selector): F[Option[O]] =
+            update { ps =>
+              val (ps1, result) = tryGet_(selector, ps)
+              (ps1, Applicative[F].pure(result))
+            }
+
+          def subscribe(selector: Selector): F[Boolean] =
+            update { ps =>
+              val (queue, success) = strategy.subscribe(selector, ps.queue)
+              (ps.copy(queue = queue), Applicative[F].pure(success))
+            }
+
+          def unsubscribe(selector: Selector): F[Unit] =
+            update { ps =>
+              (ps.copy(queue = strategy.unsubscribe(selector, ps.queue)), Applicative[F].unit)
+            }
+        }
+
       }
-
     }
   }
+
+  /**
+    * Like [[apply]] but initializes state using another effect constructor
+    *
+    * This builder uses the
+    * [[https://typelevel.org/cats/guidelines.html#partially-applied-type-params Partially-Applied Type]]
+    * technique.
+    */
+  def in[G[_]](implicit G: Sync[G]) = new InPartiallyApplied(G)
 
   /**
     * Describes a the behavior of a `PubSub`.

--- a/core/shared/src/main/scala/fs2/concurrent/Queue.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Queue.scala
@@ -140,126 +140,183 @@ trait NoneTerminatedQueue[F[_], A]
 }
 
 object Queue {
+  final class InPartiallyApplied[G[_]](val G: Sync[G]) extends AnyVal {
+
+    /** Creates a queue with no size bound. */
+    def unbounded[F[_], A](implicit F: Concurrent[F]): G[Queue[F, A]] =
+      forStrategy(Strategy.fifo[A])
+
+    /** Creates an unbounded queue that distributed always at max `fairSize` elements to any subscriber. */
+    def fairUnbounded[F[_], A](fairSize: Int)(implicit F: Concurrent[F]): G[Queue[F, A]] =
+      forStrategy(Strategy.fifo[A].transformSelector[Int]((sz, _) => sz.min(fairSize)))
+
+    /** Creates a queue with the specified size bound. */
+    def bounded[F[_], A](maxSize: Int)(implicit F: Concurrent[F]): G[Queue[F, A]] =
+      forStrategy(Strategy.boundedFifo(maxSize))
+
+    /** Creates a bounded queue terminated by enqueueing `None`. All elements before `None` are preserved. */
+    def boundedNoneTerminated[F[_], A](maxSize: Int)(
+        implicit F: Concurrent[F]): G[NoneTerminatedQueue[F, A]] =
+      forStrategyNoneTerminated(PubSub.Strategy.closeDrainFirst(Strategy.boundedFifo(maxSize)))
+
+    /** Creates a queue which stores the last `maxSize` enqueued elements and which never blocks on enqueue. */
+    def circularBuffer[F[_], A](maxSize: Int)(implicit F: Concurrent[F]): G[Queue[F, A]] =
+      forStrategy(Strategy.circularBuffer(maxSize))
+
+    /** Created a bounded queue that distributed always at max `fairSize` elements to any subscriber. */
+    def fairBounded[F[_], A](maxSize: Int, fairSize: Int)(
+        implicit F: Concurrent[F]): G[Queue[F, A]] =
+      forStrategy(Strategy.boundedFifo(maxSize).transformSelector[Int]((sz, _) => sz.min(fairSize)))
+
+    /** Created an unbounded queue terminated by enqueueing `None`. All elements before `None`. */
+    def noneTerminated[F[_], A](implicit F: Concurrent[F]): G[NoneTerminatedQueue[F, A]] =
+      forStrategyNoneTerminated(PubSub.Strategy.closeDrainFirst(Strategy.fifo))
+
+    /** Creates a queue which allows at most a single element to be enqueued at any time. */
+    def synchronous[F[_], A](implicit F: Concurrent[F]): G[Queue[F, A]] =
+      forStrategy(Strategy.synchronous)
+
+    /** Like [[synchronous]], except that any enqueue of `None` will never block and cancels any dequeue operation. */
+    def synchronousNoneTerminated[F[_], A](
+        implicit F: Concurrent[F]): G[NoneTerminatedQueue[F, A]] =
+      forStrategyNoneTerminated(PubSub.Strategy.closeNow(Strategy.synchronous))
+
+    /** Creates a queue from the supplied strategy. */
+    private[fs2] def forStrategy[F[_]: Concurrent, S, A](
+        strategy: PubSub.Strategy[A, Chunk[A], S, Int]): G[Queue[F, A]] = {
+      implicit val SyncG: Sync[G] = G
+      PubSub.in[G].from(strategy).map { pubSub =>
+        new Queue[F, A] {
+
+          def enqueue1(a: A): F[Unit] =
+            pubSub.publish(a)
+
+          def offer1(a: A): F[Boolean] =
+            pubSub.tryPublish(a)
+
+          def dequeue1: F[A] =
+            pubSub.get(1).flatMap(headUnsafe[F, A])
+
+          def tryDequeue1: F[Option[A]] = pubSub.tryGet(1).flatMap {
+            case Some(chunk) => headUnsafe[F, A](chunk).map(Some(_))
+            case None        => Applicative[F].pure(None)
+          }
+
+          def dequeueChunk1(maxSize: Int): F[Chunk[A]] =
+            pubSub.get(maxSize)
+
+          def tryDequeueChunk1(maxSize: Int): F[Option[Chunk[A]]] =
+            pubSub.tryGet(maxSize)
+
+          def dequeueChunk(maxSize: Int): Stream[F, A] =
+            pubSub.getStream(maxSize).flatMap(Stream.chunk)
+
+          def dequeueBatch: Pipe[F, Int, A] =
+            _.flatMap { sz =>
+              Stream.evalUnChunk(pubSub.get(sz))
+            }
+        }
+      }
+    }
+
+    /** Creates a queue that is terminated by enqueueing `None` from the supplied strategy. */
+    private[fs2] def forStrategyNoneTerminated[F[_]: Concurrent, S, A](
+        strategy: PubSub.Strategy[Option[A], Option[Chunk[A]], S, Int])
+      : G[NoneTerminatedQueue[F, A]] = {
+      implicit val SyncG: Sync[G] = G
+      PubSub.in[G].from(strategy).map { pubSub =>
+        new NoneTerminatedQueue[F, A] {
+          def enqueue1(a: Option[A]): F[Unit] =
+            pubSub.publish(a)
+
+          def offer1(a: Option[A]): F[Boolean] =
+            pubSub.tryPublish(a)
+
+          def dequeueChunk(maxSize: Int): Stream[F, A] =
+            pubSub
+              .getStream(maxSize)
+              .unNoneTerminate
+              .flatMap(Stream.chunk)
+
+          def dequeueBatch: Pipe[F, Int, A] =
+            _.evalMap(pubSub.get).unNoneTerminate
+              .flatMap(Stream.chunk)
+
+          def tryDequeue1: F[Option[Option[A]]] =
+            pubSub.tryGet(1).flatMap {
+              case None              => Applicative[F].pure(None)
+              case Some(None)        => Applicative[F].pure(Some(None))
+              case Some(Some(chunk)) => headUnsafe[F, A](chunk).map(a => Some(Some(a)))
+            }
+
+          def dequeueChunk1(maxSize: Int): F[Option[Chunk[A]]] =
+            pubSub.get(maxSize)
+
+          def tryDequeueChunk1(maxSize: Int): F[Option[Option[Chunk[A]]]] =
+            pubSub.tryGet(maxSize)
+
+          def dequeue1: F[Option[A]] =
+            pubSub.get(1).flatMap {
+              case None        => Applicative[F].pure(None)
+              case Some(chunk) => headUnsafe[F, A](chunk).map(Some(_))
+            }
+        }
+      }
+    }
+  }
+
+  /**
+    * Provides constructors for Queue with state initialized using
+    * another `Sync` datatype.
+    *
+    * This method uses the [[http://typelevel.org/cats/guidelines.html#partially-applied-type-params Partially Applied Type Params technique]]
+    *
+    * {{{
+    *   val queue = Queue.in[SyncIO].unbounded[IO, String]
+    * }}}
+    */
+  def in[G[_]](implicit G: Sync[G]) = new InPartiallyApplied(G)
 
   /** Creates a queue with no size bound. */
   def unbounded[F[_], A](implicit F: Concurrent[F]): F[Queue[F, A]] =
-    forStrategy(Strategy.fifo[A])
+    in[F].unbounded
 
   /** Creates an unbounded queue that distributed always at max `fairSize` elements to any subscriber. */
   def fairUnbounded[F[_], A](fairSize: Int)(implicit F: Concurrent[F]): F[Queue[F, A]] =
-    forStrategy(Strategy.fifo[A].transformSelector[Int]((sz, _) => sz.min(fairSize)))
+    in[F].fairUnbounded(fairSize)
 
   /** Creates a queue with the specified size bound. */
   def bounded[F[_], A](maxSize: Int)(implicit F: Concurrent[F]): F[Queue[F, A]] =
-    forStrategy(Strategy.boundedFifo(maxSize))
+    in[F].bounded(maxSize)
 
   /** Creates a bounded queue terminated by enqueueing `None`. All elements before `None` are preserved. */
   def boundedNoneTerminated[F[_], A](maxSize: Int)(
       implicit F: Concurrent[F]): F[NoneTerminatedQueue[F, A]] =
-    forStrategyNoneTerminated(PubSub.Strategy.closeDrainFirst(Strategy.boundedFifo(maxSize)))
+    in[F].boundedNoneTerminated(maxSize)
 
   /** Creates a queue which stores the last `maxSize` enqueued elements and which never blocks on enqueue. */
   def circularBuffer[F[_], A](maxSize: Int)(implicit F: Concurrent[F]): F[Queue[F, A]] =
-    forStrategy(Strategy.circularBuffer(maxSize))
+    in[F].circularBuffer(maxSize)
 
   /** Created a bounded queue that distributed always at max `fairSize` elements to any subscriber. */
   def fairBounded[F[_], A](maxSize: Int, fairSize: Int)(implicit F: Concurrent[F]): F[Queue[F, A]] =
-    forStrategy(Strategy.boundedFifo(maxSize).transformSelector[Int]((sz, _) => sz.min(fairSize)))
+    in[F].fairBounded(maxSize, fairSize)
 
   /** Created an unbounded queue terminated by enqueueing `None`. All elements before `None`. */
   def noneTerminated[F[_], A](implicit F: Concurrent[F]): F[NoneTerminatedQueue[F, A]] =
-    forStrategyNoneTerminated(PubSub.Strategy.closeDrainFirst(Strategy.fifo))
+    in[F].noneTerminated
 
   /** Creates a queue which allows at most a single element to be enqueued at any time. */
   def synchronous[F[_], A](implicit F: Concurrent[F]): F[Queue[F, A]] =
-    forStrategy(Strategy.synchronous)
+    in[F].synchronous
 
   /** Like [[synchronous]], except that any enqueue of `None` will never block and cancels any dequeue operation. */
   def synchronousNoneTerminated[F[_], A](implicit F: Concurrent[F]): F[NoneTerminatedQueue[F, A]] =
-    forStrategyNoneTerminated(PubSub.Strategy.closeNow(Strategy.synchronous))
+    in[F].synchronousNoneTerminated
 
   private[fs2] def headUnsafe[F[_]: Sync, A](chunk: Chunk[A]): F[A] =
     if (chunk.size == 1) Applicative[F].pure(chunk(0))
     else Sync[F].raiseError(new Throwable(s"Expected chunk of size 1. got $chunk"))
-
-  /** Creates a queue from the supplied strategy. */
-  private[fs2] def forStrategy[F[_]: Concurrent, S, A](
-      strategy: PubSub.Strategy[A, Chunk[A], S, Int]): F[Queue[F, A]] =
-    PubSub(strategy).map { pubSub =>
-      new Queue[F, A] {
-
-        def enqueue1(a: A): F[Unit] =
-          pubSub.publish(a)
-
-        def offer1(a: A): F[Boolean] =
-          pubSub.tryPublish(a)
-
-        def dequeue1: F[A] =
-          pubSub.get(1).flatMap(headUnsafe[F, A])
-
-        def tryDequeue1: F[Option[A]] = pubSub.tryGet(1).flatMap {
-          case Some(chunk) => headUnsafe[F, A](chunk).map(Some(_))
-          case None        => Applicative[F].pure(None)
-        }
-
-        def dequeueChunk1(maxSize: Int): F[Chunk[A]] =
-          pubSub.get(maxSize)
-
-        def tryDequeueChunk1(maxSize: Int): F[Option[Chunk[A]]] =
-          pubSub.tryGet(maxSize)
-
-        def dequeueChunk(maxSize: Int): Stream[F, A] =
-          pubSub.getStream(maxSize).flatMap(Stream.chunk)
-
-        def dequeueBatch: Pipe[F, Int, A] =
-          _.flatMap { sz =>
-            Stream.evalUnChunk(pubSub.get(sz))
-          }
-      }
-    }
-
-  /** Creates a queue that is terminated by enqueueing `None` from the supplied strategy. */
-  private[fs2] def forStrategyNoneTerminated[F[_]: Concurrent, S, A](
-      strategy: PubSub.Strategy[Option[A], Option[Chunk[A]], S, Int])
-    : F[NoneTerminatedQueue[F, A]] =
-    PubSub(strategy).map { pubSub =>
-      new NoneTerminatedQueue[F, A] {
-        def enqueue1(a: Option[A]): F[Unit] =
-          pubSub.publish(a)
-
-        def offer1(a: Option[A]): F[Boolean] =
-          pubSub.tryPublish(a)
-
-        def dequeueChunk(maxSize: Int): Stream[F, A] =
-          pubSub
-            .getStream(maxSize)
-            .unNoneTerminate
-            .flatMap(Stream.chunk)
-
-        def dequeueBatch: Pipe[F, Int, A] =
-          _.evalMap(pubSub.get).unNoneTerminate
-            .flatMap(Stream.chunk)
-
-        def tryDequeue1: F[Option[Option[A]]] =
-          pubSub.tryGet(1).flatMap {
-            case None              => Applicative[F].pure(None)
-            case Some(None)        => Applicative[F].pure(Some(None))
-            case Some(Some(chunk)) => headUnsafe[F, A](chunk).map(a => Some(Some(a)))
-          }
-
-        def dequeueChunk1(maxSize: Int): F[Option[Chunk[A]]] =
-          pubSub.get(maxSize)
-
-        def tryDequeueChunk1(maxSize: Int): F[Option[Option[Chunk[A]]]] =
-          pubSub.tryGet(maxSize)
-
-        def dequeue1: F[Option[A]] =
-          pubSub.get(1).flatMap {
-            case None        => Applicative[F].pure(None)
-            case Some(chunk) => headUnsafe[F, A](chunk).map(Some(_))
-          }
-      }
-    }
 
   private[fs2] object Strategy {
 
@@ -382,106 +439,135 @@ trait InspectableQueue[F[_], A] extends Queue[F, A] {
 
 object InspectableQueue {
 
-  /** Creates a queue with no size bound. */
-  def unbounded[F[_], A](implicit F: Concurrent[F]): F[InspectableQueue[F, A]] =
-    forStrategy(Queue.Strategy.fifo[A])(_.headOption)(_.size)
+  final class InPartiallyApplied[G[_]](val G: Sync[G]) extends AnyVal {
 
-  /** Creates a queue with the specified size bound. */
-  def bounded[F[_], A](maxSize: Int)(implicit F: Concurrent[F]): F[InspectableQueue[F, A]] =
-    forStrategy(Queue.Strategy.boundedFifo[A](maxSize))(_.headOption)(_.size)
+    /** Creates a queue with no size bound. */
+    def unbounded[F[_], A](implicit F: Concurrent[F]): G[InspectableQueue[F, A]] =
+      forStrategy(Queue.Strategy.fifo[A])(_.headOption)(_.size)
 
-  /** Creates a queue which stores the last `maxSize` enqueued elements and which never blocks on enqueue. */
-  def circularBuffer[F[_], A](maxSize: Int)(implicit F: Concurrent[F]): F[InspectableQueue[F, A]] =
-    forStrategy(Queue.Strategy.circularBuffer[A](maxSize))(_.headOption)(_.size)
+    /** Creates a queue with the specified size bound. */
+    def bounded[F[_], A](maxSize: Int)(implicit F: Concurrent[F]): G[InspectableQueue[F, A]] =
+      forStrategy(Queue.Strategy.boundedFifo[A](maxSize))(_.headOption)(_.size)
 
-  private[fs2] def forStrategy[F[_]: Concurrent, S, A](
-      strategy: PubSub.Strategy[A, Chunk[A], S, Int]
-  )(
-      headOf: S => Option[A]
-  )(
-      sizeOf: S => Int
-  ): F[InspectableQueue[F, A]] = {
-    implicit def eqInstance: Eq[S] = Eq.fromUniversalEquals[S]
-    PubSub(PubSub.Strategy.Inspectable.strategy(strategy)).map { pubSub =>
-      new InspectableQueue[F, A] {
-        def enqueue1(a: A): F[Unit] = pubSub.publish(a)
+    /** Creates a queue which stores the last `maxSize` enqueued elements and which never blocks on enqueue. */
+    def circularBuffer[F[_], A](maxSize: Int)(
+        implicit F: Concurrent[F]): G[InspectableQueue[F, A]] =
+      forStrategy(Queue.Strategy.circularBuffer[A](maxSize))(_.headOption)(_.size)
 
-        def offer1(a: A): F[Boolean] = pubSub.tryPublish(a)
+    private[fs2] def forStrategy[F[_]: Concurrent, S, A](
+        strategy: PubSub.Strategy[A, Chunk[A], S, Int]
+    )(
+        headOf: S => Option[A]
+    )(
+        sizeOf: S => Int
+    ): G[InspectableQueue[F, A]] = {
+      implicit val SyncG: Sync[G] = G
+      implicit def eqInstance: Eq[S] = Eq.fromUniversalEquals[S]
+      PubSub.in[G].from(PubSub.Strategy.Inspectable.strategy(strategy)).map { pubSub =>
+        new InspectableQueue[F, A] {
+          def enqueue1(a: A): F[Unit] = pubSub.publish(a)
 
-        def dequeue1: F[A] = pubSub.get(Right(1)).flatMap {
-          case Left(s) =>
-            Sync[F].raiseError(new Throwable(
-              s"Inspectable `dequeue1` requires chunk of size 1 with `A` got Left($s)"))
-          case Right(chunk) =>
-            Queue.headUnsafe[F, A](chunk)
+          def offer1(a: A): F[Boolean] = pubSub.tryPublish(a)
 
-        }
+          def dequeue1: F[A] = pubSub.get(Right(1)).flatMap {
+            case Left(s) =>
+              Sync[F].raiseError(new Throwable(
+                s"Inspectable `dequeue1` requires chunk of size 1 with `A` got Left($s)"))
+            case Right(chunk) =>
+              Queue.headUnsafe[F, A](chunk)
 
-        def tryDequeue1: F[Option[A]] = pubSub.tryGet(Right(1)).flatMap {
-          case None => Applicative[F].pure(None)
-          case Some(Left(s)) =>
-            Sync[F].raiseError(new Throwable(
-              s"Inspectable `dequeue1` requires chunk of size 1 with `A` got Left($s)"))
-          case Some(Right(chunk)) =>
-            Queue.headUnsafe[F, A](chunk).map(Some(_))
-        }
-
-        def dequeueChunk1(maxSize: Int): F[Chunk[A]] =
-          pubSub.get(Right(maxSize)).map(_.toOption.getOrElse(Chunk.empty))
-
-        def tryDequeueChunk1(maxSize: Int): F[Option[Chunk[A]]] =
-          pubSub.tryGet(Right(maxSize)).map(_.map(_.toOption.getOrElse(Chunk.empty)))
-
-        def dequeueChunk(maxSize: Int): Stream[F, A] =
-          pubSub.getStream(Right(maxSize)).flatMap {
-            case Left(_)      => Stream.empty
-            case Right(chunk) => Stream.chunk(chunk)
           }
 
-        def dequeueBatch: Pipe[F, Int, A] =
-          _.flatMap { sz =>
-            Stream
-              .evalUnChunk(
-                pubSub.get(Right(sz)).map {
-                  _.toOption.getOrElse(Chunk.empty)
-                }
-              )
+          def tryDequeue1: F[Option[A]] = pubSub.tryGet(Right(1)).flatMap {
+            case None => Applicative[F].pure(None)
+            case Some(Left(s)) =>
+              Sync[F].raiseError(new Throwable(
+                s"Inspectable `dequeue1` requires chunk of size 1 with `A` got Left($s)"))
+            case Some(Right(chunk)) =>
+              Queue.headUnsafe[F, A](chunk).map(Some(_))
           }
 
-        def peek1: F[A] =
-          Sync[F].bracket(Sync[F].delay(new Token))({ token =>
-            def take: F[A] =
-              pubSub.get(Left(Some(token))).flatMap {
-                case Left(s) =>
-                  headOf(s) match {
-                    case None    => take
-                    case Some(a) => Applicative[F].pure(a)
-                  }
+          def dequeueChunk1(maxSize: Int): F[Chunk[A]] =
+            pubSub.get(Right(maxSize)).map(_.toOption.getOrElse(Chunk.empty))
 
-                case Right(chunk) =>
-                  Sync[F].raiseError(new Throwable(
-                    s"Inspectable `peek1` requires state to be returned, got: $chunk"))
-              }
+          def tryDequeueChunk1(maxSize: Int): F[Option[Chunk[A]]] =
+            pubSub.tryGet(Right(maxSize)).map(_.map(_.toOption.getOrElse(Chunk.empty)))
 
-            take
-          })(token => pubSub.unsubscribe(Left(Some(token))))
-
-        def size: Stream[F, Int] =
-          Stream
-            .bracket(Sync[F].delay(new Token))(token => pubSub.unsubscribe(Left(Some(token))))
-            .flatMap { token =>
-              pubSub.getStream(Left(Some(token))).flatMap {
-                case Left(s)  => Stream.emit(sizeOf(s))
-                case Right(_) => Stream.empty // impossible
-              }
+          def dequeueChunk(maxSize: Int): Stream[F, A] =
+            pubSub.getStream(Right(maxSize)).flatMap {
+              case Left(_)      => Stream.empty
+              case Right(chunk) => Stream.chunk(chunk)
             }
 
-        def getSize: F[Int] =
-          pubSub.get(Left(None)).map {
-            case Left(s)  => sizeOf(s)
-            case Right(_) => -1
-          }
+          def dequeueBatch: Pipe[F, Int, A] =
+            _.flatMap { sz =>
+              Stream
+                .evalUnChunk(
+                  pubSub.get(Right(sz)).map {
+                    _.toOption.getOrElse(Chunk.empty)
+                  }
+                )
+            }
+
+          def peek1: F[A] =
+            Sync[F].bracket(Sync[F].delay(new Token))({ token =>
+              def take: F[A] =
+                pubSub.get(Left(Some(token))).flatMap {
+                  case Left(s) =>
+                    headOf(s) match {
+                      case None    => take
+                      case Some(a) => Applicative[F].pure(a)
+                    }
+
+                  case Right(chunk) =>
+                    Sync[F].raiseError(new Throwable(
+                      s"Inspectable `peek1` requires state to be returned, got: $chunk"))
+                }
+
+              take
+            })(token => pubSub.unsubscribe(Left(Some(token))))
+
+          def size: Stream[F, Int] =
+            Stream
+              .bracket(Sync[F].delay(new Token))(token => pubSub.unsubscribe(Left(Some(token))))
+              .flatMap { token =>
+                pubSub.getStream(Left(Some(token))).flatMap {
+                  case Left(s)  => Stream.emit(sizeOf(s))
+                  case Right(_) => Stream.empty // impossible
+                }
+              }
+
+          def getSize: F[Int] =
+            pubSub.get(Left(None)).map {
+              case Left(s)  => sizeOf(s)
+              case Right(_) => -1
+            }
+        }
       }
     }
   }
+
+  /**
+    * Provides constructors for InspectableQueue with state initialized using
+    * another `Sync` datatype.
+    *
+    * This method uses the [[http://typelevel.org/cats/guidelines.html#partially-applied-type-params Partially Applied Type Params technique]]
+    *
+    * {{{
+    *   val queue = InspectableQueue.in[SyncIO].unbounded[IO, String]
+    * }}}
+    */
+  def in[G[_]](implicit G: Sync[G]) = new InPartiallyApplied(G)
+
+  /** Creates a queue with no size bound. */
+  def unbounded[F[_], A](implicit F: Concurrent[F]): F[InspectableQueue[F, A]] =
+    in[F].unbounded
+
+  /** Creates a queue with the specified size bound. */
+  def bounded[F[_], A](maxSize: Int)(implicit F: Concurrent[F]): F[InspectableQueue[F, A]] =
+    in[F].bounded(maxSize)
+
+  /** Creates a queue which stores the last `maxSize` enqueued elements and which never blocks on enqueue. */
+  def circularBuffer[F[_], A](maxSize: Int)(implicit F: Concurrent[F]): F[InspectableQueue[F, A]] =
+    in[F].circularBuffer(maxSize)
 }

--- a/core/shared/src/main/scala/fs2/concurrent/Topic.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Topic.scala
@@ -84,12 +84,25 @@ abstract class Topic[F[_], A] { self =>
 
 object Topic {
 
-  def apply[F[_], A](initial: A)(implicit F: Concurrent[F]): F[Topic[F, A]] = {
+  /**
+    * Constructs a `Topic` for a provided `Concurrent` datatype. The
+    * `initial` value is immediately published.
+    */
+  def apply[F[_], A](initial: A)(implicit F: Concurrent[F]): F[Topic[F, A]] =
+    in[F, F, A](initial)
+
+  /**
+    * Constructs a `Topic` for a provided `Concurrent` datatype.
+    * Like [[apply]], but a `Topic` state is initialized using another effect constructor
+    */
+  def in[G[_], F[_], A](initial: A)(implicit F: Concurrent[F], G: Sync[G]): G[Topic[F, A]] = {
     implicit def eqInstance: Eq[Strategy.State[A]] =
       Eq.instance[Strategy.State[A]](_.subscribers.keySet == _.subscribers.keySet)
 
-    PubSub(PubSub.Strategy.Inspectable.strategy(Strategy.boundedSubscribers(initial))).map {
-      pubSub =>
+    PubSub
+      .in[G]
+      .from(PubSub.Strategy.Inspectable.strategy(Strategy.boundedSubscribers(initial)))
+      .map { pubSub =>
         new Topic[F, A] {
 
           def subscriber(size: Int): Stream[F, ((Token, Int), Stream[F, ScalaQueue[A]])] =
@@ -145,7 +158,7 @@ object Topic {
                 }
               }
         }
-    }
+      }
   }
 
   private[fs2] object Strategy {
@@ -160,12 +173,13 @@ object Topic {
       * If that subscription is exceeded any other `publish` to the topic will hold,
       * until such subscriber disappears, or consumes more elements.
       *
-      * @param initial  Initial value of the topic.
+      * @param initial Initial value of the topic.
       */
     def boundedSubscribers[F[_], A](
         start: A): PubSub.Strategy[A, ScalaQueue[A], State[A], (Token, Int)] =
       new PubSub.Strategy[A, ScalaQueue[A], State[A], (Token, Int)] {
         def initial: State[A] = State(start, Map.empty)
+
         def accepts(i: A, state: State[A]): Boolean =
           state.subscribers.forall { case ((_, max), q) => q.size < max }
 

--- a/experimental/src/main/scala/fs2/experimental/concurrent/Queue.scala
+++ b/experimental/src/main/scala/fs2/experimental/concurrent/Queue.scala
@@ -10,12 +10,12 @@ object Queue {
   def forStrategy[F[_]: Concurrent, S, A](
       strategy: PubSub.Strategy[A, Chunk[A], S, Int]
   ): F[fs2.concurrent.Queue[F, A]] =
-    fs2.concurrent.Queue.forStrategy(strategy)
+    fs2.concurrent.Queue.in[F].forStrategy(strategy)
 
   private[fs2] def forStrategyNoneTerminated[F[_]: Concurrent, S, A](
       strategy: PubSub.Strategy[Option[A], Option[Chunk[A]], S, Int])
     : F[fs2.concurrent.NoneTerminatedQueue[F, A]] =
-    fs2.concurrent.Queue.forStrategyNoneTerminated(strategy)
+    fs2.concurrent.Queue.in[F].forStrategyNoneTerminated(strategy)
 
   object Strategy {
 


### PR DESCRIPTION
Adds constructors similar to those we now have in cats-effect, for SignallingRef, Queue and Topic, as proposed by @mpilquist @ [gitter](https://gitter.im/functional-streams-for-scala/fs2?at=5cb1f90fbd70a40d5f436249).