### PR TITLE
Add streams for entries of directories & file trees

### DIFF
--- a/core/shared/src/test/scala/fs2/StreamSpec.scala
+++ b/core/shared/src/test/scala/fs2/StreamSpec.scala
@@ -975,6 +975,14 @@ class StreamSpec extends Fs2Spec {
         .asserting(_ shouldBe x)
     }
 
+    "fromBlockingIterator" in forAll { x: List[Int] =>
+      Stream
+        .fromBlockingIterator[IO](Blocker.liftExecutionContext(implicitly), x.iterator)
+        .compile
+        .toList
+        .asserting(_ shouldBe x)
+    }
+
     "groupAdjacentBy" in forAll { (s: Stream[Pure, Int], n0: PosInt) =>
       val n = n0 % 20 + 1
       val f = (i: Int) => i % n

--- a/io/src/main/scala/fs2/io/file/file.scala
+++ b/io/src/main/scala/fs2/io/file/file.scala
@@ -126,7 +126,7 @@ package object file {
   /**
     * Creates a stream of [[Path]]s inside a directory.
     */
-  def streamDirectory[F[_]: Sync: ContextShift](blocker: Blocker, path: Path): Stream[F, Path] =
+  def directoryStream[F[_]: Sync: ContextShift](blocker: Blocker, path: Path): Stream[F, Path] =
     _runJavaCollectionResource[F, DirectoryStream[Path]](
       blocker,
       blocker.delay(Files.newDirectoryStream(path)),
@@ -135,7 +135,7 @@ package object file {
   /**
     * Creates a stream of [[Path]]s inside a directory, filtering the results by the given predicate.
     */
-  def streamDirectory[F[_]: Sync: ContextShift](blocker: Blocker,
+  def directoryStream[F[_]: Sync: ContextShift](blocker: Blocker,
                                                 path: Path,
                                                 filter: Path => Boolean): Stream[F, Path] =
     _runJavaCollectionResource[F, DirectoryStream[Path]](
@@ -146,7 +146,7 @@ package object file {
   /**
     * Creates a stream of [[Path]]s inside a directory which match the given glob.
     */
-  def streamDirectory[F[_]: Sync: ContextShift](blocker: Blocker,
+  def directoryStream[F[_]: Sync: ContextShift](blocker: Blocker,
                                                 path: Path,
                                                 glob: String): Stream[F, Path] =
     _runJavaCollectionResource[F, DirectoryStream[Path]](

--- a/io/src/main/scala/fs2/io/file/file.scala
+++ b/io/src/main/scala/fs2/io/file/file.scala
@@ -133,8 +133,8 @@ package object file {
       _.asScala.iterator)
 
   /**
-   * Creates a stream of [[Path]]s inside a directory, filtering the results by the given predicate.
-   */
+    * Creates a stream of [[Path]]s inside a directory, filtering the results by the given predicate.
+    */
   def streamDirectory[F[_]: Sync: ContextShift](blocker: Blocker,
                                                 path: Path,
                                                 filter: Path => Boolean): Stream[F, Path] =
@@ -144,8 +144,8 @@ package object file {
       _.asScala.iterator)
 
   /**
-   * Creates a stream of [[Path]]s inside a directory which match the given glob.
-   */
+    * Creates a stream of [[Path]]s inside a directory which match the given glob.
+    */
   def streamDirectory[F[_]: Sync: ContextShift](blocker: Blocker,
                                                 path: Path,
                                                 glob: String): Stream[F, Path] =
@@ -155,22 +155,22 @@ package object file {
       _.asScala.iterator)
 
   /**
-   * Creates a stream of [[Path]]s contained in a given file tree. Depth is unlimited.
-   */
+    * Creates a stream of [[Path]]s contained in a given file tree. Depth is unlimited.
+    */
   def walk[F[_]: Sync: ContextShift](blocker: Blocker, start: Path): Stream[F, Path] =
     walk[F](blocker, start, Seq.empty)
 
   /**
-   * Creates a stream of [[Path]]s contained in a given file tree, respecting the supplied options. Depth is unlimited.
-   */
+    * Creates a stream of [[Path]]s contained in a given file tree, respecting the supplied options. Depth is unlimited.
+    */
   def walk[F[_]: Sync: ContextShift](blocker: Blocker,
                                      start: Path,
                                      options: Seq[FileVisitOption]): Stream[F, Path] =
     walk[F](blocker, start, Int.MaxValue, options)
 
   /**
-   * Creates a stream of [[Path]]s contained in a given file tree down to a given depth.
-   */
+    * Creates a stream of [[Path]]s contained in a given file tree down to a given depth.
+    */
   def walk[F[_]: Sync: ContextShift](blocker: Blocker,
                                      start: Path,
                                      maxDepth: Int,

--- a/io/src/test/scala/fs2/io/file/FileSpec.scala
+++ b/io/src/test/scala/fs2/io/file/FileSpec.scala
@@ -115,4 +115,85 @@ class FileSpec extends BaseFileSpec {
     }
   }
 
+  "streamDirectory" - {
+    "returns an empty Stream on an empty directory" in {
+      Stream
+        .resource(Blocker[IO])
+        .flatMap { blocker =>
+          tempDirectory
+            .flatMap { path =>
+              file.streamDirectory[IO](blocker, path)
+            }
+        }
+        .compile
+        .toList
+        .unsafeRunSync()
+        .length shouldBe 0
+    }
+
+    "returns all files in a directory correctly" in {
+      Stream
+        .resource(Blocker[IO])
+        .flatMap { blocker =>
+          tempFiles(10)
+            .flatMap { paths =>
+              val parent = paths.head.getParent
+              file.streamDirectory[IO](blocker, parent).tupleRight(paths)
+            }
+        }
+        .map { case (path, paths) => paths.exists(_.normalize === path.normalize) }
+        .compile
+        .fold(true)(_ & _)
+        .unsafeRunSync() shouldBe true
+    }
+  }
+
+  "walk" - {
+    "returns the only file in a directory correctly" in {
+      Stream
+        .resource(Blocker[IO])
+        .flatMap { blocker =>
+          tempFile
+            .flatMap { path =>
+              file.walk[IO](blocker, path.getParent).map(_.normalize === path.normalize)
+            }
+        }
+        .compile
+        .toList
+        .unsafeRunSync()
+        .length shouldBe 2 // the directory and the file
+    }
+
+    "returns all files in a directory correctly" in {
+      Stream
+        .resource(Blocker[IO])
+        .flatMap { blocker =>
+          tempFiles(10)
+            .flatMap { paths =>
+              val parent = paths.head.getParent
+              file.walk[IO](blocker, parent).tupleRight(parent :: paths)
+            }
+        }
+        .map { case (path, paths) => paths.exists(_.normalize === path.normalize) }
+        .compile
+        .fold(true)(_ & _)
+        .unsafeRunSync() shouldBe true // the directory itself and the files
+    }
+
+    "returns all files in a nested tree correctly" in {
+      Stream
+        .resource(Blocker[IO])
+        .flatMap { blocker =>
+          tempFilesHierarchy
+            .flatMap { topDir =>
+              file.walk[IO](blocker, topDir)
+            }
+        }
+        .compile
+        .toList
+        .unsafeRunSync()
+        .length shouldBe 31 // the root + 5 children + 5 files per child directory
+    }
+  }
+
 }

--- a/io/src/test/scala/fs2/io/file/FileSpec.scala
+++ b/io/src/test/scala/fs2/io/file/FileSpec.scala
@@ -115,14 +115,14 @@ class FileSpec extends BaseFileSpec {
     }
   }
 
-  "streamDirectory" - {
+  "directoryStream" - {
     "returns an empty Stream on an empty directory" in {
       Stream
         .resource(Blocker[IO])
         .flatMap { blocker =>
           tempDirectory
             .flatMap { path =>
-              file.streamDirectory[IO](blocker, path)
+              file.directoryStream[IO](blocker, path)
             }
         }
         .compile
@@ -138,7 +138,7 @@ class FileSpec extends BaseFileSpec {
           tempFiles(10)
             .flatMap { paths =>
               val parent = paths.head.getParent
-              file.streamDirectory[IO](blocker, parent).tupleRight(paths)
+              file.directoryStream[IO](blocker, parent).tupleRight(paths)
             }
         }
         .map { case (path, paths) => paths.exists(_.normalize === path.normalize) }


### PR DESCRIPTION
Wrap up `getDirectoryStream(...)` and `walk(...)`  `java.nio.file.Files` into nice streams while taking care of resource management, blocking I/O and exceptions.

Implements parts of #1533, complementary to #1540.