### PR TITLE
Fix offsets for some Array.copy calls

### DIFF
--- a/io/src/main/scala/fs2/io/JavaInputOutputStream.scala
+++ b/io/src/main/scala/fs2/io/JavaInputOutputStream.scala
@@ -92,7 +92,7 @@ private[io] object JavaInputOutputStream {
         val result = out match {
           case Some(bytes) =>
             F.delay {
-              Array.copy(bytes.values, 0, dest, off, bytes.size)
+              Array.copy(bytes.values, bytes.offset, dest, off, bytes.size)
               bytes.size
             }
           case None =>
@@ -118,7 +118,7 @@ private[io] object JavaInputOutputStream {
                         out.toBytes -> rem.toBytes.some
                       }
                     F.delay {
-                      Array.copy(copy.values, 0, dest, off, copy.size)
+                      Array.copy(copy.values, copy.offset, dest, off, copy.size)
                     } >> (maybeKeep match {
                       case Some(rem) if rem.size > 0 =>
                         dnState.set(Ready(rem.some)).as(copy.size)

--- a/io/src/main/scala/fs2/io/udp/AsynchronousSocketGroup.scala
+++ b/io/src/main/scala/fs2/io/udp/AsynchronousSocketGroup.scala
@@ -234,7 +234,7 @@ object AsynchronousSocketGroup {
           if (srcBytes.size == srcBytes.values.size) srcBytes.values
           else {
             val destBytes = new Array[Byte](srcBytes.size)
-            Array.copy(srcBytes.values, 0, destBytes, srcBytes.offset, srcBytes.size)
+            Array.copy(srcBytes.values, srcBytes.offset, destBytes, 0, srcBytes.size)
             destBytes
           }
         }


### PR DESCRIPTION
This resulted in garbled data when using `fs2.io.toInputStream`. I've found another instance of such broken call in `AsynchronousSocketGroup`, so I fixed that as well.

I've also replaced a custom generator in `JavaInputOutputStreamSpec` with the one leveraging the standard `Chunk[Byte]` generator. Now the existing tests also cover the issue in question.