### PR TITLE
Removed Stream.bracketCancellable and Pull.acquire*

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1912,7 +1912,7 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
       f: ExitCase[Throwable] => F2[Unit]
   )(implicit F2: Applicative[F2]): Stream[F2, O] =
     Stream.fromFreeC(
-      Algebra.acquire[F2, O, Unit](().pure[F2], (_, ec) => f(ec)).flatMap(get[F2, O])
+      Algebra.acquire[F2, O, Unit](().pure[F2], (_, ec) => f(ec)).flatMap(_ => get[F2, O])
     )
 
   /**

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3965,6 +3965,17 @@ object Stream extends StreamLowPriority {
     }
 
     /**
+      * Takes the first value output by this stream and returns it in the result of a pull.
+      * If no value is output before the stream terminates, the pull is failed with a `NoSuchElementException`.
+      * If more than 1 value is output, everything beyond the first is ignored.
+      */
+    def singleton(implicit F: RaiseThrowable[F]): Pull[F, INothing, O] =
+      uncons1.flatMap {
+        case None         => Pull.raiseError(new NoSuchElementException)
+        case Some((o, _)) => Pull.pure(o)
+      }
+
+    /**
       * Like `uncons`, but instead of performing normal `uncons`, this will
       * run the stream up to the first chunk available.
       * Useful when zipping multiple streams (legs) into one stream.

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1911,9 +1911,9 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
   def onFinalizeCaseWeak[F2[x] >: F[x]](
       f: ExitCase[Throwable] => F2[Unit]
   )(implicit F2: Applicative[F2]): Stream[F2, O] =
-    Stream.fromFreeC(Algebra.acquire[F2, O, Unit](().pure[F2], (_, ec) => f(ec)).flatMap {
-      case (_, _) => get[F2, O]
-    })
+    Stream.fromFreeC(
+      Algebra.acquire[F2, O, Unit](().pure[F2], (_, ec) => f(ec)).flatMap(get[F2, O])
+    )
 
   /**
     * Like [[Stream#evalMap]], but will evaluate effects in parallel, emitting the results
@@ -3539,15 +3539,15 @@ object Stream extends StreamLowPriority {
     * res0: List[Int] = List(0, 1, 2, 3, 4, 5)
     * }}}
     */
-  def unfoldLoop[F[x] <: Pure[x], S, O](s: S)(f: S => (O, Option[S])): Stream[F, O] = 
-    Pull.loop[F, O, S]{
-      s => 
-          val (o, sOpt) = f(s)
-          Pull.output1(o) >> Pull.pure(sOpt)
-    }(s)
-    .void
-    .stream
-  
+  def unfoldLoop[F[x] <: Pure[x], S, O](s: S)(f: S => (O, Option[S])): Stream[F, O] =
+    Pull
+      .loop[F, O, S] { s =>
+        val (o, sOpt) = f(s)
+        Pull.output1(o) >> Pull.pure(sOpt)
+      }(s)
+      .void
+      .stream
+
   /** Like [[unfoldLoop]], but takes an effectful function. */
   def unfoldLoopEval[F[_], S, O](s: S)(f: S => F[(O, Option[S])]): Stream[F, O] =
     Pull

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1882,7 +1882,7 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
     * subsequent appends or other scope-preserving transformations.
     *
     * Scopes can be manually introduced via [[scope]] if desired.
-    * 
+    *
     * Example use case: `a.concurrently(b).onFinalizeWeak(f).compile.resource.use(g)`
     * In this example, use of `onFinalize` would result in `b` shutting down before
     * `g` is run, because `onFinalize` creates a scope, whose lifetime is extended
