### PR TITLE
Fix API links

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Quick links:
 * [Docs and getting help](#docs)
 
 [microsite]: http://fs2.io/index.html
-[core-api]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-core_2.12/1.0.1/fs2-core_2.12-1.0.1-javadoc.jar/!/fs2/index.html
-[io-api]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-io_2.12/1.0.1/fs2-io_2.12-1.0.1-javadoc.jar/!/fs2/io/index.html
-[rx-api]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-reactive-streams_2.12/1.0.1/fs2-reactive-streams_2.12-1.0.1-javadoc.jar/!/fs2/interop/reactivestreams/index.html
-[experimental-api]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-experimental_2.12/1.0.1/fs2-experimental_2.12-1.0.1-javadoc.jar/!/fs2/experimental/index.html
+[core-api]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-core_2.12/1.0.4/fs2-core_2.12-1.0.4-javadoc.jar/!/fs2/index.html
+[io-api]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-io_2.12/1.0.4/fs2-io_2.12-1.0.4-javadoc.jar/!/fs2/io/index.html
+[rx-api]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-reactive-streams_2.12/1.0.4/fs2-reactive-streams_2.12-1.0.4-javadoc.jar/!/fs2/interop/reactivestreams/index.html
+[experimental-api]: https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-experimental_2.12/1.0.4/fs2-experimental_2.12-1.0.4-javadoc.jar/!/fs2/experimental/index.html
 
 ### <a id="getit"></a> Where to get the latest version ###
 

--- a/site/src/main/tut/documentation.md
+++ b/site/src/main/tut/documentation.md
@@ -5,12 +5,6 @@ section: "documentation"
 position: 4
 ---
 
-#### API ScalaDocs
-
-* [The core library][core-api], which defines the basic types for streams and pulls. 
-* [The `io` library][io-api], FS2 bindings for NIO-based file I/O and TCP/UDP networking.
-
-
 #### Talks and Presentations
 
 * [Declarative Control Flow with fs2 Stream](https://www.youtube.com/watch?v=YSN__0VEsaw), a talk by [Fabio Labella][1] at the [Typelevel Summit](https://typelevel.org/event/2018-03-summit-boston/), celebrated in Boston in March 2018. Slides available at the author's [Github](https://github.com/SystemFw/TL-Summit-Boston-2018).


### PR DESCRIPTION
Removed API links from the documentation page, as they are broken anyway and to avoid need to keep them in sync in two different places
Refs #1470