### PR TITLE
FreeC.Bind: use method for continuations

### DIFF
--- a/core/shared/src/main/scala/fs2/internal/FreeC.scala
+++ b/core/shared/src/main/scala/fs2/internal/FreeC.scala
@@ -185,9 +185,9 @@ private[fs2] object FreeC {
     override def toString: String = s"FreeC.Eval($fr)"
   }
 
-  abstract class Bind[F[_], X, R](val step: FreeC[F, X]) extends FreeC[F, R] { self =>
+  abstract class Bind[F[_], X, R](val step: FreeC[F, X]) extends FreeC[F, R] {
     def cont(r: Result[X]): FreeC[F, R]
-    val delegate: Bind[F, X, R] = self
+    def delegate: Bind[F, X, R] = this
     override def toString: String = s"FreeC.Bind($step)"
   }
 
@@ -227,9 +227,10 @@ private[fs2] object FreeC {
               }
             case bb: FreeC.Bind[F, z, _] =>
               val nb = new Bind[F, z, R](bb.step) {
+                private[this] val bdel = b.delegate
                 def cont(zr: Result[z]): FreeC[F, R] =
-                  new Bind[F, y, R](bb.cont(zr)) { self =>
-                    override val delegate: Bind[F, y, R] = b.delegate
+                  new Bind[F, y, R](bb.cont(zr)) {
+                    override val delegate: Bind[F, y, R] = bdel
                     def cont(yr: Result[y]): FreeC[F, R] = delegate.cont(yr)
                   }
               }


### PR DESCRIPTION
In the FreeC datatype, the Bind constructor represents the case of a `bind` or `flatMap` operation in a free monad constructor: it takes the step `FreeC[F, A]`, and the continuation of what to do with the result. Currently, the implementation represents that continuation using a value of type `Function1`. In Scala there is another way to represent that a record has a function attached: by declaring an abstract method, and using inheritance as a form of parameterisation.

- This commit changes the Bind case class to an abstract class with an abstract `cont` method, which represents that continuation. This may avoid the allocation and indirection of `Function1` instances.

- Because we are using method calls instead of functions, and because a delegated call from a `Bind` object to another means introducing a stack frame in every call, the naive translation of the `Bind` case in `mk` was causing several `StackOverflow`. To solve this problem, we add to the `Bind` class a `delegate` field, to another `Bind` on the same types: when creating a `Bind` that would delegate unto other, we use the source's own delegate. Inductively, this ensures that the chain of delegates from every object would always point either to another non-delegated `Bind`, or to itself.

- We modify the `View` class in line with the changes to `Bind`, so we turn `View` into an abstract class, we turn the `next` field (a `Function1`) into an abstract method, and instead of a `pureContinuation` function, we use a `PureView` subclass, private to the scope of the `ViewL` object.