@@ -1905,14 +1905,15 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Algebra[Nothing, 
     * subsequent appends or other scope-preserving transformations.
     *
     * Scopes can be manually introduced via [[scope]] if desired.
-    * 
+    *
     * See [[onFinalizeWeak]] for more details on semantics.
     */
-  def onFinalizeCaseWeak[F2[x] >: F[x]](f: ExitCase[Throwable] => F2[Unit])(
-      implicit F2: Applicative[F2]): Stream[F2, O] =
-    Stream.fromFreeC(Algebra.acquire[F2, O, Unit](().pure[F2], (_, ec) => f(ec)).flatMap {
-      case (_, _) => get[F2, O]
-    })
+  def onFinalizeCaseWeak[F2[x] >: F[x]](
+      f: ExitCase[Throwable] => F2[Unit]
+  )(implicit F2: Applicative[F2]): Stream[F2, O] =
+    Stream.fromFreeC(
+      Algebra.acquire[F2, O, Unit](().pure[F2], (_, ec) => f(ec)).flatMap(_ => get[F2, O])
+    )
 
   /**
     * Like [[Stream#evalMap]], but will evaluate effects in parallel, emitting the results
@@ -3036,62 +3037,16 @@ object Stream extends StreamLowPriority {
   def bracketCase[F[x] >: Pure[x], R](
       acquire: F[R]
   )(release: (R, ExitCase[Throwable]) => F[Unit]): Stream[F, R] =
-    fromFreeC(Algebra.acquire[F, R, R](acquire, release).flatMap {
-      case (r, token) => Stream.emit(r).covary[F].get[F, R]
-    }).scope
+    bracketCaseWeak(acquire)(release).scope
 
   /**
     * Like [[bracketCase]] but no scope is introduced, causing resource finalization to
     * occur at the end of the current scope at the time of acquisition.
     */
-  def bracketCaseWeak[F[x] >: Pure[x], R](acquire: F[R])(
-      release: (R, ExitCase[Throwable]) => F[Unit]): Stream[F, R] =
-    fromFreeC(Algebra.acquire[F, R, R](acquire, release).flatMap {
-      case (r, token) => Stream.emit(r).covary[F].get[F, R]
-    })
-
-  /**
-    * Like [[bracket]] but the result value consists of a cancellation
-    * Stream and the acquired resource. Running the cancellation Stream frees the resource.
-    * This allows the acquired resource to be released earlier than at the end of the
-    * containing Stream scope.
-    * Note that this operation is safe: if the cancellation Stream is not run manually,
-    * the resource is still guaranteed be release at the end of the containing Stream scope.
-    */
-  def bracketCancellable[F[x] >: Pure[x], R](
+  def bracketCaseWeak[F[x] >: Pure[x], R](
       acquire: F[R]
-  )(release: R => F[Unit]): Stream[F, (Stream[F, Unit], R)] =
-    bracketCaseCancellable(acquire)((r, _) => release(r))
-
-  /**
-    * Like [[bracketCancellable]] but the release action is passed an `ExitCase[Throwable]`.
-    *
-    * `ExitCase.Canceled` is passed to the release action in the event of either stream interruption or
-    * overall compiled effect cancelation.
-    */
-  def bracketCaseCancellable[F[x] >: Pure[x], R](
-      acquire: F[R]
-  )(release: (R, ExitCase[Throwable]) => F[Unit]): Stream[F, (Stream[F, Unit], R)] =
-    bracketWithResource(acquire)(release)
-      .map {
-        case (res, r) =>
-          (Stream.eval(res.release(ExitCase.Canceled)).flatMap {
-            case Left(t)  => Stream.fromFreeC(Algebra.raiseError[F, Unit](t))
-            case Right(u) => Stream.emit(u)
-          }, r)
-      }
-
-  private[fs2] def bracketWithResource[F[x] >: Pure[x], R](
-      acquire: F[R]
-  )(release: (R, ExitCase[Throwable]) => F[Unit]): Stream[F, (fs2.internal.Resource[F], R)] =
-    fromFreeC(Algebra.acquire[F, (fs2.internal.Resource[F], R), R](acquire, release).flatMap {
-      case (r, res) =>
-        Stream
-          .emit(r)
-          .covary[F]
-          .map(o => (res, o))
-          .get[F, (fs2.internal.Resource[F], R)]
-    }).scope
+  )(release: (R, ExitCase[Throwable]) => F[Unit]): Stream[F, R] =
+    fromFreeC(Algebra.acquire[F, R, R](acquire, release).flatMap(Algebra.output1(_)))
 
   /**
     * Creates a pure stream that emits the elements of the supplied chunk.

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3870,6 +3870,17 @@ object Stream extends StreamLowPriority {
           }
       }
 
+    /**
+      * Takes the first value output by this stream and returns it in the result of a pull.
+      * If no value is output before the stream terminates, the pull is failed with a `NoSuchElementException`.
+      * If more than 1 value is output, everything beyond the first is ignored.
+      */
+    def headOrError(implicit F: RaiseThrowable[F]): Pull[F, INothing, O] =
+      uncons1.flatMap {
+        case None         => Pull.raiseError(new NoSuchElementException)
+        case Some((o, _)) => Pull.pure(o)
+      }
+
     /** Writes all inputs to the output of the returned `Pull`. */
     def echo: Pull[F, O, Unit] = Pull.fromFreeC(self.get)
 
@@ -3994,17 +4005,6 @@ object Stream extends StreamLowPriority {
         }
       go(init, self)
     }
