### PR TITLE
Add `evalFilter` and `evalFilterAsync`

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1034,9 +1034,9 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
   def evalFilterAsync[F2[x] >: F[x]: Concurrent](
       maxConcurrent: Int
   )(f: O => F2[Boolean]): Stream[F2, O] =
-    map { o =>
-      Stream.eval(f(o)).ifM(Stream.emit(o), Stream.empty)
-    }.parJoin(maxConcurrent)
+    parEvalMap[F2, Stream[F2, O]](maxConcurrent) { o =>
+      f(o).map(if (_) Stream.emit(o) else Stream.empty)
+    }.flatten
 
   /**
     * Like `filter`, but the predicate `f` depends on the previously emitted and

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1019,17 +1019,18 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
   def filter(p: O => Boolean): Stream[F, O] = mapChunks(_.filter(p))
 
   /**
-   * Like `filter`, but allows filtering based on an effect.
-   */
+    * Like `filter`, but allows filtering based on an effect.
+    */
   def evalFilter[F2[x] >: F[x]: Functor](f: O => F2[Boolean]): Stream[F2, O] =
     evalMap(o => f(o).map(_.guard[Option].as(o))).unNone
 
   /**
-   * Like `filter`, but allows filtering based on an effect, with up to [[maxConcurrent]] concurrently running effects.
-   * The ordering of emitted elements is unchanged.
-   */
-  def evalFilterAsync[F2[x] >: F[x]: Concurrent](maxConcurrent: Int)(f: O => F2[Boolean]): Stream[F2, O] =
-    parEvalMap(maxConcurrent)(o => f(o).map(_.guard[Option].as(o))).unNone
+    * Like `filter`, but allows filtering based on an effect, with up to [[maxConcurrent]] concurrently running effects.
+    * The ordering of emitted elements is unchanged.
+    */
+  def evalFilterAsync[F2[x] >: F[x]: Concurrent](maxConcurrent: Int)(
+      f: O => F2[Boolean]): Stream[F2, O] =
+    parEvalMap[F2, Option[O]](maxConcurrent)(o => f(o).map(_.guard[Option].as(o))).unNone
 
   /**
     * Like `filter`, but the predicate `f` depends on the previously emitted and

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1022,15 +1022,16 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
     * Like `filter`, but allows filtering based on an effect.
     */
   def evalFilter[F2[x] >: F[x]: Functor](f: O => F2[Boolean]): Stream[F2, O] =
-    evalMap(o => f(o).map(_.guard[Option].as(o))).unNone
+    flatMap(o => Stream.eval(f(o)).ifM(Stream.emit(o), Stream.empty))
 
   /**
     * Like `filter`, but allows filtering based on an effect, with up to [[maxConcurrent]] concurrently running effects.
     * The ordering of emitted elements is unchanged.
     */
-  def evalFilterAsync[F2[x] >: F[x]: Concurrent](maxConcurrent: Int)(
-      f: O => F2[Boolean]): Stream[F2, O] =
-    parEvalMap[F2, Option[O]](maxConcurrent)(o => f(o).map(_.guard[Option].as(o))).unNone
+  def evalFilterAsync[F2[x] >: F[x]: Concurrent](
+      maxConcurrent: Int
+  )(f: O => F2[Boolean]): Stream[F2, O] =
+    parEvalMap[F2, Stream[F2, O]](maxConcurrent)( o => f(o).map(if(_) Stream.emit(o) else Stream.empty) ).flatten
 
   /**
     * Like `filter`, but the predicate `f` depends on the previously emitted and
@@ -1896,7 +1897,7 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
     * subsequent appends or other scope-preserving transformations.
     *
     * Scopes can be manually introduced via [[scope]] if desired.
-    * 
+    *
     * Example use case: `a.concurrently(b).onFinalizeWeak(f).compile.resource.use(g)`
     * In this example, use of `onFinalize` would result in `b` shutting down before
     * `g` is run, because `onFinalize` creates a scope, whose lifetime is extended
@@ -1919,11 +1920,12 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
     * subsequent appends or other scope-preserving transformations.
     *
     * Scopes can be manually introduced via [[scope]] if desired.
-    * 
+    *
     * See [[onFinalizeWeak]] for more details on semantics.
     */
