### PR TITLE
Stream: reimplement range without fold

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3408,13 +3408,14 @@ object Stream extends StreamLowPriority {
     * res0: List[Int] = List(10, 12, 14, 16, 18)
     * }}}
     */
-  def range[F[x] >: Pure[x]](start: Int, stopExclusive: Int, by: Int = 1): Stream[F, Int] =
-    unfold(start) { i =>
+  def range[F[x] >: Pure[x]](start: Int, stopExclusive: Int, by: Int = 1): Stream[F, Int] = {
+    def go(i: Int): Stream[F, Int] =
       if ((by > 0 && i < stopExclusive && start < stopExclusive) ||
           (by < 0 && i > stopExclusive && start > stopExclusive))
-        Some((i, i + by))
-      else None
-    }
+        emit(i) ++ go(i + by)
+      else empty
+    go(start)
+  }
 
   /**
     * Lazily produce a sequence of nonoverlapping ranges, where each range


### PR DESCRIPTION
The `Stream.range` operation, for creating a stream of integers from
an initial value to a final value in a step-by-step way, was
implemented using `unfold`. An `unfold` is too general and too lazy for what we need to output integer values (which has no side effects). Thus, this commit makes a lighter implementation of `Stream.range`, by unfolding the `unfold` call and removing the extra `Option` and `Tuple` objects.