### PR TITLE
FreeC.flatMap: avoid creating objects

### DIFF
--- a/core/shared/src/main/scala/fs2/internal/FreeC.scala
+++ b/core/shared/src/main/scala/fs2/internal/FreeC.scala
@@ -32,8 +32,8 @@ private[fs2] sealed abstract class FreeC[F[_], +R] {
           case Result.Pure(r) =>
             try f(r)
             catch { case NonFatal(e) => FreeC.Result.Fail(e) }
-          case Result.Interrupted(scope, err) => FreeC.Result.Interrupted(scope, err)
-          case Result.Fail(e)                 => FreeC.Result.Fail(e)
+          case r @ Result.Interrupted(scope, err) => r.asInstanceOf[FreeC[F, R2]]
+          case r @ Result.Fail(e)                 => r.asInstanceOf[FreeC[F, R2]]
       }
     )
 


### PR DESCRIPTION
A small performance tweak to FreeC.flatMap: in the `Interrupted` or `Failed` classes, instead of creating a new object, just return the receiver object as an instance of the new target type.

Also, unify the three `Result` cases of `FreeC.translate`.