### PR TITLE
Unfold Algebra.suspend.

### DIFF
--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -220,7 +220,7 @@ object Pull extends PullLowPriority {
     * allowing use of a mutable value in pull computations.
     */
   def suspend[F[x] >: Pure[x], O, R](p: => Pull[F, O, R]): Pull[F, O, R] =
-    fromFreeC(Algebra.suspend(p.get))
+    fromFreeC(FreeC.suspend(p.get))
 
   /** `Sync` instance for `Pull`. */
   implicit def syncInstance[F[_], O](

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3469,7 +3469,7 @@ object Stream extends StreamLowPriority {
     * }}}
     */
   def suspend[F[_], O](s: => Stream[F, O]): Stream[F, O] =
-    fromFreeC(Algebra.suspend(s.get))
+    fromFreeC(FreeC.suspend(s.get))
 
   /**
     * Creates a stream by successively applying `f` until a `None` is returned, emitting

--- a/core/shared/src/main/scala/fs2/internal/Algebra.scala
+++ b/core/shared/src/main/scala/fs2/internal/Algebra.scala
@@ -158,9 +158,6 @@ private[fs2] object Algebra {
   def raiseError[F[_], O](t: Throwable): FreeC[Algebra[F, O, ?], INothing] =
     FreeC.raiseError[Algebra[F, O, ?]](t)
 
-  def suspend[F[_], O, R](f: => FreeC[Algebra[F, O, ?], R]): FreeC[Algebra[F, O, ?], R] =
-    FreeC.suspend(f)
-
   def translate[F[_], G[_], O](
       s: FreeC[Algebra[F, O, ?], Unit],
       u: F ~> G


### PR DESCRIPTION
Given that the suspend method of the `Algebra` object simply redirects to that of `FreeC`, we may save the "middle man". 

This is different from other methods, where it has to add the `Algebra[]` parameterisation.