### PR TITLE
Fix recursive aux functions differences

### DIFF
--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -1,5 +1,6 @@
 package fs2
 
+import scala.annotation.tailrec
 import scala.collection.immutable.{Queue => SQueue}
 import scala.collection.{IndexedSeq => GIndexedSeq, Seq => GSeq}
 import scala.reflect.ClassTag
@@ -1538,7 +1539,7 @@ object Chunk {
         // Based on the implementation of tailRecM for Vector from cats, licensed under MIT
         val buf = collection.mutable.Buffer.newBuilder[B]
         var state = List(f(a).iterator)
-        @annotation.tailrec
+        @tailrec
         def go(): Unit = state match {
           case Nil => ()
           case h :: tail if h.isEmpty =>
@@ -1582,6 +1583,7 @@ object Chunk {
       if (n <= 0) Queue.empty
       else if (n >= size) this
       else {
+        @tailrec
         def go(acc: SQueue[Chunk[A]], rem: SQueue[Chunk[A]], toTake: Int): Queue[A] =
           if (toTake <= 0) new Queue(acc, n)
           else {
@@ -1602,6 +1604,7 @@ object Chunk {
       if (n <= 0) this
       else if (n >= size) Queue.empty
       else {
+        @tailrec
         def go(rem: SQueue[Chunk[A]], toDrop: Int): Queue[A] =
           if (toDrop <= 0) new Queue(rem, size - n)
           else {

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -1518,10 +1518,10 @@ object Chunk {
     new Traverse[Chunk] with Monad[Chunk] with FunctorFilter[Chunk] {
       def foldLeft[A, B](fa: Chunk[A], b: B)(f: (B, A) => B): B = fa.foldLeft(b)(f)
       def foldRight[A, B](fa: Chunk[A], b: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] = {
-        def loop(i: Int): Eval[B] =
-          if (i < fa.size) f(fa(i), Eval.defer(loop(i + 1)))
+        def go(i: Int): Eval[B] =
+          if (i < fa.size) f(fa(i), Eval.defer(go(i + 1)))
           else b
-        loop(0)
+        go(0)
       }
       override def toList[A](fa: Chunk[A]): List[A] = fa.toList
       override def isEmpty[A](fa: Chunk[A]): Boolean = fa.isEmpty
@@ -1539,22 +1539,22 @@ object Chunk {
         val buf = collection.mutable.Buffer.newBuilder[B]
         var state = List(f(a).iterator)
         @annotation.tailrec
-        def loop(): Unit = state match {
+        def go(): Unit = state match {
           case Nil => ()
           case h :: tail if h.isEmpty =>
             state = tail
-            loop()
+            go()
           case h :: tail =>
             h.next match {
               case Right(b) =>
                 buf += b
-                loop()
+                go()
               case Left(a) =>
                 state = (f(a).iterator) :: h :: tail
-                loop()
+                go()
             }
         }
-        loop()
+        go()
         Chunk.buffer(buf.result)
       }
       override def functor: Functor[Chunk] = this
@@ -1582,16 +1582,16 @@ object Chunk {
       if (n <= 0) Queue.empty
       else if (n >= size) this
       else {
-        def loop(acc: SQueue[Chunk[A]], rem: SQueue[Chunk[A]], toTake: Int): Queue[A] =
+        def go(acc: SQueue[Chunk[A]], rem: SQueue[Chunk[A]], toTake: Int): Queue[A] =
           if (toTake <= 0) new Queue(acc, n)
           else {
             val (next, tail) = rem.dequeue
             val nextSize = next.size
-            if (nextSize < toTake) loop(acc :+ next, tail, toTake - nextSize)
+            if (nextSize < toTake) go(acc :+ next, tail, toTake - nextSize)
             else if (nextSize == toTake) new Queue(acc :+ next, n)
             else new Queue(acc :+ next.take(toTake), n)
           }
-        loop(SQueue.empty, chunks, n)
+        go(SQueue.empty, chunks, n)
       }
 
     /** Takes the right-most `n` elements of this chunk queue in a way that preserves chunk structure. */
@@ -1602,16 +1602,16 @@ object Chunk {
       if (n <= 0) this
       else if (n >= size) Queue.empty
       else {
-        def loop(rem: SQueue[Chunk[A]], toDrop: Int): Queue[A] =
+        def go(rem: SQueue[Chunk[A]], toDrop: Int): Queue[A] =
           if (toDrop <= 0) new Queue(rem, size - n)
           else {
             val next = rem.head
             val nextSize = next.size
-            if (nextSize < toDrop) loop(rem.tail, toDrop - nextSize)
+            if (nextSize < toDrop) go(rem.tail, toDrop - nextSize)
             else if (nextSize == toDrop) new Queue(rem.tail, size - n)
             else new Queue(next.drop(toDrop) +: rem.tail, size - n)
           }
-        loop(chunks, n)
+        go(chunks, n)
       }
 
     /** Drops the right-most `n` elements of this chunk queue in a way that preserves chunk structure. */

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3108,14 +3108,14 @@ object Stream extends StreamLowPriority {
     */
   def fixedRate[F[_]](d: FiniteDuration)(implicit timer: Timer[F]): Stream[F, Unit] = {
     def now: Stream[F, Long] = Stream.eval(timer.clock.monotonic(NANOSECONDS))
-    def loop(started: Long): Stream[F, Unit] =
+    def go(started: Long): Stream[F, Unit] =
       now.flatMap { finished =>
         val elapsed = finished - started
         Stream.sleep_(d - elapsed.nanos) ++ now.flatMap { started =>
-          Stream.emit(()) ++ loop(started)
+          Stream.emit(()) ++ go(started)
         }
       }
-    now.flatMap(loop)
+    now.flatMap(go)
   }
 
   final class PartiallyAppliedFromEither[F[_]] {
@@ -3218,8 +3218,8 @@ object Stream extends StreamLowPriority {
     */
   def random[F[_]](implicit F: Sync[F]): Stream[F, Int] =
     Stream.eval(F.delay(new scala.util.Random())).flatMap { r =>
-      def loop: Stream[F, Int] = Stream.emit(r.nextInt) ++ loop
-      loop
+      def go: Stream[F, Int] = Stream.emit(r.nextInt) ++ go
+      go
     }
 
   /**
@@ -3229,8 +3229,8 @@ object Stream extends StreamLowPriority {
     */
   def randomSeeded[F[x] >: Pure[x]](seed: Long): Stream[F, Int] = Stream.suspend {
     val r = new scala.util.Random(seed)
-    def loop: Stream[F, Int] = Stream.emit(r.nextInt) ++ loop
-    loop
+    def go: Stream[F, Int] = Stream.emit(r.nextInt) ++ go
+    go
   }
 
   /**
@@ -3375,12 +3375,12 @@ object Stream extends StreamLowPriority {
     * }}}
     */
   def unfold[F[x] >: Pure[x], S, O](s: S)(f: S => Option[(O, S)]): Stream[F, O] = {
-    def loop(s: S): Stream[F, O] =
+    def go(s: S): Stream[F, O] =
       f(s) match {
-        case Some((o, s)) => emit(o) ++ loop(s)
+        case Some((o, s)) => emit(o) ++ go(s)
         case None         => empty
       }
-    suspend(loop(s))
+    suspend(go(s))
   }
 
   /**
@@ -3396,22 +3396,22 @@ object Stream extends StreamLowPriority {
 
   /** Like [[unfold]], but takes an effectful function. */
   def unfoldEval[F[_], S, O](s: S)(f: S => F[Option[(O, S)]]): Stream[F, O] = {
-    def loop(s: S): Stream[F, O] =
+    def go(s: S): Stream[F, O] =
       eval(f(s)).flatMap {
-        case Some((o, s)) => emit(o) ++ loop(s)
+        case Some((o, s)) => emit(o) ++ go(s)
         case None         => empty
       }
-    suspend(loop(s))
+    suspend(go(s))
   }
 
   /** Like [[unfoldChunk]], but takes an effectful function. */
   def unfoldChunkEval[F[_], S, O](s: S)(f: S => F[Option[(Chunk[O], S)]]): Stream[F, O] = {
-    def loop(s: S): Stream[F, O] =
+    def go(s: S): Stream[F, O] =
       eval(f(s)).flatMap {
-        case Some((c, s)) => chunk(c) ++ loop(s)
+        case Some((c, s)) => chunk(c) ++ go(s)
         case None         => empty
       }
-    suspend(loop(s))
+    suspend(go(s))
   }
 
   /** Provides syntax for streams that are invariant in `F` and `O`. */

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -12,6 +12,7 @@ import fs2.internal.FreeC.Result
 import fs2.internal.{Resource => _, _}
 import java.io.PrintStream
 
+import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
@@ -1215,7 +1216,7 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
           l >> Pull.done
       }
 
-    @annotation.tailrec
+    @tailrec
     def doChunk(chunk: Chunk[O],
                 s: Stream[F, O],
                 k1: O2,

--- a/core/shared/src/main/scala/fs2/internal/CompileScope.scala
+++ b/core/shared/src/main/scala/fs2/internal/CompileScope.scala
@@ -295,6 +295,7 @@ private[fs2] final class CompileScope[F[_]] private (
     *
     */
   def findStepScope(scopeId: Token): F[Option[CompileScope[F]]] = {
+    @tailrec
     def go(scope: CompileScope[F]): CompileScope[F] =
       scope.parent match {
         case None         => scope

--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -2,6 +2,8 @@ package fs2
 
 import java.nio.charset.Charset
 
+import scala.annotation.tailrec
+
 /** Provides utilities for working with streams of text (e.g., encoding byte streams to strings). */
 object text {
   private val utf8Charset = Charset.forName("UTF-8")
@@ -121,11 +123,11 @@ object text {
     def extractLines(buffer: Vector[String],
                      chunk: Chunk[String],
                      pendingLineFeed: Boolean): (Chunk[String], Vector[String], Boolean) = {
-      @annotation.tailrec
+      @tailrec
       def go(remainingInput: Vector[String],
-               buffer: Vector[String],
-               output: Vector[String],
-               pendingLineFeed: Boolean): (Chunk[String], Vector[String], Boolean) =
+             buffer: Vector[String],
+             output: Vector[String],
+             pendingLineFeed: Boolean): (Chunk[String], Vector[String], Boolean) =
         if (remainingInput.isEmpty) {
           (Chunk.indexedSeq(output), buffer, pendingLineFeed)
         } else {
@@ -142,10 +144,10 @@ object text {
             val pendingLF =
               if (carry.nonEmpty) carry.last == '\r' else pendingLineFeed
             go(remainingInput.tail,
-                 if (out.isEmpty) buffer :+ carry else Vector(carry),
-                 if (out.isEmpty) output
-                 else output ++ ((buffer :+ out.head).mkString +: out.tail),
-                 pendingLF)
+               if (out.isEmpty) buffer :+ carry else Vector(carry),
+               if (out.isEmpty) output
+               else output ++ ((buffer :+ out.head).mkString +: out.tail),
+               pendingLF)
           }
         }
       go(chunk.toVector, buffer, Vector.empty, pendingLineFeed)

--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -122,7 +122,7 @@ object text {
                      chunk: Chunk[String],
                      pendingLineFeed: Boolean): (Chunk[String], Vector[String], Boolean) = {
       @annotation.tailrec
-      def loop(remainingInput: Vector[String],
+      def go(remainingInput: Vector[String],
                buffer: Vector[String],
                output: Vector[String],
                pendingLineFeed: Boolean): (Chunk[String], Vector[String], Boolean) =
@@ -133,22 +133,22 @@ object text {
           if (pendingLineFeed) {
             if (next.headOption == Some('\n')) {
               val out = (buffer.init :+ buffer.last.init).mkString
-              loop(next.tail +: remainingInput.tail, Vector.empty, output :+ out, false)
+              go(next.tail +: remainingInput.tail, Vector.empty, output :+ out, false)
             } else {
-              loop(remainingInput, buffer, output, false)
+              go(remainingInput, buffer, output, false)
             }
           } else {
             val (out, carry) = linesFromString(next)
             val pendingLF =
               if (carry.nonEmpty) carry.last == '\r' else pendingLineFeed
-            loop(remainingInput.tail,
+            go(remainingInput.tail,
                  if (out.isEmpty) buffer :+ carry else Vector(carry),
                  if (out.isEmpty) output
                  else output ++ ((buffer :+ out.head).mkString +: out.tail),
                  pendingLF)
           }
         }
-      loop(chunk.toVector, buffer, Vector.empty, pendingLineFeed)
+      go(chunk.toVector, buffer, Vector.empty, pendingLineFeed)
     }
 
     def go(buffer: Vector[String],

--- a/io/src/test/scala/fs2/io/JavaInputOutputStreamSpec.scala
+++ b/io/src/test/scala/fs2/io/JavaInputOutputStreamSpec.scala
@@ -4,6 +4,8 @@ import cats.effect.IO
 import fs2.{Chunk, EventuallySupport, Fs2Spec, Stream}
 import org.scalacheck.{Arbitrary, Gen}
 
+import scala.annotation.tailrec
+
 class JavaInputOutputStreamSpec extends Fs2Spec with EventuallySupport {
 
   "ToInputStream" - {
@@ -33,7 +35,7 @@ class JavaInputOutputStreamSpec extends Fs2Spec with EventuallySupport {
             // consume in same thread pool. Production application should never do this,
             // instead they have to fork this to dedicated thread pool
             val buff = new Array[Byte](20)
-            @annotation.tailrec
+            @tailrec
             def go(acc: Vector[Byte]): IO[Vector[Byte]] =
               is.read(buff) match {
                 case -1   => IO.pure(acc)


### PR DESCRIPTION
Sometimes it's "loop" and sometimes "go". If there is no semantics in "loop" I think is better to make them uniform.