### PR TITLE
Added bracketWeak, bracketCaseWeak, and onFinalizeWeak to allow scope-less resource management

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1850,6 +1850,12 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
     * subsequent appends or other scope-preserving transformations.
     *
     * Scopes can be manually introduced via [[scope]] if desired.
+    * 
+    * Example use case: `a.concurrently(b).onFinalizeWeak(f).compile.resource.use(g)`
+    * In this example, use of `onFinalize` would result in `b` shutting down before
+    * `g` is run, because `onFinalize` creates a scope, whose lifetime is extended
+    * over the compiled resource. By using `onFinalizeWeak` instead, `f` is attached
+    * to the scope governing `concurrently`.
     */
   def onFinalizeWeak[F2[x] >: F[x]](f: F2[Unit])(implicit F2: Applicative[F2]): Stream[F2, O] =
     onFinalizeCaseWeak(_ => f)
@@ -1866,6 +1872,8 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
     * subsequent appends or other scope-preserving transformations.
     *
     * Scopes can be manually introduced via [[scope]] if desired.
+    * 
+    * See [[onFinalizeWeak]] for more details on semantics.
     */
   def onFinalizeCaseWeak[F2[x] >: F[x]](f: ExitCase[Throwable] => F2[Unit])(
       implicit F2: Applicative[F2]): Stream[F2, O] =


### PR DESCRIPTION
These three combinators behave like `bracket`, `bracketCase`, and `onFinalize` did in 1.0.5. One nice property of having these three operations is that we won't run in to a situation where someone was relying on the 1.0.5 behavior and there's no way to get it back in 1.1.0.