### PR TITLE
Unify FreeC and Algebra types.

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/FreeCBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/FreeCBenchmark.scala
@@ -16,7 +16,7 @@ class FreeCBenchmark {
   @Benchmark
   def nestedMaps = {
     val nestedMapsFreeC =
-      (0 to N).foldLeft(FreeC.pure[IO, Int](0): FreeC[IO, Int]) { (acc, i) =>
+      (0 to N).foldLeft(FreeC.pure[IO, Int](0): FreeC[IO, INothing, Int]) { (acc, i) =>
         acc.map(_ + i)
       }
     run(nestedMapsFreeC)
@@ -25,21 +25,20 @@ class FreeCBenchmark {
   @Benchmark
   def nestedFlatMaps = {
     val nestedFlatMapsFreeC =
-      (0 to N).foldLeft(FreeC.pure[IO, Int](0): FreeC[IO, Int]) { (acc, i) =>
+      (0 to N).foldLeft(FreeC.pure[IO, Int](0): FreeC[IO, INothing, Int]) { (acc, i) =>
         acc.flatMap(j => FreeC.pure(i + j))
       }
     run(nestedFlatMapsFreeC)
   }
 
-  private def run[F[_], R](self: FreeC[F, R])(implicit F: MonadError[F, Throwable]): F[Option[R]] =
+  private def run[F[_], O, R](
+      self: FreeC[F, O, R]
+  )(implicit F: MonadError[F, Throwable]): F[Option[R]] =
     self.viewL match {
       case Result.Pure(r)             => F.pure(Some(r))
       case Result.Fail(e)             => F.raiseError(e)
       case Result.Interrupted(_, err) => err.fold[F[Option[R]]](F.pure(None)) { F.raiseError }
-      case v @ ViewL.View(step) =>
-        F.flatMap(F.attempt(step)) { r =>
-          run(v.next(Result.fromEither(r)))
-        }
+      case v @ ViewL.View(_)          => F.raiseError(new RuntimeException("Never get here)"))
     }
 
 }

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -127,11 +127,11 @@ import scala.concurrent.duration._
   * @hideImplicitConversion PureOps
   * @hideImplicitConversion IdOps
   **/
-final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, Nothing, ?], Unit])
+final class Stream[+F[_], +O] private (private val free: FreeC[Nothing, Nothing, Unit])
     extends AnyVal {
 
-  private[fs2] def get[F2[x] >: F[x], O2 >: O]: FreeC[Algebra[F2, O2, ?], Unit] =
-    free.asInstanceOf[FreeC[Algebra[F2, O2, ?], Unit]]
+  private[fs2] def get[F2[x] >: F[x], O2 >: O]: FreeC[F2, O2, Unit] =
+    free.asInstanceOf[FreeC[F2, O2, Unit]]
 
   /**
     * Appends `s2` to the end of this stream.
@@ -1091,7 +1091,7 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
             f(hd(0)).get
 
           case _ =>
-            def go(idx: Int): FreeC[Algebra[F2, O2, ?], Unit] =
+            def go(idx: Int): FreeC[F2, O2, Unit] =
               if (idx == hd.size) Stream.fromFreeC(tl).flatMap(f).get
               else {
                 f(hd(idx)).get.transformWith {
@@ -2914,8 +2914,8 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
 }
 
 object Stream extends StreamLowPriority {
-  @inline private[fs2] def fromFreeC[F[_], O](free: FreeC[Algebra[F, O, ?], Unit]): Stream[F, O] =
-    new Stream(free.asInstanceOf[FreeC[Algebra[Nothing, Nothing, ?], Unit]])
+  @inline private[fs2] def fromFreeC[F[_], O](free: FreeC[F, O, Unit]): Stream[F, O] =
+    new Stream(free.asInstanceOf[FreeC[Nothing, Nothing, Unit]])
 
   /** Creates a pure stream that emits the supplied values. To convert to an effectful stream, use `covary`. */
   def apply[F[x] >: Pure[x], O](os: O*): Stream[F, O] = emits(os)
@@ -3022,7 +3022,7 @@ object Stream extends StreamLowPriority {
       .map {
         case (res, r) =>
           (Stream.eval(res.release(ExitCase.Canceled)).flatMap {
-            case Left(t)  => Stream.fromFreeC(Algebra.raiseError[F, Unit](t))
+            case Left(t)  => Stream.fromFreeC(Algebra.raiseError[F](t))
             case Right(u) => Stream.emit(u)
           }, r)
       }
@@ -3100,7 +3100,7 @@ object Stream extends StreamLowPriority {
 
   /** Empty pure stream. */
   val empty: Stream[Pure, INothing] =
-    fromFreeC[Pure, INothing](Algebra.pure[Pure, INothing, Unit](())): Stream[Pure, INothing]
+    fromFreeC[Pure, INothing](Algebra.pure[Pure, Unit](())): Stream[Pure, INothing]
 
   /**
     * Creates a single element stream that gets its value by evaluating the supplied effect. If the effect fails,
@@ -3298,7 +3298,7 @@ object Stream extends StreamLowPriority {
     * This is a low-level method and generally should not be used by user code.
     */
   def getScope[F[x] >: Pure[x]]: Stream[F, Scope[F]] =
-    Stream.fromFreeC(Algebra.getScope[F, Scope[F]].flatMap(Algebra.output1(_)))
+    Stream.fromFreeC(Algebra.getScope[F].flatMap(Algebra.output1(_)))
 
   /**
     * A stream that never emits and never terminates.
@@ -3526,7 +3526,7 @@ object Stream extends StreamLowPriority {
 
   /** Provides syntax for streams that are invariant in `F` and `O`. */
   final class InvariantOps[F[_], O] private[Stream] (
-      private val free: FreeC[Algebra[F, O, ?], Unit]
+      private val free: FreeC[F, O, Unit]
   ) extends AnyVal {
     private def self: Stream[F, O] = Stream.fromFreeC(free)
 
@@ -3622,7 +3622,7 @@ object Stream extends StreamLowPriority {
 
     /** Gets a projection of this stream that allows converting it to a `Pull` in a number of ways. */
     def pull: ToPull[F, O] =
-      new ToPull[F, O](free.asInstanceOf[FreeC[Algebra[Nothing, Nothing, ?], Unit]])
+      new ToPull[F, O](free.asInstanceOf[FreeC[Nothing, Nothing, Unit]])
 
     /**
       * Repeatedly invokes `using`, running the resultant `Pull` each time, halting when a pull
@@ -3640,8 +3640,7 @@ object Stream extends StreamLowPriority {
     new PureOps(s.get[Pure, O])
 
   /** Provides syntax for pure streams. */
-  final class PureOps[O] private[Stream] (private val free: FreeC[Algebra[Pure, O, ?], Unit])
-      extends AnyVal {
+  final class PureOps[O] private[Stream] (private val free: FreeC[Pure, O, Unit]) extends AnyVal {
     private def self: Stream[Pure, O] = Stream.fromFreeC[Pure, O](free)
 
     /** Alias for covary, to be able to write `Stream.empty[X]`. */
@@ -3669,8 +3668,7 @@ object Stream extends StreamLowPriority {
     new IdOps(s.get[Id, O])
 
   /** Provides syntax for pure pipes based on `cats.Id`. */
-  final class IdOps[O] private[Stream] (private val free: FreeC[Algebra[Id, O, ?], Unit])
-      extends AnyVal {
+  final class IdOps[O] private[Stream] (private val free: FreeC[Id, O, Unit]) extends AnyVal {
     private def self: Stream[Id, O] = Stream.fromFreeC[Id, O](free)
 
     private def idToApplicative[F[_]: Applicative]: Id ~> F =
@@ -3684,9 +3682,8 @@ object Stream extends StreamLowPriority {
     new FallibleOps(s.get[Fallible, O])
 
   /** Provides syntax for fallible streams. */
-  final class FallibleOps[O] private[Stream] (
-      private val free: FreeC[Algebra[Fallible, O, ?], Unit]
-  ) extends AnyVal {
+  final class FallibleOps[O] private[Stream] (private val free: FreeC[Fallible, O, Unit])
+      extends AnyVal {
     private def self: Stream[Fallible, O] = Stream.fromFreeC[Fallible, O](free)
 
     /** Lifts this stream to the specified effect type. */
@@ -3712,11 +3709,11 @@ object Stream extends StreamLowPriority {
 
   /** Projection of a `Stream` providing various ways to get a `Pull` from the `Stream`. */
   final class ToPull[F[_], O] private[Stream] (
-      private val free: FreeC[Algebra[Nothing, Nothing, ?], Unit]
+      private val free: FreeC[Nothing, Nothing, Unit]
   ) extends AnyVal {
 
     private def self: Stream[F, O] =
-      Stream.fromFreeC(free.asInstanceOf[FreeC[Algebra[F, O, ?], Unit]])
+      Stream.fromFreeC(free.asInstanceOf[FreeC[F, O, Unit]])
 
     /**
       * Waits for a chunk of elements to be available in the source stream.
@@ -3966,7 +3963,7 @@ object Stream extends StreamLowPriority {
       */
     def stepLeg: Pull[F, INothing, Option[StepLeg[F, O]]] =
       Pull
-        .fromFreeC(Algebra.getScope[F, INothing])
+        .fromFreeC(Algebra.getScope[F])
         .flatMap { scope =>
           new StepLeg[F, O](Chunk.empty, scope.id, self.get).stepLeg
         }
@@ -4060,7 +4057,7 @@ object Stream extends StreamLowPriority {
   }
 
   object Compiler extends LowPrioCompiler {
-    private def compile[F[_], O, B](stream: FreeC[Algebra[F, O, ?], Unit], init: B)(
+    private def compile[F[_], O, B](stream: FreeC[F, O, Unit], init: B)(
         f: (B, Chunk[O]) => B
     )(implicit F: Sync[F]): F[B] =
       F.bracketCase(CompileScope.newRoot[F])(
@@ -4103,11 +4100,11 @@ object Stream extends StreamLowPriority {
 
   /** Projection of a `Stream` providing various ways to compile a `Stream[F,O]` to an `F[...]`. */
   final class CompileOps[F[_], G[_], O] private[Stream] (
-      private val free: FreeC[Algebra[Nothing, Nothing, ?], Unit]
+      private val free: FreeC[Nothing, Nothing, Unit]
   )(implicit compiler: Compiler[F, G]) {
 
     private def self: Stream[F, O] =
-      Stream.fromFreeC(free.asInstanceOf[FreeC[Algebra[F, O, ?], Unit]])
+      Stream.fromFreeC(free.asInstanceOf[FreeC[F, O, Unit]])
 
     /**
       * Compiles this stream in to a value of the target effect type `F` and
@@ -4417,7 +4414,7 @@ object Stream extends StreamLowPriority {
   final class StepLeg[F[_], O](
       val head: Chunk[O],
       private[fs2] val scopeId: Token,
-      private[fs2] val next: FreeC[Algebra[F, O, ?], Unit]
+      private[fs2] val next: FreeC[F, O, Unit]
   ) { self =>
 
     /**


### PR DESCRIPTION
This Pull Requests unifies the two major ADT at the internal implementation of the Stream: `FreeC[F[_], R]`, the Free monad with catch and interruption; and `Algebra[F[_], O, R]`, a representation of the _instructions_ in that FreeC program. These two ADT were combined to form a stream, using the approximate type alias `PullF[_], O, R]` as `FreeC[Algebra[F, O, ?], Unit]`. Notably, the only way in which an object of type `Algebra[F, O, R]` could appear in a `FreeC` was through a special sub-class of `FreeC`, that is `Eval[F[_], A](fr: F[A])`

We unify these two ADTs by doing the following: 
- We add the output parameter `O`, representing the output data of a stream, as an extra covarant parameter of `FreeC`.
- We turn the `Eval[F[_], A]` into an abstract class, 
- We remove the `Algebra` special trait, and turn all the sub-classes of `Algebra` into subclasses of `Eval`.  
- Because `FreeC` and `Algebra` classes are in different files, we need to unseal it. This could be solved by merging the two files, but that would be a bigger change.

As a result, a Pull is no longer represented as a `FreeC[Algebra[F, O, ?], Unit]`, but as a `FreeC[F, O, R]` instead.

Note that all the changes in this PR are in the internal implementation: almost nothing of it affects the `Stream` or `Pull` public APIs. 

#### Translate to mapOutput

Before this change, the implementation of `Stream[F, A].map[B](f: A => B)` had to work at two levels: one being a `FunctionK` between two type-instances of `Algebra`, with different output (middle) types. To apply this transformation through the Stream, the `FreeC` ADT had a `translate` method. 

After the changes, we no longer need that `FunctionK` wrapper, and we can just replace the `translate` method of `FreeC` with a `mapOutput` method.  