### PR TITLE
Replace pool used in example blocking execution context

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ import scala.concurrent.ExecutionContext
 
 object Converter extends IOApp {
   private val blockingExecutionContext =
-    Resource.make(IO(ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(2))))(ec => IO(ec.shutdown()))
+    Resource.make(IO(ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())))(ec => IO(ec.shutdown()))
 
   val converter: Stream[IO, Unit] = Stream.resource(blockingExecutionContext).flatMap { blockingEC =>
     def fahrenheitToCelsius(f: Double): Double =

--- a/docs/ReadmeExample.md
+++ b/docs/ReadmeExample.md
@@ -23,7 +23,7 @@ import scala.concurrent.ExecutionContext
 
 object Converter extends IOApp {
   private val blockingExecutionContext =
-    Resource.make(IO(ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(2))))(ec => IO(ec.shutdown()))
+    Resource.make(IO(ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())))(ec => IO(ec.shutdown()))
 
   val converter: Stream[IO, Unit] = Stream.resource(blockingExecutionContext).flatMap { blockingEC =>
     def fahrenheitToCelsius(f: Double): Double =
@@ -64,7 +64,7 @@ implicit val cs: ContextShift[IO] = IO.contextShift(scala.concurrent.ExecutionCo
 
 //note: this should be shut down when it's no longer necessary - normally that's at the end of your app.
 //See the whole README example for proper resource management in terms of ExecutionContexts.
-val blockingExecutionContext = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(2))
+val blockingExecutionContext = ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
 
 def fahrenheitToCelsius(f: Double): Double =
   (f - 32.0) * (5.0/9.0)

--- a/docs/src/ReadmeExample.md
+++ b/docs/src/ReadmeExample.md
@@ -12,7 +12,7 @@ import scala.concurrent.ExecutionContext
 
 object Converter extends IOApp {
   private val blockingExecutionContext =
-    Resource.make(IO(ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(2))))(ec => IO(ec.shutdown()))
+    Resource.make(IO(ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())))(ec => IO(ec.shutdown()))
 
   val converter: Stream[IO, Unit] = Stream.resource(blockingExecutionContext).flatMap { blockingEC =>
     def fahrenheitToCelsius(f: Double): Double =
@@ -52,7 +52,7 @@ implicit val cs: ContextShift[IO] = IO.contextShift(scala.concurrent.ExecutionCo
 
 //note: this should be shut down when it's no longer necessary - normally that's at the end of your app.
 //See the whole README example for proper resource management in terms of ExecutionContexts.
-val blockingExecutionContext = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(2))
+val blockingExecutionContext = ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
 
 def fahrenheitToCelsius(f: Double): Double =
   (f - 32.0) * (5.0/9.0)


### PR DESCRIPTION
We probably don't want to use a fixed thread pool in a blocking context; update the examples accordingly. This is per a discussion with @djspiewak in the cats-effect gitter room this morning (couldn't figure out how to link directly to it).