### PR TITLE
Update dependencies for 2.13.0-RC1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 
 scala:
   - 2.11.12
-  - 2.13.0-M5
+  - 2.13.0-RC1
   - 2.12.7
 
 jdk:
@@ -28,7 +28,7 @@ script:
   - sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 -Dfs2.test.verbose testJVM
   - sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 -Dfs2.test.verbose testJS
   - sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 doc mimaReportBinaryIssues
-  - (test $TRAVIS_SCALA_VERSION == "2.11.12" && sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 -J-Xms2g -J-Xmx2g docs/tut) || test $TRAVIS_SCALA_VERSION == "2.12.7" || test $TRAVIS_SCALA_VERSION == "2.13.0-M5"
+  - (test $TRAVIS_SCALA_VERSION == "2.11.12" && sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 -J-Xms2g -J-Xmx2g docs/tut) || test $TRAVIS_SCALA_VERSION == "2.12.7" || test $TRAVIS_SCALA_VERSION == "2.13.0-RC1"
 
 after_success:
   - test $PUBLISH == "true" && test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "series/1.0" && GPG_WARN_ON_FAILURE=true sbt +publish

--- a/build.sbt
+++ b/build.sbt
@@ -49,12 +49,12 @@ lazy val commonSettings = Seq(
   javaOptions in (Test, run) ++= Seq("-Xms64m", "-Xmx64m"),
   libraryDependencies ++= Seq(
     compilerPlugin("org.typelevel" %% "kind-projector" % "0.10.0"),
-    "org.typelevel" %%% "cats-core" % "1.6.0",
-    "org.typelevel" %%% "cats-laws" % "1.6.0" % "test",
-    "org.typelevel" %%% "cats-effect" % "1.3.0",
-    "org.typelevel" %%% "cats-effect-laws" % "1.3.0" % "test",
-    "org.scala-lang.modules" %%% "scala-collection-compat" % "0.3.0",
-    "org.scalatest" %%% "scalatest" % "3.0.6" % "test"
+    "org.typelevel" %%% "cats-core" % "2.0.0-M1",
+    "org.typelevel" %%% "cats-laws" % "2.0.0-M1" % "test",
+    "org.typelevel" %%% "cats-effect" % "2.0.0-M1",
+    "org.typelevel" %%% "cats-effect-laws" % "2.0.0-M1" % "test",
+    "org.scala-lang.modules" %%% "scala-collection-compat" % "1.0.0",
+    "org.scalatest" %%% "scalatest" % "3.0.8-RC2" % "test"
   ),
   libraryDependencies += {
     CrossVersion.partialVersion(scalaVersion.value) match {
@@ -266,7 +266,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
       }
       baseDirectory.value / "../shared/src/main" / dir
     },
-    libraryDependencies += "org.scodec" %%% "scodec-bits" % "1.1.9"
+    libraryDependencies += "org.scodec" %%% "scodec-bits" % "1.1.10"
   )
   .jsSettings(commonJsSettings: _*)
 


### PR DESCRIPTION
Apparently, there are some new ambiguities in scalacheck under 2.11:

```
[error] /home/travis/build/functional-streams-for-scala/fs2/core/shared/src/test/scala/fs2/ChunkGen.scala:233:10: ambiguous reference to overloaded definition,
[error] both method apply in object Cogen of type (f: (org.scalacheck.rng.Seed, List[A]) => org.scalacheck.rng.Seed)org.scalacheck.Cogen[List[A]]
[error] and  method apply in object Cogen of type (implicit ev: org.scalacheck.Cogen[List[A]])org.scalacheck.Cogen[List[A]]
[error] match expected type ?
[error]     Cogen[List[A]].contramap(_.toList)
[error]          ^
[error] /home/travis/build/functional-streams-for-scala/fs2/core/shared/src/test/scala/fs2/FreeCSpec.scala:36:88: ambiguous reference to overloaded definition,
[error] both method apply in object Cogen of type (f: (org.scalacheck.rng.Seed, Unit) => org.scalacheck.rng.Seed)org.scalacheck.Cogen[Unit]
[error] and  method apply in object Cogen of type (implicit ev: org.scalacheck.Cogen[Unit])org.scalacheck.Cogen[Unit]
[error] match expected type ?
[error]       f <- arbFunction1[Result[A], FreeC[F, A]](Arbitrary(freeGen[F, A](fDepth)), Cogen[Unit].contramap(_ => ())).arbitrary
[error]                                                                                        ^
[error] /home/travis/build/functional-streams-for-scala/fs2/core/shared/src/test/scala/fs2/TestUtil.scala:100:73: ambiguous reference to overloaded definition,
[error] both method apply in object Cogen of type (f: (org.scalacheck.rng.Seed, List[A]) => org.scalacheck.rng.Seed)org.scalacheck.Cogen[List[A]]
[error] and  method apply in object Cogen of type (implicit ev: org.scalacheck.Cogen[List[A]])org.scalacheck.Cogen[List[A]]
[error] match expected type ?
[error]     implicit def pureStreamCoGen[A: Cogen]: Cogen[PureStream[A]] = Cogen[List[A]].contramap[PureStream[A]](_.get.toList)
[error]                                                                         ^
[error] three errors found
```