### PR TITLE
Update Scala and SBT Version where outdated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 scala:
   - 2.11.12
   - 2.13.0
-  - 2.12.8
+  - 2.12.9
 
 jdk:
   - openjdk11
@@ -28,7 +28,7 @@ script:
   - sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 -Dfs2.test.verbose testJVM
   - sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 -Dfs2.test.verbose testJS
   - sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 doc mimaReportBinaryIssues
-  - (test $TRAVIS_SCALA_VERSION == "2.11.12" && sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 -J-Xms2g -J-Xmx2g docs/tut) || test $TRAVIS_SCALA_VERSION == "2.12.8" || test $TRAVIS_SCALA_VERSION == "2.13.0"
+  - (test $TRAVIS_SCALA_VERSION == "2.11.12" && sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 -J-Xms2g -J-Xmx2g docs/tut) || test $TRAVIS_SCALA_VERSION == "2.12.9" || test $TRAVIS_SCALA_VERSION == "2.13.0"
 
 after_success:
   - test $PUBLISH == "true" && test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "series/1.1" && GPG_WARN_ON_FAILURE=true sbt +publish

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1882,7 +1882,7 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
     * subsequent appends or other scope-preserving transformations.
     *
     * Scopes can be manually introduced via [[scope]] if desired.
-    * 
+    *
     * Example use case: `a.concurrently(b).onFinalizeWeak(f).compile.resource.use(g)`
     * In this example, use of `onFinalize` would result in `b` shutting down before
     * `g` is run, because `onFinalize` creates a scope, whose lifetime is extended
@@ -1905,11 +1905,12 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
     * subsequent appends or other scope-preserving transformations.
     *
     * Scopes can be manually introduced via [[scope]] if desired.
-    * 
+    *
     * See [[onFinalizeWeak]] for more details on semantics.
     */
-  def onFinalizeCaseWeak[F2[x] >: F[x]](f: ExitCase[Throwable] => F2[Unit])(
-      implicit F2: Applicative[F2]): Stream[F2, O] =
+  def onFinalizeCaseWeak[F2[x] >: F[x]](
+      f: ExitCase[Throwable] => F2[Unit]
+  )(implicit F2: Applicative[F2]): Stream[F2, O] =
     Stream.fromFreeC(Algebra.acquire[F2, O, Unit](().pure[F2], (_, ec) => f(ec)).flatMap {
       case (_, _) => get[F2, O]
     })
@@ -3044,8 +3045,9 @@ object Stream extends StreamLowPriority {
     * Like [[bracketCase]] but no scope is introduced, causing resource finalization to
     * occur at the end of the current scope at the time of acquisition.
     */
-  def bracketCaseWeak[F[x] >: Pure[x], R](acquire: F[R])(
-      release: (R, ExitCase[Throwable]) => F[Unit]): Stream[F, R] =
+  def bracketCaseWeak[F[x] >: Pure[x], R](
+      acquire: F[R]
+  )(release: (R, ExitCase[Throwable]) => F[Unit]): Stream[F, R] =
     fromFreeC(Algebra.acquire[F, R, R](acquire, release).flatMap {
       case (r, token) => Stream.emit(r).covary[F].get[F, R]
     })

--- a/sbt
+++ b/sbt
@@ -5,12 +5,12 @@
 
 set -o pipefail
 
-declare -r sbt_release_version="0.13.16"
-declare -r sbt_unreleased_version="0.13.16"
+declare -r sbt_release_version="1.3.0"
+declare -r sbt_unreleased_version="1.3.0"
 
-declare -r latest_213="2.13.0-M2"
-declare -r latest_212="2.12.4"
-declare -r latest_211="2.11.11"
+declare -r latest_213="2.13.0"
+declare -r latest_212="2.12.9"
+declare -r latest_211="2.11.12"
 declare -r latest_210="2.10.6"
 declare -r latest_29="2.9.3"
 declare -r latest_28="2.8.2"


### PR DESCRIPTION
Apparently master had some scalafmt edits it needed made. 

The sbt file became outdated, and 2.12.9 is supported so seems good to get into CI.