### PR TITLE
Add Queue#push1 and Queue#push operators

### DIFF
--- a/core/shared/src/main/scala/fs2/concurrent/PubSub.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/PubSub.scala
@@ -281,7 +281,7 @@ private[fs2] object PubSub {
             update { ps =>
               if (strategy.accepts(i, ps.queue)) {
                 val ps1 = publish_(i, ps)
-                (ps1, Applicative[F].pure(Option.empty[O]))
+                (ps1, Applicative[F].pure(None))
               } else {
                 tryGet_(selector, ps) match {
                   case (ps1, None) =>

--- a/experimental/src/main/scala/fs2/experimental/concurrent/PubSub.scala
+++ b/experimental/src/main/scala/fs2/experimental/concurrent/PubSub.scala
@@ -25,6 +25,7 @@ object PubSub {
         def unsubscribe(selector: Selector): F[Unit] = self.unsubscribe(selector)
         def publish(a: I): F[Unit] = self.publish(a)
         def tryPublish(a: I): F[Boolean] = self.tryPublish(a)
+        def push(a: I, selector: Selector) = self.push(a, selector)
       }
     }
 


### PR DESCRIPTION
This is an operator I've implemented to make certain Queue scenarios a little easier and less error-prone to handle. The basic idea is that I wanted a transactional way to "push" an element out of the queue by force, sort of a `getAndSet`-style operation, but for single queue elements. You can implement something sort-of similar using this:

```scala
val q: Queue[IO, Int] = ???
q.offer1(elem).flatMap { offerWorked =>
  if (offerWorked) {
    Applicative[F].pure(None) //Queue is not full, so return nothing
  } else {
    q.dequeue1.flatMap(a => q.enqueue1(elem) >> Applicative[F].pure(Some(a))) //Queue is full, dequeue and enqueue again
  }
}
```

The problem with this technique is that if the queue is shared concurrently then the lack of enqueueing/dequeueing as a transaction could cause determinism issues, where the state of the queue will be changing underneath our feet.

This implementation goes down to the `PubSub` level to do it in a single `update` so that it should work concurrently as well as locally. At the `Queue` level there are two new methods: `push1` which works for individual elements, and `push` which is the streaming version.

If anything looks weird or fishy about the implementation or docs, feel free to point them out. Thanks in advance for looking at this PR!