### PR TITLE
Add fs2-google-pubsub as a related project

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ If you have a project you'd like to include in this list, either open a PR or le
 * [fs2-cron](https://github.com/fthomas/fs2-cron): FS2 streams based on cron expressions.
 * [fs2-crypto](https://github.com/Spinoco/fs2-crypto): TLS support for fs2.
 * [fs2-elastic](https://github.com/amarrella/fs2-elastic): Simple client for Elasticsearch.
+* [fs2-google-pubsub](https://github.com/permutive/fs2-google-pubsub): A [Google Cloud Pub/Sub](https://cloud.google.com/pubsub/) implementation using fs2 and cats-effect.
 * [fs2-grpc](https://github.com/fiadliel/fs2-grpc): gRPC implementation for FS2 / Cats Effect.
 * [fs2-http](https://github.com/Spinoco/fs2-http): Http server and client library implemented in fs2.
 * [fs2-jms](https://github.com/kiambogo/fs2-jms): JMS connectors for FS2 streams


### PR DESCRIPTION
Obviously up to you guys to decide whether this should be added or not. I guess as a word of warning, the API isn't very stable, but otherwise we have been using that library in production for around 6 months now.