### PR TITLE
Updates for 2.13.0-RC1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 
 scala:
   - 2.11.12
-  - 2.13.0-M5
+  - 2.13.0-RC1
   - 2.12.7
 
 jdk:
@@ -28,7 +28,7 @@ script:
   - sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 -Dfs2.test.verbose testJVM
   - sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 -Dfs2.test.verbose testJS
   - sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 doc mimaReportBinaryIssues
-  - (test $TRAVIS_SCALA_VERSION == "2.11.12" && sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 -J-Xms2g -J-Xmx2g docs/tut) || test $TRAVIS_SCALA_VERSION == "2.12.7" || test $TRAVIS_SCALA_VERSION == "2.13.0-M5"
+  - (test $TRAVIS_SCALA_VERSION == "2.11.12" && sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 -J-Xms2g -J-Xmx2g docs/tut) || test $TRAVIS_SCALA_VERSION == "2.12.7" || test $TRAVIS_SCALA_VERSION == "2.13.0-RC1"
 
 after_success:
   - test $PUBLISH == "true" && test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "series/1.0" && GPG_WARN_ON_FAILURE=true sbt +publish

--- a/build.sbt
+++ b/build.sbt
@@ -48,12 +48,12 @@ lazy val commonSettings = Seq(
   scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value,
   javaOptions in (Test, run) ++= Seq("-Xms64m", "-Xmx64m"),
   libraryDependencies ++= Seq(
-    compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.9"),
-    "org.typelevel" %%% "cats-core" % "1.6.0",
-    "org.typelevel" %%% "cats-laws" % "1.6.0" % "test",
-    "org.typelevel" %%% "cats-effect" % "1.3.0",
-    "org.typelevel" %%% "cats-effect-laws" % "1.3.0" % "test",
-    "org.scalatest" %%% "scalatest" % "3.0.6" % "test"
+    compilerPlugin("org.typelevel" %% "kind-projector" % "0.10.0"),
+    "org.typelevel" %%% "cats-core" % "2.0.0-M1",
+    "org.typelevel" %%% "cats-laws" % "2.0.0-M1" % "test",
+    "org.typelevel" %%% "cats-effect" % "2.0.0-M1",
+    "org.typelevel" %%% "cats-effect-laws" % "2.0.0-M1" % "test",
+    "org.scalatest" %%% "scalatest" % "3.0.8-RC2" % "test"
   ),
   libraryDependencies += {
     CrossVersion.partialVersion(scalaVersion.value) match {
@@ -265,7 +265,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
       }
       baseDirectory.value / "../shared/src/main" / dir
     },
-    libraryDependencies += "org.scodec" %%% "scodec-bits" % "1.1.9"
+    libraryDependencies += "org.scodec" %%% "scodec-bits" % "1.1.10"
   )
   .jsSettings(commonJsSettings: _*)
 

--- a/core/shared/src/test/scala/fs2/ChunkGen.scala
+++ b/core/shared/src/test/scala/fs2/ChunkGen.scala
@@ -230,7 +230,7 @@ trait ChunkGen extends ChunkGenLowPriority {
     Arbitrary(genCharChunk)
 
   implicit def cogenChunk[A: Cogen]: Cogen[Chunk[A]] =
-    Cogen[List[A]].contramap(_.toList)
+    implicitly[Cogen[List[A]]].contramap(_.toList)
 
   implicit def shrinkChunk[A]: Shrink[Chunk[A]] =
     Shrink[Chunk[A]](c => removeChunks(c.size, c))

--- a/core/shared/src/test/scala/fs2/FreeCSpec.scala
+++ b/core/shared/src/test/scala/fs2/FreeCSpec.scala
@@ -33,7 +33,7 @@ class FreeCSpec extends Fs2Spec {
     def withBinds = for {
       fDepth <- nextDepth
       freeDepth <- nextDepth
-      f <- arbFunction1[Result[A], FreeC[F, A]](Arbitrary(freeGen[F, A](fDepth)), Cogen[Unit].contramap(_ => ())).arbitrary
+      f <- arbFunction1[Result[A], FreeC[F, A]](Arbitrary(freeGen[F, A](fDepth)), implicitly[Cogen[Unit]].contramap(_ => ())).arbitrary
       freeFA <- freeGen[F, A](freeDepth)
     } yield freeFA.transformWith(f)
 

--- a/core/shared/src/test/scala/fs2/TestUtil.scala
+++ b/core/shared/src/test/scala/fs2/TestUtil.scala
@@ -97,7 +97,7 @@ object TestUtil extends TestUtilPlatform with ChunkGen {
         unchunked[A], randomlyChunked[A], uniformlyChunked[A],
         filtered[A])
 
-    implicit def pureStreamCoGen[A: Cogen]: Cogen[PureStream[A]] = Cogen[List[A]].contramap[PureStream[A]](_.get.toList)
+    implicit def pureStreamCoGen[A: Cogen]: Cogen[PureStream[A]] = implicitly[Cogen[List[A]]].contramap[PureStream[A]](_.get.toList)
 
     implicit def pureStreamShrink[A]: Shrink[PureStream[A]] = Shrink { s => Shrink.shrink(s.get.toList).map(as => PureStream(s"shrunk: ${as.size} from ${s.tag}", Stream.chunk(Chunk.seq(as)))) }
   }


### PR DESCRIPTION
Includes @kubukoz's commit from #1453 but rebased after my #1454, #1455, #1456, and one additional fix for an interaction between ScalaCheck 1.14's `Cogen.apply` and the backported SAM support in 2.11.