### PR TITLE
kind-projector has moved to typelevel org

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ lazy val commonSettings = Seq(
   scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value,
   javaOptions in (Test, run) ++= Seq("-Xms64m", "-Xmx64m"),
   libraryDependencies ++= Seq(
-    compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.9"),
+    compilerPlugin("org.typelevel" %% "kind-projector" % "0.10.0"),
     "org.typelevel" %%% "cats-core" % "1.6.0",
     "org.typelevel" %%% "cats-laws" % "1.6.0" % "test",
     "org.typelevel" %%% "cats-effect" % "1.2.0",


### PR DESCRIPTION
it would be helpful to have this merged for the Scala community
build. normally we're able to override this kind of thing in our
own config but it's not working in this case for some reason