### PR TITLE
Performance trick: NoException.

### DIFF
--- a/core/shared/src/main/scala/fs2/internal/FreeC.scala
+++ b/core/shared/src/main/scala/fs2/internal/FreeC.scala
@@ -87,7 +87,7 @@ private[fs2] object FreeC {
 
   def raiseError[F[_], A](rsn: Throwable): FreeC[F, A] = Result.Fail(rsn)
 
-  def interrupted[F[_], X, A](interruptContext: X, failure: Option[Throwable]): FreeC[F, A] =
+  def interrupted[F[_], X, A](interruptContext: X, failure: Throwable): FreeC[F, A] =
     Result.Interrupted(interruptContext, failure)
 
   sealed trait Result[+R] { self =>

--- a/core/shared/src/main/scala/fs2/internal/NoExceptionIsGoodException.scala
+++ b/core/shared/src/main/scala/fs2/internal/NoExceptionIsGoodException.scala
@@ -1,0 +1,8 @@
+package fs2.internal
+
+/** This object is a special singleton-instance Throwable that we use as a place-holder,
+  * to indicate that we do not have, in fact, any exception; but without using any
+  * `Left`, `Right`, or `Some` objects
+  *
+  */
+private[fs2] final case object NoExceptionIsAGoodException extends Throwable


### PR DESCRIPTION
There are many places in FS2 Internals where an `Option[Throwable]`, or an `Either[Throwable, Unit]` is used to indicate presence or absence of an error. This has a memory cost: although the first one only has extra allocation when there is an error, the second one always allocates either a
Right or a Left.

It turns out there is a zero-extra-allocations way to represent the absence of exceptions: since `Throwable` is a non-sealed trait, we can represent any special case with another sub-type, namely an object, that extends from `Throwable`. In particular, we can represent that there are no Exceptions, by using a special sub-type of Exception. 