### PR TITLE
Remove scala-collection-compat dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,6 @@ lazy val commonSettings = Seq(
     "org.typelevel" %%% "cats-laws" % "1.6.0" % "test",
     "org.typelevel" %%% "cats-effect" % "1.3.0",
     "org.typelevel" %%% "cats-effect-laws" % "1.3.0" % "test",
-    "org.scala-lang.modules" %%% "scala-collection-compat" % "0.3.0",
     "org.scalatest" %%% "scalatest" % "3.0.6" % "test"
   ),
   libraryDependencies += {

--- a/core/shared/src/main/scala-2.12-/fs2/internal/package.scala
+++ b/core/shared/src/main/scala-2.12-/fs2/internal/package.scala
@@ -1,0 +1,12 @@
+package fs2
+
+import scala.collection.generic.CanBuildFrom
+import scala.collection.mutable.Builder
+
+package object internal {
+  private[fs2] type Factory[-A, +C] = CanBuildFrom[Nothing, A, C]
+
+  private[fs2] implicit class FactoryOps[-A, +C](private val factory: Factory[A, C]) {
+    def newBuilder: Builder[A, C] = factory()
+  }
+}

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -12,7 +12,6 @@ import fs2.internal.FreeC.Result
 import fs2.internal.{Resource => _, _}
 import java.io.PrintStream
 
-import scala.collection.compat._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 


### PR DESCRIPTION
It seems like a shame to have a dependency on scala-collection-compat (which is currently broken and waiting for an incompatible 2.0 release) when all that fs2 needs from it is one alias and one extension method.

This change shouldn't affect compatibility for any Scala version and would unblock #1453.

r? @mpilquist 