### PR TITLE
Add Parallel instance for Stream

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -4614,7 +4614,11 @@ object Stream extends StreamLowPriority {
         λ[ZipStream[M, ?] ~> Stream[M, ?]](_.underlying)
     }
 
-  final case class ZipStream[F[_], O](underlying: Stream[F, O])
+  final case class ZipStream[F[_], O](underlying: Stream[F, O]) {
+    //temporary - for nice output in failed property tests
+    override def toString: String = underlying.asInstanceOf[Stream[IO, O]].compile.toList.map(_.toString).unsafeRunSync()
+  }
+
   object ZipStream {
     implicit def applicativeInstance[F[_]]: CommutativeApplicative[ZipStream[F, ?]] =
       new CommutativeApplicative[ZipStream[F, ?]] {

--- a/core/shared/src/test/scala/fs2/StreamLawsSpec.scala
+++ b/core/shared/src/test/scala/fs2/StreamLawsSpec.scala
@@ -63,7 +63,7 @@ class StreamLawsSpec extends Fs2Spec with StreamArbitrary {
   )
   checkAll("MonoidK[Stream[F, ?]]", MonoidKTests[Stream[IO, ?]].monoidK[Int])
   checkAll(
-    "NonEmptyParalell[Stream[F, ?]]",
+    "NonEmptyParallel[Stream[F, ?]]",
     NonEmptyParallelTests[Stream[IO, ?], Stream.ZipStream[IO, ?]].nonEmptyParallel[Int, String]
   )
   checkAll(


### PR DESCRIPTION
Very much WIP.

Remaining things to do:
- [ ] Figure out what to do about Applicative/Parallel laws (ZipStream uses an infinite stream at `pure`, so equality checks are tricky here)
- [ ] Use an efficient newtype encoding (like `NonEmptyChain` and friends from cats)