### PR TITLE
Replace deprecated ⇒

### DIFF
--- a/core/jvm/src/test/scala/fs2/PipeSpec.scala
+++ b/core/jvm/src/test/scala/fs2/PipeSpec.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 import org.scalacheck.Gen
 import cats.effect.IO
-import cats.implicits.{catsSyntaxEither ⇒ _, _}
+import cats.implicits.{catsSyntaxEither => _, _}
 
 import scala.concurrent.duration._
 import TestUtil._

--- a/core/jvm/src/test/scala/fs2/StreamSpec.scala
+++ b/core/jvm/src/test/scala/fs2/StreamSpec.scala
@@ -63,8 +63,8 @@ class StreamSpec extends Fs2Spec with Inside {
       val stream: Stream[IO, Int] = Stream.fromEither[IO](either)
 
       either match {
-        case Left(_) ⇒ stream.compile.toList.attempt.unsafeRunSync() shouldBe either
-        case Right(_) ⇒ stream.compile.toList.unsafeRunSync() shouldBe either.toList
+        case Left(_) => stream.compile.toList.attempt.unsafeRunSync() shouldBe either
+        case Right(_) => stream.compile.toList.unsafeRunSync() shouldBe either.toList
       }
     }
 

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -272,9 +272,9 @@ private[fs2] trait PullLowPriority {
   implicit def monadInstance[F[_], O]: Monad[Pull[F, O, ?]] =
     new Monad[Pull[F, O, ?]] {
       override def pure[A](a: A): Pull[F, O, A] = Pull.pure(a)
-      override def flatMap[A, B](p: Pull[F, O, A])(f: A ⇒ Pull[F, O, B]): Pull[F, O, B] =
+      override def flatMap[A, B](p: Pull[F, O, A])(f: A => Pull[F, O, B]): Pull[F, O, B] =
         p.flatMap(f)
-      override def tailRecM[A, B](a: A)(f: A ⇒ Pull[F, O, Either[A, B]]): Pull[F, O, B] =
+      override def tailRecM[A, B](a: A)(f: A => Pull[F, O, Either[A, B]]): Pull[F, O, B] =
         f(a).flatMap {
           case Left(a)  => tailRecM(a)(f)
           case Right(b) => Pull.pure(b)

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -4362,10 +4362,10 @@ private[fs2] trait StreamLowPriority {
     new Monad[Stream[F, ?]] {
       override def pure[A](x: A): Stream[F, A] = Stream(x)
 
-      override def flatMap[A, B](fa: Stream[F, A])(f: A ⇒ Stream[F, B]): Stream[F, B] =
+      override def flatMap[A, B](fa: Stream[F, A])(f: A => Stream[F, B]): Stream[F, B] =
         fa.flatMap(f)
 
-      override def tailRecM[A, B](a: A)(f: A ⇒ Stream[F, Either[A, B]]): Stream[F, B] =
+      override def tailRecM[A, B](a: A)(f: A => Stream[F, Either[A, B]]): Stream[F, B] =
         f(a).flatMap {
           case Left(a)  => tailRecM(a)(f)
           case Right(b) => Stream(b)

--- a/core/shared/src/test/scala/fs2/PullSpec.scala
+++ b/core/shared/src/test/scala/fs2/PullSpec.scala
@@ -40,8 +40,8 @@ class PullSpec extends Fs2Spec {
       val pull: Pull[IO, Int, Unit] = Pull.fromEither[IO](either)
 
       either match {
-        case Left(_) ⇒ pull.stream.compile.toList.attempt.unsafeRunSync() shouldBe either
-        case Right(_) ⇒
+        case Left(_) => pull.stream.compile.toList.attempt.unsafeRunSync() shouldBe either
+        case Right(_) =>
           pull.stream.compile.toList.unsafeRunSync() shouldBe either.toList
       }
     }


### PR DESCRIPTION
The unicode arrow `⇒` is deprecated in 2.13, and it's used very inconsistently here anyway, so it seems reasonable just to standardize on `=>`.