### PR TITLE
Rolled back cats-core to 1.6.1 in prep for 1.0.5 release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,8 +54,8 @@ lazy val commonSettings = Seq(
   javaOptions in (Test, run) ++= Seq("-Xms64m", "-Xmx64m"),
   libraryDependencies ++= Seq(
     compilerPlugin("org.typelevel" %% "kind-projector" % "0.10.1"),
-    "org.typelevel" %%% "cats-core" % "2.0.0-M2",
-    "org.typelevel" %%% "cats-laws" % "2.0.0-M2" % "test",
+    "org.typelevel" %%% "cats-core" % "1.6.1",
+    "org.typelevel" %%% "cats-laws" % "2.0.0-M3" % "test",
     "org.typelevel" %%% "cats-effect" % "1.3.1",
     "org.typelevel" %%% "cats-effect-laws" % "1.3.1" % "test",
     "org.scalacheck" %%% "scalacheck" % "1.14.0" % "test",


### PR DESCRIPTION
Note: we have to keep test dependency on 2.0.0-M3 in order for our test suite to work (cats 1.6 is on scalacheck 1.13 whereas 2.0.0 is on 1.14).