-  def onFinalizeCaseWeak[F2[x] >: F[x]](f: ExitCase[Throwable] => F2[Unit])(
-      implicit F2: Applicative[F2]): Stream[F2, O] =
+  def onFinalizeCaseWeak[F2[x] >: F[x]](
+      f: ExitCase[Throwable] => F2[Unit]
+  )(implicit F2: Applicative[F2]): Stream[F2, O] =
     Stream.fromFreeC(Algebra.acquire[F2, O, Unit](().pure[F2], (_, ec) => f(ec)).flatMap {
       case (_, _) => get[F2, O]
     })
@@ -3058,8 +3060,9 @@ object Stream extends StreamLowPriority {
     * Like [[bracketCase]] but no scope is introduced, causing resource finalization to
     * occur at the end of the current scope at the time of acquisition.
     */
-  def bracketCaseWeak[F[x] >: Pure[x], R](acquire: F[R])(
-      release: (R, ExitCase[Throwable]) => F[Unit]): Stream[F, R] =
+  def bracketCaseWeak[F[x] >: Pure[x], R](
+      acquire: F[R]
+  )(release: (R, ExitCase[Throwable]) => F[Unit]): Stream[F, R] =
     fromFreeC(Algebra.acquire[F, R, R](acquire, release).flatMap {
       case (r, token) => Stream.emit(r).covary[F].get[F, R]
     })

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1020,6 +1020,9 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
 
   /**
     * Like `filter`, but allows filtering based on an effect.
+    *
+    * Note: The result Stream will consist of chunks that are empty or 1-element-long.
+    * If you want to operate on chunks after using it, consider buffering, e.g. by using [[buffer]].
     */
   def evalFilter[F2[x] >: F[x]: Functor](f: O => F2[Boolean]): Stream[F2, O] =
     flatMap(o => Stream.eval(f(o)).ifM(Stream.emit(o), Stream.empty))
@@ -1031,7 +1034,9 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
   def evalFilterAsync[F2[x] >: F[x]: Concurrent](
       maxConcurrent: Int
   )(f: O => F2[Boolean]): Stream[F2, O] =
-    parEvalMap[F2, Stream[F2, O]](maxConcurrent)( o => f(o).map(if(_) Stream.emit(o) else Stream.empty) ).flatten
+    parEvalMap[F2, Stream[F2, O]](maxConcurrent)(
+      o => f(o).map(if (_) Stream.emit(o) else Stream.empty)
+    ).flatten
 
   /**
     * Like `filter`, but the predicate `f` depends on the previously emitted and

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1034,9 +1034,9 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
   def evalFilterAsync[F2[x] >: F[x]: Concurrent](
       maxConcurrent: Int
   )(f: O => F2[Boolean]): Stream[F2, O] =
-    parEvalMap[F2, Stream[F2, O]](maxConcurrent)(
-      o => f(o).map(if (_) Stream.emit(o) else Stream.empty)
-    ).flatten
+    map { o =>
+      Stream.eval(f(o)).ifM(Stream.emit(o), Stream.empty)
+    }.parJoin(maxConcurrent)
 
   /**
     * Like `filter`, but the predicate `f` depends on the previously emitted and

--- a/core/shared/src/test/scala/fs2/StreamSpec.scala
+++ b/core/shared/src/test/scala/fs2/StreamSpec.scala
@@ -917,20 +917,20 @@ class StreamSpec extends Fs2Spec {
     "evalFilter" - {
       "with effectful const(true)" in forAll { (s: Stream[Pure, Int]) =>
         withClue("takes all elements") {
-          s.evalFilter(_ => IO.pure(true)).compile.toList.asserting(_ shouldBe s.toList)
+          s.evalFilter(_ => SyncIO.pure(true)).compile.toList.asserting(_ shouldBe s.toList)
         }
       }
 
       "with effectful const(false)" in forAll { (s: Stream[Pure, Int]) =>
         withClue("takes no elements") {
-          s.evalFilter(_ => IO.pure(false)).compile.toList.asserting(_ shouldBe empty)
+          s.evalFilter(_ => SyncIO.pure(false)).compile.toList.asserting(_ shouldBe empty)
         }
       }
 
       "with function that filters out odd elements" in {
         Stream
           .range(1, 10)
-          .evalFilter(e => IO(e % 2 == 0))
+          .evalFilter(e => SyncIO(e % 2 == 0))
           .compile
           .toList
           .asserting(_ shouldBe List(2, 4, 6, 8))
@@ -938,7 +938,9 @@ class StreamSpec extends Fs2Spec {
     }
 
     "evalFilterAsync" - {
-      "with effectful const(true)" in forAll { (s: Stream[Pure, Int]) =>
+      "with effectful const(true)" in { 
+        val s: Stream[Pure, Int] = Stream.range(10, 1000)
+
         withClue("takes all elements") {
           s.covary[IO]
             .evalFilterAsync(5)(_ => IO.pure(true))
@@ -948,7 +950,9 @@ class StreamSpec extends Fs2Spec {
         }
       }
 
-      "with effectful const(false)" in forAll { (s: Stream[Pure, Int]) =>
+      "with effectful const(false)" in  {
+        val s: Stream[Pure, Int] = Stream.range(10, 1000)
+
         withClue("takes no elements") {
           s.covary[IO]
             .evalFilterAsync(5)(_ => IO.pure(false))

--- a/core/shared/src/test/scala/fs2/StreamSpec.scala
+++ b/core/shared/src/test/scala/fs2/StreamSpec.scala
@@ -915,13 +915,17 @@ class StreamSpec extends Fs2Spec {
     }
 
     "evalFilter" - {
-      "with effectful const(true)" in forAll { (s: Stream[Pure, Int]) =>
+      "with effectful const(true)" in {
+        val s = pureStreamGenerator[Int].sample
+
         withClue("takes all elements") {
           s.evalFilter(_ => SyncIO.pure(true)).compile.toList.asserting(_ shouldBe s.toList)
         }
       }
 
-      "with effectful const(false)" in forAll { (s: Stream[Pure, Int]) =>
+      "with effectful const(false)" in {
+        val s = pureStreamGenerator[Int].sample
+
         withClue("takes no elements") {
           s.evalFilter(_ => SyncIO.pure(false)).compile.toList.asserting(_ shouldBe empty)
         }

--- a/core/shared/src/test/scala/fs2/StreamSpec.scala
+++ b/core/shared/src/test/scala/fs2/StreamSpec.scala
@@ -918,17 +918,13 @@ class StreamSpec extends Fs2Spec {
       "with effectful const(true)" in {
         val s = pureStreamGenerator[Int].sample
 
-        withClue("takes all elements") {
-          s.evalFilter(_ => SyncIO.pure(true)).compile.toList.asserting(_ shouldBe s.toList)
-        }
+        s.evalFilter(_ => SyncIO.pure(true)).compile.toList.asserting(_ shouldBe s.toList)
       }
 
       "with effectful const(false)" in {
         val s = pureStreamGenerator[Int].sample
 
-        withClue("takes no elements") {
-          s.evalFilter(_ => SyncIO.pure(false)).compile.toList.asserting(_ shouldBe empty)
-        }
+        s.evalFilter(_ => SyncIO.pure(false)).compile.toList.asserting(_ shouldBe empty)
       }
 
       "with function that filters out odd elements" in {
@@ -945,25 +941,21 @@ class StreamSpec extends Fs2Spec {
       "with effectful const(true)" in { 
         val s: Stream[Pure, Int] = Stream.range(10, 1000)
 
-        withClue("takes all elements") {
-          s.covary[IO]
-            .evalFilterAsync(5)(_ => IO.pure(true))
-            .compile
-            .toList
-            .asserting(_ shouldBe s.toList)
-        }
+        s.covary[IO]
+          .evalFilterAsync(5)(_ => IO.pure(true))
+          .compile
+          .toList
+          .asserting(_ shouldBe s.toList)
       }
 
       "with effectful const(false)" in  {
         val s: Stream[Pure, Int] = Stream.range(10, 1000)
 
-        withClue("takes no elements") {
-          s.covary[IO]
-            .evalFilterAsync(5)(_ => IO.pure(false))
-            .compile
-            .toList
-            .asserting(_ shouldBe empty)
-        }
+        s.covary[IO]
+          .evalFilterAsync(5)(_ => IO.pure(false))
+          .compile
+          .toList
+          .asserting(_ shouldBe empty)
       }
 
       "with function that filters out odd elements" in {


### PR DESCRIPTION
Creating a draft PR to discuss the signatures and implementations before going too deep in.

I have a few suggestions for the implementation of `evalFilter`:

- `evalMap` + `unNone` (current implementation in this PR)
- `flatMap` + `Stream.eval(f(elem)).map(_.guard[Option].foldMap(Stream.emits))`
- manual `pull.uncons` and operating on chunks (might require `Applicative[F]` I'm afraid)

May eventually close #1570 