### PR TITLE
Changed Pull#{stream,streamNoScope} to require Unit result type

### DIFF
--- a/core/jvm/src/main/scala/fs2/compress.scala
+++ b/core/jvm/src/main/scala/fs2/compress.scala
@@ -70,7 +70,7 @@ object compress {
   def inflate[F[_]](nowrap: Boolean = false, bufferSize: Int = 1024 * 32)(
       implicit ev: RaiseThrowable[F]): Pipe[F, Byte, Byte] =
     _.pull.uncons.flatMap {
-      case None => Pull.pure(None)
+      case None => Pull.done
       case Some((hd, tl)) =>
         val inflater = new Inflater(nowrap)
         val buffer = new Array[Byte](bufferSize)

--- a/core/shared/src/main/scala/fs2/concurrent/Signal.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Signal.scala
@@ -74,7 +74,7 @@ object Signal extends SignalLowPriorityImplicits {
       (y, restOfYs) = firstYAndRestOfYs
       _ <- OptionT.liftF(Pull.output1[F, PullOutput]((x, y, restOfXs, restOfYs)))
     } yield ()
-    firstPull.value.stream
+    firstPull.value.void.stream
       .covaryOutput[PullOutput]
       .flatMap {
         case (x, y, restOfXs, restOfYs) =>

--- a/core/shared/src/test/scala/fs2/CompilationTest.scala
+++ b/core/shared/src/test/scala/fs2/CompilationTest.scala
@@ -11,8 +11,8 @@ object ThisModuleShouldCompile {
   /* Some checks that `.pull` can be used without annotations */
   Stream(1, 2, 3, 4).through(_.take(2))
   Stream.eval(IO.pure(1)).through(_.take(2))
-  Stream(1, 2, 3).covary[IO].pull.uncons1.stream
-  Stream.eval(IO.pure(1)).pull.uncons1.stream
+  Stream(1, 2, 3).covary[IO].pull.uncons1.void.stream
+  Stream.eval(IO.pure(1)).pull.uncons1.void.stream
 
   /* Also in a polymorphic context. */
   def a[F[_], A](s: Stream[F, A]) = s.through(_.take(2))
@@ -36,20 +36,20 @@ object ThisModuleShouldCompile {
     .pull
     .uncons1
     .flatMap {
-      case Some((hd, _)) => Pull.output1(hd).as(None)
-      case None          => Pull.pure(None)
+      case Some((hd, _)) => Pull.output1(hd)
+      case None          => Pull.done
     }
     .stream
   Stream(1, 2, 3).pull.uncons1
     .flatMap {
-      case Some((hd, _)) => Pull.output1(hd).as(None)
-      case None          => Pull.pure(None)
+      case Some((hd, _)) => Pull.output1(hd)
+      case None          => Pull.done
     }
     .stream
   Stream(1, 2, 3).pull.uncons1
     .flatMap {
-      case Some((hd, _)) => Pull.eval(IO.pure(1)) >> Pull.output1(hd).as(None)
-      case None          => Pull.pure(None)
+      case Some((hd, _)) => Pull.eval(IO.pure(1)) >> Pull.output1(hd)
+      case None          => Pull.done
     }
     .stream
   (Stream(1, 2, 3).evalMap(IO(_))): Stream[IO, Int]

--- a/core/shared/src/test/scala/fs2/PullSpec.scala
+++ b/core/shared/src/test/scala/fs2/PullSpec.scala
@@ -11,6 +11,7 @@ class PullSpec extends Fs2Spec {
           .onFinalize(ref.set(1))
           .pull
           .echoChunk
+          .void
           .stream
           .compile
           .toList


### PR DESCRIPTION
This was something I noticed when working on the topic/fs3 branch. This PR changes the `stream` and `streamNoScope` methods to require the result type of the `Pull` to be `Unit`. This is the `Pull` equivalent of `-Xfatal-warnings -Ywarn-value-discard` -- folks can explicitly indicate they want the result type thrown away via `p.void.stream`.

Note how many cases in fs2 itself were using a nonsensical result type -- these are vestiges of the old 0.9 `Pull` API where termination has to be explicitly signaled via an `Option` result type.