### PR TITLE
Changed ++ to guarantee resource finalization of LHS before evaluating RHS

### DIFF
--- a/core/shared/src/test/scala/fs2/StreamSpec.scala
+++ b/core/shared/src/test/scala/fs2/StreamSpec.scala
@@ -144,24 +144,24 @@ class StreamSpec extends Fs2Spec {
 
       "finalizer should not be called until necessary" in {
         IO.suspend {
-          val buffer = collection.mutable.ListBuffer[Symbol]()
+          val buffer = collection.mutable.ListBuffer[String]()
           Stream
-            .bracket(IO(buffer += 'Acquired)) { _ =>
-              buffer += 'ReleaseInvoked
-              IO(buffer += 'Released).void
+            .bracket(IO(buffer += "Acquired")) { _ =>
+              buffer += "ReleaseInvoked"
+              IO(buffer += "Released").void
             }
             .flatMap { _ =>
-              buffer += 'Used
+              buffer += "Used"
               Stream.emit(())
             }
             .flatMap { s =>
-              buffer += 'FlatMapped
+              buffer += "FlatMapped"
               Stream(s)
             }
             .compile
             .toList
             .asserting { _ =>
-              buffer.toList shouldBe List('Acquired, 'Used, 'FlatMapped, 'ReleaseInvoked, 'Released)
+              buffer.toList shouldBe List("Acquired", "Used", "FlatMapped", "ReleaseInvoked", "Released")
             }
         }
       }

--- a/io/src/main/scala/fs2/io/io.scala
+++ b/io/src/main/scala/fs2/io/io.scala
@@ -105,7 +105,7 @@ package object io {
       val os =
         if (closeAfterUse) Stream.bracket(fos)(os => blocker.delay(os.close()))
         else Stream.eval(fos)
-      os.flatMap(os => useOs(os).scope ++ Stream.eval(blocker.delay(os.flush())))
+      os.flatMap(os => useOs(os) ++ Stream.eval(blocker.delay(os.flush())))
     }
 
   //

--- a/io/src/test/scala/fs2/io/tcp/SocketSpec.scala
+++ b/io/src/test/scala/fs2/io/tcp/SocketSpec.scala
@@ -37,7 +37,6 @@ class SocketSpec extends Fs2Spec {
                   .reads(1024)
                   .through(socket.writes())
                   .onFinalize(socket.endOfOutput)
-                  .scope
               }
           }
           .parJoinUnbounded
@@ -52,8 +51,7 @@ class SocketSpec extends Fs2Spec {
                   .chunk(message)
                   .through(socket.writes())
                   .drain
-                  .onFinalize(socket.endOfOutput)
-                  .scope ++
+                  .onFinalize(socket.endOfOutput) ++
                   socket.reads(1024, None).chunks.map(_.toArray)
               }
             }
@@ -95,7 +93,6 @@ class SocketSpec extends Fs2Spec {
                   .through(socket.writes())
                   .drain
                   .onFinalize(socket.endOfOutput)
-                  .scope
               })
           }
           .parJoinUnbounded


### PR DESCRIPTION
This needs some benchmarking. Let me know if you have any suggestions on the types of streams we should benchmark. It *should* be trivial to show that this is more expensive but I highly, highly doubt the performance is an issue in real streams.