### PR TITLE
Delete evalMap return restriction

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,3 +1,1 @@
--J-Xms2g
--J-Xmx4g
 -J-XX:MaxMetaspaceSize=512m

--- a/.sbtopts
+++ b/.sbtopts
@@ -1,1 +1,3 @@
+-J-Xms2g
+-J-Xmx4g
 -J-XX:MaxMetaspaceSize=512m

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -972,7 +972,7 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
     * Not as powerful as `observe` since not all pipes can be represented by `O => F[A]`, but much faster.
     * Alias for `evalMap(o => f(o).as(o))`.
     */
-  def evalTap[F2[x] >: F[x]: Functor, A](f: O => F2[A]): Stream[F2, O] =
+  def evalTap[F2[x] >: F[x]: Functor](f: O => F2[_]): Stream[F2, O] =
     evalMap(o => f(o).as(o))
 
   /**

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -976,13 +976,6 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
     evalMap(o => f(o).as(o))
 
   /**
-    * Like `flatMap` but ignores the result of the function `O => Stream[F2, A]`.
-    * Alias for `flatMap(o => f(o).as(o))`.
-    */
-  def flatTap[F2[x] >: F[x]: Functor, A](f: O => Stream[F2, A]): Stream[F2, O] =
-    flatMap(o => f(o).as(o))
-
-  /**
     * Emits `true` as soon as a matching element is received, else `false` if no input matches.
     * '''Pure''': this operation maps to `List.exists`
     *

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -721,7 +721,7 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
     * Note: the resulting stream will not emit values, even if the pipes do.
     * If you need to emit `Unit` values, consider using `balanceThrough`.
     *
-    * @param chunkSie max size of chunks taken from the source stream
+    * @param chunkSize max size of chunks taken from the source stream
     * @param pipes pipes that will concurrently process the work
     */
   def balanceTo[F2[x] >: F[x]: Concurrent](chunkSize: Int)(

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -836,7 +836,7 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
     * scala> Stream.range(0,10).dropRight(5).toList
     * res0: List[Int] = List(0, 1, 2, 3, 4)
     * }}}
-    **/
+    */
   def dropRight(n: Int): Stream[F, O] =
     if (n <= 0) this
     else {
@@ -968,8 +968,8 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
   }
 
   /**
-    * Like `observe` but observes with a function `O => F[A]` instead of a pipe.
-    * Not as powerful as `observe` since not all pipes can be represented by `O => F[A]`, but much faster.
+    * Like `observe` but observes with a function `O => F[_]` instead of a pipe.
+    * Not as powerful as `observe` since not all pipes can be represented by `O => F[_]`, but much faster.
     * Alias for `evalMap(o => f(o).as(o))`.
     */
   def evalTap[F2[x] >: F[x]: Functor](f: O => F2[_]): Stream[F2, O] =

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -968,11 +968,11 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
   }
 
   /**
-    * Like `observe` but observes with a function `O => F[Unit]` instead of a pipe.
-    * Not as powerful as `observe` since not all pipes can be represented by `O => F[Unit]`, but much faster.
+    * Like `observe` but observes with a function `O => F[A]` instead of a pipe.
+    * Not as powerful as `observe` since not all pipes can be represented by `O => F[A]`, but much faster.
     * Alias for `evalMap(o => f(o).as(o))`.
     */
-  def evalTap[F2[x] >: F[x]: Functor](f: O => F2[Unit]): Stream[F2, O] =
+  def evalTap[F2[x] >: F[x]: Functor, A](f: O => F2[A]): Stream[F2, O] =
     evalMap(o => f(o).as(o))
 
   /**


### PR DESCRIPTION
This PR deletes the `evalMap` unnecessary restriction of receive a function returning `Unit` because the result type of that function will be actually ignored.