### PR TITLE
Move InvariantOps to benchmarks.

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/FreeCBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/FreeCBenchmark.scala
@@ -1,10 +1,12 @@
 package fs2
 package benchmark
 
+import cats.MonadError
 import cats.effect.IO
 import org.openjdk.jmh.annotations.{Benchmark, Scope, State}
 
 import fs2.internal.FreeC
+import fs2.internal.FreeC.{Result, ViewL}
 
 @State(Scope.Thread)
 class FreeCBenchmark {
@@ -17,7 +19,7 @@ class FreeCBenchmark {
       (0 to N).foldLeft(FreeC.pure[IO, Int](0): FreeC[IO, Int]) { (acc, i) =>
         acc.map(_ + i)
       }
-    nestedMapsFreeC.run
+    run(nestedMapsFreeC)
   }
 
   @Benchmark
@@ -26,6 +28,18 @@ class FreeCBenchmark {
       (0 to N).foldLeft(FreeC.pure[IO, Int](0): FreeC[IO, Int]) { (acc, i) =>
         acc.flatMap(j => FreeC.pure(i + j))
       }
-    nestedFlatMapsFreeC.run
+    run(nestedFlatMapsFreeC)
   }
+
+  private def run[F[_], R](self: FreeC[F, R])(implicit F: MonadError[F, Throwable]): F[Option[R]] =
+    self.viewL match {
+      case Result.Pure(r)             => F.pure(Some(r))
+      case Result.Fail(e)             => F.raiseError(e)
+      case Result.Interrupted(_, err) => err.fold[F[Option[R]]](F.pure(None)) { F.raiseError }
+      case v @ ViewL.View(step) =>
+        F.flatMap(F.attempt(step)) { r =>
+          run(v.next(Result.fromEither(r)))
+        }
+    }
+
 }


### PR DESCRIPTION
The internal `FreeC` includes an implicit extension class `InvariantOps`, with a method `run` for running a `FreeC`. As it turns out, this method is only ever used in the benchmarks, not to implement Stream or Pull. Therefore, we can move it to that package.