### PR TITLE
Optimize `evals` for lists

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3140,7 +3140,7 @@ object Stream extends StreamLowPriority {
 
   /** Like `eval`, but lifts a foldable structure. **/
   def evals[F[_], S[_]: Foldable, O](fo: F[S[O]]): Stream[F, O] =
-    eval(fo).flatMap(_.foldMap(Stream.emit))
+    eval(fo).flatMap(so => Stream.emits(so.toList))
 
   /** Like `evals`, but lifts any Seq in the effect. **/
   def evalSeq[F[_], S[A] <: Seq[A], O](fo: F[S[O]]): Stream[F, O] =


### PR DESCRIPTION
As mentioned in #1582, using `Stream.emits(foo.toList)` will be much faster for lists than `foldMap` when used with a list or structure like Chain (I suppose it'll still depend on how the Chain is built and so on, but users can optimize for their specific use-cases themselves).

Also closes #1571 