### PR TITLE
Avoid executing function twice in `mapFilter`

### DIFF
--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -1558,8 +1558,19 @@ object Chunk {
         Chunk.buffer(buf.result)
       }
       override def functor: Functor[Chunk] = this
-      override def mapFilter[A, B](fa: Chunk[A])(f: A => Option[B]): Chunk[B] =
-        fa.collect(Function.unlift(f))
+      override def mapFilter[A, B](fa: Chunk[A])(f: A => Option[B]): Chunk[B] = {
+        val size = fa.size
+        val b = collection.mutable.Buffer.newBuilder[B]
+        b.sizeHint(size)
+        var i = 0
+        while (i < size) {
+          val o = f(fa(i))
+          if (o.isDefined)
+            b += o.get
+          i += 1
+        }
+        Chunk.buffer(b.result)
+      }
     }
 
   /**


### PR DESCRIPTION
Originally reported by @Taig  

```scala
Stream.emit(1).mapFilter { x => println(x); Some(x) }
1
1
```

The reason is that `mapFilter` goes through `collect`, which takes a `PartialFunction` and says
```scala
val o = apply(i)
if (pf.isDefinedAt(o))
   b += pf(o)
```
generally `pf.isDefinedAt` does not require the body of `pf` to be evaluated when it's defined by pattern matching, but in this case it's coming through `Function.unlift`, and therefore the body executes twice.

In terms of correctness, this is only observable via side-effects, but it still feels weird and I don't think it was foreseen, hence this quick fix