-
-    /**
-      * Takes the first value output by this stream and returns it in the result of a pull.
-      * If no value is output before the stream terminates, the pull is failed with a `NoSuchElementException`.
-      * If more than 1 value is output, everything beyond the first is ignored.
-      */
-    def singleton(implicit F: RaiseThrowable[F]): Pull[F, INothing, O] =
-      uncons1.flatMap {
-        case None         => Pull.raiseError(new NoSuchElementException)
-        case Some((o, _)) => Pull.pure(o)
-      }
 
     /**
       * Like `uncons`, but instead of performing normal `uncons`, this will

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3044,47 +3044,6 @@ object Stream extends StreamLowPriority {
     * occur at the end of the current scope at the time of acquisition.
     */
   def bracketCaseWeak[F[x] >: Pure[x], R](
-<<<<<<< HEAD
-=======
-      acquire: F[R]
-  )(release: (R, ExitCase[Throwable]) => F[Unit]): Stream[F, R] =
-    fromFreeC(Algebra.acquire[F, R, R](acquire, release).flatMap {
-      case (r, token) => Stream.emit(r).covary[F].get[F, R]
-    })
-
-  /**
-    * Like [[bracket]] but the result value consists of a cancellation
-    * Stream and the acquired resource. Running the cancellation Stream frees the resource.
-    * This allows the acquired resource to be released earlier than at the end of the
-    * containing Stream scope.
-    * Note that this operation is safe: if the cancellation Stream is not run manually,
-    * the resource is still guaranteed be release at the end of the containing Stream scope.
-    */
-  def bracketCancellable[F[x] >: Pure[x], R](
-      acquire: F[R]
-  )(release: R => F[Unit]): Stream[F, (Stream[F, Unit], R)] =
-    bracketCaseCancellable(acquire)((r, _) => release(r))
-
-  /**
-    * Like [[bracketCancellable]] but the release action is passed an `ExitCase[Throwable]`.
-    *
-    * `ExitCase.Canceled` is passed to the release action in the event of either stream interruption or
-    * overall compiled effect cancelation.
-    */
-  def bracketCaseCancellable[F[x] >: Pure[x], R](
-      acquire: F[R]
-  )(release: (R, ExitCase[Throwable]) => F[Unit]): Stream[F, (Stream[F, Unit], R)] =
-    bracketWithResource(acquire)(release)
-      .map {
-        case (res, r) =>
-          (Stream.eval(res.release(ExitCase.Canceled)).flatMap {
-            case Left(t)  => Stream.fromFreeC(Algebra.raiseError[F, Unit](t))
-            case Right(u) => Stream.emit(u)
-          }, r)
-      }
-
-  private[fs2] def bracketWithResource[F[x] >: Pure[x], R](
->>>>>>> series/1.1
       acquire: F[R]
   )(release: (R, ExitCase[Throwable]) => F[Unit]): Stream[F, R] =
     fromFreeC(Algebra.acquire[F, R, R](acquire, release).flatMap(Algebra.output1(_)))

--- a/core/shared/src/main/scala/fs2/internal/Algebra.scala
+++ b/core/shared/src/main/scala/fs2/internal/Algebra.scala
@@ -35,7 +35,7 @@ private[fs2] object Algebra {
   private[this] final case class Acquire[F[_], R](
       resource: F[R],
       release: (R, ExitCase[Throwable]) => F[Unit]
-  ) extends AlgEffect[F, (R, Resource[F])]
+  ) extends AlgEffect[F, R]
   private[this] final case class OpenScope[F[_]](interruptible: Option[Concurrent[F]])
       extends AlgEffect[F, Token]
 
@@ -61,8 +61,8 @@ private[fs2] object Algebra {
   def acquire[F[_], O, R](
       resource: F[R],
       release: (R, ExitCase[Throwable]) => F[Unit]
-  ): FreeC[Algebra[F, O, ?], (R, Resource[F])] =
-    FreeC.Eval[Algebra[F, O, ?], (R, Resource[F])](Acquire(resource, release))
+  ): FreeC[Algebra[F, O, ?], R] =
+    FreeC.Eval[Algebra[F, O, ?], R](Acquire(resource, release))
 
   def mapOutput[F[_], A, B](fun: A => B): Algebra[F, A, ?] ~> Algebra[F, B, ?] =
     new (Algebra[F, A, ?] ~> Algebra[F, B, ?]) {


### PR DESCRIPTION
`Stream.bracketCancellable` and `Stream.bracketCaseCancellable` allowed early, manual finalization of resources. Upon invoking the finalizer, the internal resource would be cleaned up, ensuring we don't leak references to already invoked finalizers. Now that we introduce a scope for each `bracket`, folks would expect that invoking cancelation of this case also closes the dedicated scope -- i.e., we don't leak scopes either. Instead of implementing this, I'd like to remove these operations instead. There were no tests for these operations and they were very rarely used. Searching GitHub shows no GH hosted open source projects use either operation.

Similarly, `Pull.acquireCancellable` provided a mechanism to manually invoke finalizers. I added this back in #662 to fix resource leaks, but the motivating use cases at the time are all addressed now by using effect level bracketing.

Removal of `Pull.acquire` is perhaps the most controversial. When `Pull` was the primary mechanism in which scopes were created, acquiring a resource via `Pull` made more sense than it does now.

This PR also introduces a `s.pull.headOrError` method, that converts a `Stream[F, O]` to a `Pull[F, INothing, O]`. Uses of `Pull.acquire` can be replaced with `Stream.bracket(acquire)(release).pull.headOrError`.

Note: the only place where `Pull.Cancellable` was used was in the constructors for `FileHandle` in `fs2.io.file.pulls`. These were vestiges of a time before `cats.effect.Resource`. These constructors were removed in favor of new constructors on `FileHandle` companion that return `Resource[F, FileHandle[F]]`.