### PR TITLE
Unify FreeC and Algebra types.

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/FreeCBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/FreeCBenchmark.scala
@@ -16,7 +16,7 @@ class FreeCBenchmark {
   @Benchmark
   def nestedMaps = {
     val nestedMapsFreeC =
-      (0 to N).foldLeft(FreeC.pure[IO, Int](0): FreeC[IO, Int]) { (acc, i) =>
+      (0 to N).foldLeft(FreeC.pure[IO, Int](0): FreeC[IO, INothing, Int]) { (acc, i) =>
         acc.map(_ + i)
       }
     run(nestedMapsFreeC)
@@ -25,21 +25,20 @@ class FreeCBenchmark {
   @Benchmark
   def nestedFlatMaps = {
     val nestedFlatMapsFreeC =
-      (0 to N).foldLeft(FreeC.pure[IO, Int](0): FreeC[IO, Int]) { (acc, i) =>
+      (0 to N).foldLeft(FreeC.pure[IO, Int](0): FreeC[IO, INothing, Int]) { (acc, i) =>
         acc.flatMap(j => FreeC.pure(i + j))
       }
     run(nestedFlatMapsFreeC)
   }
 
-  private def run[F[_], R](self: FreeC[F, R])(implicit F: MonadError[F, Throwable]): F[Option[R]] =
+  private def run[F[_], O, R](
+      self: FreeC[F, O, R]
+  )(implicit F: MonadError[F, Throwable]): F[Option[R]] =
     self.viewL match {
       case Result.Pure(r)             => F.pure(Some(r))
       case Result.Fail(e)             => F.raiseError(e)
       case Result.Interrupted(_, err) => err.fold[F[Option[R]]](F.pure(None)) { F.raiseError }
-      case v @ ViewL.View(step) =>
-        F.flatMap(F.attempt(step)) { r =>
-          run(v.next(Result.fromEither(r)))
-        }
+      case v @ ViewL.View(_)          => F.raiseError(new RuntimeException("Never get here)"))
     }
 
 }

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -22,11 +22,10 @@ import fs2.internal._
   * `raiseError` is caught by `handleErrorWith`:
   *   - `handleErrorWith(raiseError(e))(f) == f(e)`
   */
-final class Pull[+F[_], +O, +R] private (private val free: FreeC[Algebra[Nothing, Nothing, ?], R])
-    extends AnyVal {
+final class Pull[+F[_], +O, +R] private (private val free: FreeC[Nothing, O, R]) extends AnyVal {
 
-  private[fs2] def get[F2[x] >: F[x], O2 >: O, R2 >: R]: FreeC[Algebra[F2, O2, ?], R2] =
-    free.asInstanceOf[FreeC[Algebra[F2, O2, ?], R2]]
+  private[fs2] def get[F2[x] >: F[x], O2 >: O, R2 >: R]: FreeC[F2, O2, R2] =
+    free.asInstanceOf[FreeC[F2, O2, R2]]
 
   /** Alias for `_.map(_ => o2)`. */
   def as[R2](r2: R2): Pull[F, O, R2] = map(_ => r2)
@@ -74,7 +73,7 @@ final class Pull[+F[_], +O, +R] private (private val free: FreeC[Algebra[Nothing
 
   /** Run `p2` after `this`, regardless of errors during `this`, then reraise any errors encountered during `this`. */
   def onComplete[F2[x] >: F[x], O2 >: O, R2 >: R](p2: => Pull[F2, O2, R2]): Pull[F2, O2, R2] =
-    handleErrorWith(e => p2 >> new Pull(Algebra.raiseError[Nothing, Nothing](e))) >> p2
+    handleErrorWith(e => p2 >> new Pull(Algebra.raiseError[Nothing](e))) >> p2
 
   /** If `this` terminates with `Pull.raiseError(e)`, invoke `h(e)`. */
   def handleErrorWith[F2[x] >: F[x], O2 >: O, R2 >: R](
@@ -88,8 +87,8 @@ final class Pull[+F[_], +O, +R] private (private val free: FreeC[Algebra[Nothing
 
 object Pull extends PullLowPriority {
 
-  @inline private[fs2] def fromFreeC[F[_], O, R](free: FreeC[Algebra[F, O, ?], R]): Pull[F, O, R] =
-    new Pull(free.asInstanceOf[FreeC[Algebra[Nothing, Nothing, ?], R]])
+  @inline private[fs2] def fromFreeC[F[_], O, R](free: FreeC[F, O, R]): Pull[F, O, R] =
+    new Pull(free.asInstanceOf[FreeC[Nothing, O, R]])
 
   /**
     * Like [[eval]] but if the effectful value fails, the exception is returned in a `Left`
@@ -98,18 +97,18 @@ object Pull extends PullLowPriority {
   def attemptEval[F[_], R](fr: F[R]): Pull[F, INothing, Either[Throwable, R]] =
     fromFreeC(
       Algebra
-        .eval[F, INothing, R](fr)
+        .eval[F, R](fr)
         .map(r => Right(r): Either[Throwable, R])
-        .handleErrorWith(t => Algebra.pure[F, INothing, Either[Throwable, R]](Left(t)))
+        .handleErrorWith(t => Algebra.pure[F, Either[Throwable, R]](Left(t)))
     )
 
   /** The completed `Pull`. Reads and outputs nothing. */
   val done: Pull[Pure, INothing, Unit] =
-    fromFreeC[Pure, INothing, Unit](Algebra.pure[Pure, INothing, Unit](()))
+    fromFreeC[Pure, INothing, Unit](Algebra.pure[Pure, Unit](()))
 
   /** Evaluates the supplied effectful value and returns the result as the resource of the returned pull. */
   def eval[F[_], R](fr: F[R]): Pull[F, INothing, R] =
-    fromFreeC(Algebra.eval[F, INothing, R](fr))
+    fromFreeC(Algebra.eval[F, R](fr))
 
   /**
     * Repeatedly uses the output of the pull as input for the next step of the pull.
@@ -119,7 +118,7 @@ object Pull extends PullLowPriority {
     r => using(r).flatMap { _.map(loop(using)).getOrElse(Pull.pure(None)) }
 
   private def mapOutput[F[_], O, O2, R](p: Pull[F, O, R])(f: O => O2): Pull[F, O2, R] =
-    Pull.fromFreeC(p.get[F, O, R].translate(Algebra.mapOutput(f)))
+    Pull.fromFreeC(p.get[F, O, R].mapOutput(f))
 
   /** Outputs a single value. */
   def output1[F[x] >: Pure[x], O](o: O): Pull[F, O, Unit] =
@@ -131,7 +130,7 @@ object Pull extends PullLowPriority {
 
   /** Pull that outputs nothing and has result of `r`. */
   def pure[F[x] >: Pure[x], R](r: R): Pull[F, INothing, R] =
-    fromFreeC(Algebra.pure(r))
+    fromFreeC[F, INothing, R](Algebra.pure(r))
 
   /**
     * Reads and outputs nothing, and fails with the given error.
@@ -139,7 +138,7 @@ object Pull extends PullLowPriority {
     * The `F` type must be explicitly provided (e.g., via `raiseError[IO]` or `raiseError[Fallible]`).
     */
   def raiseError[F[_]: RaiseThrowable](err: Throwable): Pull[F, INothing, INothing] =
-    new Pull(Algebra.raiseError[Nothing, Nothing](err))
+    new Pull(Algebra.raiseError[Nothing](err))
 
   final class PartiallyAppliedFromEither[F[_]] {
     def apply[A](either: Either[Throwable, A])(implicit ev: RaiseThrowable[F]): Pull[F, A, Unit] =
@@ -185,7 +184,9 @@ object Pull extends PullLowPriority {
       def bracketCase[A, B](acquire: Pull[F, O, A])(
           use: A => Pull[F, O, B]
       )(release: (A, ExitCase[Throwable]) => Pull[F, O, Unit]): Pull[F, O, B] =
-        Pull.fromFreeC(FreeC.bracketCase(acquire.get)(a => use(a).get)((a, c) => release(a, c).get))
+        Pull.fromFreeC(
+          FreeC.bracketCase(acquire.get, (a: A) => use(a).get, (a: A, c) => release(a, c).get)
+        )
     }
 
   /**

--- a/core/shared/src/main/scala/fs2/internal/Algebra.scala
+++ b/core/shared/src/main/scala/fs2/internal/Algebra.scala
@@ -8,27 +8,42 @@ import fs2.internal.FreeC.{Result, ViewL}
 
 import scala.util.control.NonFatal
 
-/* `Algebra[F[_], O, R]` is a Generalised Algebraic Data Type (GADT)
+/* `Eval[F[_], O, R]` is a Generalised Algebraic Data Type (GADT)
  * of atomic instructions that can be evaluated in the effect `F`
  * to generate by-product outputs of type `O`.
  *
  * Each operation also generates an output of type `R` that is used
  * as control information for the rest of the interpretation or compilation.
  */
-private[fs2] sealed trait Algebra[F[_], +O, R]
-
 private[fs2] object Algebra {
 
-  private[this] final case class Output[F[_], O](values: Chunk[O]) extends Algebra[F, O, Unit]
+  private[this] final case class Output[F[_], O](values: Chunk[O]) extends FreeC.Eval[F, O, Unit] {
+    override def mapOutput[P](f: O => P): FreeC[F, P, Unit] =
+      FreeC.suspend {
+        try Output(values.map(f))
+        catch { case NonFatal(t) => Result.Fail[F](t) }
+      }
+  }
 
-  private[this] final case class Step[F[_], X](
-      stream: FreeC[Algebra[F, X, ?], Unit],
-      scope: Option[Token]
-  ) extends Algebra[F, INothing, Option[(Chunk[X], Token, FreeC[Algebra[F, X, ?], Unit])]]
+  /**
+    * Steps through the stream, providing either `uncons` or `stepLeg`.
+    * Yields to head in form of chunk, then id of the scope that was active after step evaluated and tail of the `stream`.
+    *
+    * @param stream             Stream to step
+    * @param scopeId            If scope has to be changed before this step is evaluated, id of the scope must be supplied
+    */
+  private[this] final case class Step[F[_], X](stream: FreeC[F, X, Unit], scope: Option[Token])
+      extends FreeC.Eval[F, INothing, Option[(Chunk[X], Token, FreeC[F, X, Unit])]] {
+    override def mapOutput[P](
+        f: INothing => P
+    ): FreeC[F, P, Option[(Chunk[X], Token, FreeC[F, X, Unit])]] = this
+  }
 
   /* The `AlgEffect` trait is for operations on the `F` effect that create no `O` output.
    * They are related to resources and scopes. */
-  private[this] sealed trait AlgEffect[F[_], R] extends Algebra[F, INothing, R]
+  private[this] sealed abstract class AlgEffect[F[_], R] extends FreeC.Eval[F, INothing, R] {
+    final def mapOutput[P](f: INothing => P): FreeC[F, P, R] = this
+  }
 
   private[this] final case class Eval[F[_], R](value: F[R]) extends AlgEffect[F, R]
 
@@ -49,52 +64,20 @@ private[fs2] object Algebra {
 
   private[this] final case class GetScope[F[_]]() extends AlgEffect[F, CompileScope[F]]
 
-  def output[F[_], O](values: Chunk[O]): FreeC[Algebra[F, O, ?], Unit] =
-    FreeC.Eval[Algebra[F, O, ?], Unit](Output(values))
+  def output[F[_], O](values: Chunk[O]): FreeC[F, O, Unit] = Output(values)
 
-  def output1[F[_], O](value: O): FreeC[Algebra[F, O, ?], Unit] =
-    output(Chunk.singleton(value))
+  def output1[F[_], O](value: O): FreeC[F, O, Unit] = Output(Chunk.singleton(value))
 
-  def eval[F[_], O, R](value: F[R]): FreeC[Algebra[F, O, ?], R] =
-    FreeC.Eval[Algebra[F, O, ?], R](Eval(value))
+  def eval[F[_], R](value: F[R]): FreeC[F, INothing, R] = Eval(value)
 
   def acquire[F[_], O, R](
       resource: F[R],
       release: (R, ExitCase[Throwable]) => F[Unit]
-  ): FreeC[Algebra[F, O, ?], R] =
-    FreeC.Eval[Algebra[F, O, ?], R](Acquire(resource, release))
+  ): FreeC[F, O, R] =
+    Acquire(resource, release)
 
-  def mapOutput[F[_], A, B](fun: A => B): Algebra[F, A, ?] ~> Algebra[F, B, ?] =
-    new (Algebra[F, A, ?] ~> Algebra[F, B, ?]) {
-      def apply[R](alg: Algebra[F, A, R]): Algebra[F, B, R] = alg match {
-        case o: Output[F, A] => Output[F, B](o.values.map(fun))
-        case _               => alg.asInstanceOf[Algebra[F, B, R]]
-      }
-    }
-
-  /**
-    * Steps through the stream, providing either `uncons` or `stepLeg`.
-    * Yields to head in form of chunk, then id of the scope that was active after step evaluated and tail of the `stream`.
-    *
-    * @param stream             Stream to step
-    * @param scopeId            If scope has to be changed before this step is evaluated, id of the scope must be supplied
-    */
-  private def step[F[_], O, X](
-      stream: FreeC[Algebra[F, O, ?], Unit],
-      scopeId: Option[Token]
-  ): FreeC[Algebra[F, X, ?], Option[(Chunk[O], Token, FreeC[Algebra[F, O, ?], Unit])]] =
-    FreeC
-      .Eval[Algebra[F, X, ?], Option[(Chunk[O], Token, FreeC[Algebra[F, O, ?], Unit])]](
-        Step[F, O](stream, scopeId)
-      )
-
-  def stepLeg[F[_], O](
-      leg: Stream.StepLeg[F, O]
-  ): FreeC[Algebra[F, Nothing, ?], Option[Stream.StepLeg[F, O]]] =
-    step[F, O, Nothing](
-      leg.next,
-      Some(leg.scopeId)
-    ).map {
+  def stepLeg[F[_], O](leg: Stream.StepLeg[F, O]): FreeC[F, Nothing, Option[Stream.StepLeg[F, O]]] =
+    Step[F, O](leg.next, Some(leg.scopeId)).map {
       _.map { case (h, id, t) => new Stream.StepLeg[F, O](h, id, t) }
     }
 
@@ -102,7 +85,7 @@ private[fs2] object Algebra {
     * Wraps supplied pull in new scope, that will be opened before this pull is evaluated
     * and closed once this pull either finishes its evaluation or when it fails.
     */
-  def scope[F[_], O](s: FreeC[Algebra[F, O, ?], Unit]): FreeC[Algebra[F, O, ?], Unit] =
+  def scope[F[_], O](s: FreeC[F, O, Unit]): FreeC[F, O, Unit] =
     scope0(s, None)
 
   /**
@@ -110,33 +93,21 @@ private[fs2] object Algebra {
     * Note that this may fail with `Interrupted` when interruption occurred
     */
   private[fs2] def interruptScope[F[_], O](
-      s: FreeC[Algebra[F, O, ?], Unit]
-  )(implicit F: Concurrent[F]): FreeC[Algebra[F, O, ?], Unit] =
+      s: FreeC[F, O, Unit]
+  )(implicit F: Concurrent[F]): FreeC[F, O, Unit] =
     scope0(s, Some(F))
 
-  private[this] def openScope[F[_], O](
-      interruptible: Option[Concurrent[F]]
-  ): FreeC[Algebra[F, O, ?], Token] =
-    FreeC.Eval[Algebra[F, O, ?], Token](OpenScope(interruptible))
-
-  private[fs2] def closeScope[F[_], O](
-      token: Token,
-      interruptedScope: Option[(Token, Option[Throwable])],
-      exitCase: ExitCase[Throwable]
-  ): FreeC[Algebra[F, O, ?], Unit] =
-    FreeC.Eval[Algebra[F, O, ?], Unit](CloseScope(token, interruptedScope, exitCase))
-
   private def scope0[F[_], O](
-      s: FreeC[Algebra[F, O, ?], Unit],
+      s: FreeC[F, O, Unit],
       interruptible: Option[Concurrent[F]]
-  ): FreeC[Algebra[F, O, ?], Unit] =
-    openScope(interruptible).flatMap { scopeId =>
+  ): FreeC[F, O, Unit] =
+    OpenScope(interruptible).flatMap { scopeId =>
       s.transformWith {
-        case Result.Pure(_) => closeScope(scopeId, interruptedScope = None, ExitCase.Completed)
+        case Result.Pure(_) => CloseScope(scopeId, interruptedScope = None, ExitCase.Completed)
         case Result.Interrupted(interruptedScopeId: Token, err) =>
-          closeScope(scopeId, interruptedScope = Some((interruptedScopeId, err)), ExitCase.Canceled)
+          CloseScope(scopeId, interruptedScope = Some((interruptedScopeId, err)), ExitCase.Canceled)
         case Result.Fail(err) =>
-          closeScope(scopeId, interruptedScope = None, ExitCase.Error(err)).transformWith {
+          CloseScope(scopeId, interruptedScope = None, ExitCase.Error(err)).transformWith {
             case Result.Pure(_)    => raiseError(err)
             case Result.Fail(err0) => raiseError(CompositeFailure(err, err0, Nil))
             case Result.Interrupted(interruptedScopeId, _) =>
@@ -149,29 +120,27 @@ private[fs2] object Algebra {
       }
     }
 
-  def getScope[F[_], O]: FreeC[Algebra[F, O, ?], CompileScope[F]] =
-    FreeC.eval[Algebra[F, O, ?], CompileScope[F]](GetScope())
+  def getScope[F[_]]: FreeC[F, INothing, CompileScope[F]] =
+    GetScope()
 
-  def pure[F[_], O, R](r: R): FreeC[Algebra[F, O, ?], R] =
-    FreeC.pure[Algebra[F, O, ?], R](r)
+  def pure[F[_], R](r: R): FreeC[F, INothing, R] =
+    FreeC.pure[F, R](r)
 
-  def raiseError[F[_], O](t: Throwable): FreeC[Algebra[F, O, ?], INothing] =
-    FreeC.raiseError[Algebra[F, O, ?]](t)
+  def raiseError[F[_]](t: Throwable): FreeC[F, INothing, INothing] =
+    FreeC.raiseError(t)
 
   def translate[F[_], G[_], O](
-      s: FreeC[Algebra[F, O, ?], Unit],
+      s: FreeC[F, O, Unit],
       u: F ~> G
-  )(implicit G: TranslateInterrupt[G]): FreeC[Algebra[G, O, ?], Unit] =
+  )(implicit G: TranslateInterrupt[G]): FreeC[G, O, Unit] =
     translate0[F, G, O](u, s, G.concurrentInstance)
 
-  def uncons[F[_], X, O](
-      s: FreeC[Algebra[F, O, ?], Unit]
-  ): FreeC[Algebra[F, X, ?], Option[(Chunk[O], FreeC[Algebra[F, O, ?], Unit])]] =
-    step(s, None).map { _.map { case (h, _, t) => (h, t) } }
+  def uncons[F[_], X, O](s: FreeC[F, O, Unit]): FreeC[F, X, Option[(Chunk[O], FreeC[F, O, Unit])]] =
+    Step(s, None).map { _.map { case (h, _, t) => (h, t) } }
 
   /** Left-folds the output of a stream. */
   def compile[F[_], O, B](
-      stream: FreeC[Algebra[F, O, ?], Unit],
+      stream: FreeC[F, O, Unit],
       scope: CompileScope[F],
       extendLastTopLevelScope: Boolean,
       init: B
@@ -192,7 +161,7 @@ private[fs2] object Algebra {
   private[this] trait CompileCont[F[_], X, Y] {
     final type Out = Y
     def done(scope: CompileScope[F]): F[Y]
-    def out(head: Chunk[X], scope: CompileScope[F], tail: FreeC[Algebra[F, X, ?], Unit]): F[Y]
+    def out(head: Chunk[X], scope: CompileScope[F], tail: FreeC[F, X, Unit]): F[Y]
     def interrupted(scopeId: Token, err: Option[Throwable]): F[Y]
   }
 
@@ -214,31 +183,31 @@ private[fs2] object Algebra {
   private[this] def compileLoop[F[_], O](
       scope: CompileScope[F],
       extendLastTopLevelScope: Boolean,
-      stream: FreeC[Algebra[F, O, ?], Unit]
+      stream: FreeC[F, O, Unit]
   )(
       implicit F: MonadError[F, Throwable]
-  ): F[Option[(Chunk[O], CompileScope[F], FreeC[Algebra[F, O, ?], Unit])]] = {
+  ): F[Option[(Chunk[O], CompileScope[F], FreeC[F, O, Unit])]] = {
 
     def go[X, Res](
         scope: CompileScope[F],
         compileCont: CompileCont[F, X, Res],
         extendedTopLevelScope: Option[CompileScope[F]],
-        stream: FreeC[Algebra[F, X, ?], Unit]
+        stream: FreeC[F, X, Unit]
     ): F[Res] =
       stream.viewL match {
-        case _: FreeC.Result.Pure[Algebra[F, X, ?], Unit] =>
+        case _: FreeC.Result.Pure[F, Unit] =>
           compileCont.done(scope)
 
-        case failed: FreeC.Result.Fail[Algebra[F, X, ?]] =>
+        case failed: FreeC.Result.Fail[F] =>
           F.raiseError(failed.error)
 
-        case interrupted: FreeC.Result.Interrupted[Algebra[F, X, ?], _] =>
+        case interrupted: FreeC.Result.Interrupted[F, _] =>
           interrupted.context match {
             case scopeId: Token => compileCont.interrupted(scopeId, interrupted.deferredError)
             case other          => sys.error(s"Unexpected interruption context: $other (compileLoop)")
           }
 
-        case view: ViewL.View[Algebra[F, X, ?], y, Unit] =>
+        case view: ViewL.View[F, X, y, Unit] =>
           def resume(res: Result[y]): F[Res] =
             go[X, Res](scope, compileCont, extendedTopLevelScope, view.next(res))
 
@@ -269,7 +238,7 @@ private[fs2] object Algebra {
                     def out(
                         head: Chunk[y],
                         outScope: CompileScope[F],
-                        tail: FreeC[Algebra[F, y, ?], Unit]
+                        tail: FreeC[F, y, Unit]
                     ): F[Res] = {
                       // if we originally swapped scopes we want to return the original
                       // scope back to the go as that is the scope that is expected to be here.
@@ -395,12 +364,12 @@ private[fs2] object Algebra {
 
     object CompileEnd
         extends CompileCont[F, O, Option[
-          (Chunk[O], CompileScope[F], FreeC[Algebra[F, O, ?], Unit])
+          (Chunk[O], CompileScope[F], FreeC[F, O, Unit])
         ]] {
 
       def done(scope: CompileScope[F]): F[Out] = F.pure(None)
 
-      def out(head: Chunk[O], scope: CompileScope[F], tail: FreeC[Algebra[F, O, ?], Unit]): F[Out] =
+      def out(head: Chunk[O], scope: CompileScope[F], tail: FreeC[F, O, Unit]): F[Out] =
         F.pure(Some((head, scope, tail)))
 
       def interrupted(scopeId: Token, err: Option[Throwable]): F[Out] =
@@ -425,32 +394,31 @@ private[fs2] object Algebra {
     * @return
     */
   def interruptBoundary[F[_], O](
-      stream: FreeC[Algebra[F, O, ?], Unit],
+      stream: FreeC[F, O, Unit],
       interruptedScope: Token,
       interruptedError: Option[Throwable]
-  ): FreeC[Algebra[F, O, ?], Unit] =
+  ): FreeC[F, O, Unit] =
     stream.viewL match {
-      case _: FreeC.Result.Pure[Algebra[F, O, ?], Unit] =>
+      case _: FreeC.Result.Pure[F, Unit] =>
         FreeC.interrupted(interruptedScope, interruptedError)
-      case failed: FreeC.Result.Fail[Algebra[F, O, ?]] =>
+      case failed: FreeC.Result.Fail[F] =>
         Algebra.raiseError(
           CompositeFailure
             .fromList(interruptedError.toList :+ failed.error)
             .getOrElse(failed.error)
         )
-      case interrupted: FreeC.Result.Interrupted[Algebra[F, O, ?], _] =>
+      case interrupted: FreeC.Result.Interrupted[F, _] =>
         // impossible
         FreeC.interrupted(interrupted.context, interrupted.deferredError)
 
-      case view: ViewL.View[Algebra[F, O, ?], _, Unit] =>
+      case view: ViewL.View[F, O, _, Unit] =>
         view.step match {
           case close: CloseScope[F] =>
-            Algebra
-              .closeScope(
-                close.scopeId,
-                Some((interruptedScope, interruptedError)),
-                ExitCase.Canceled
-              ) // Inner scope is getting closed b/c a parent was interrupted
+            CloseScope(
+              close.scopeId,
+              Some((interruptedScope, interruptedError)),
+              ExitCase.Canceled
+            ) // Inner scope is getting closed b/c a parent was interrupted
               .transformWith(view.next)
           case _ =>
             // all other cases insert interruption cause
@@ -462,25 +430,22 @@ private[fs2] object Algebra {
 
   private def translate0[F[_], G[_], O](
       fK: F ~> G,
-      stream: FreeC[Algebra[F, O, ?], Unit],
+      stream: FreeC[F, O, Unit],
       concurrent: Option[Concurrent[G]]
-  ): FreeC[Algebra[G, O, ?], Unit] = {
+  ): FreeC[G, O, Unit] = {
 
-    def translateStep[X](
-        next: FreeC[Algebra[F, X, ?], Unit],
-        isMainLevel: Boolean
-    ): FreeC[Algebra[G, X, ?], Unit] =
+    def translateStep[X](next: FreeC[F, X, Unit], isMainLevel: Boolean): FreeC[G, X, Unit] =
       next.viewL match {
-        case _: FreeC.Result.Pure[Algebra[F, X, ?], Unit] =>
-          FreeC.pure[Algebra[G, X, ?], Unit](())
+        case _: FreeC.Result.Pure[F, Unit] =>
+          FreeC.pure[G, Unit](())
 
-        case failed: FreeC.Result.Fail[Algebra[F, X, ?]] =>
+        case failed: FreeC.Result.Fail[F] =>
           Algebra.raiseError(failed.error)
 
-        case interrupted: FreeC.Result.Interrupted[Algebra[F, X, ?], _] =>
+        case interrupted: FreeC.Result.Interrupted[F, _] =>
           FreeC.interrupted(interrupted.context, interrupted.deferredError)
 
-        case view: ViewL.View[Algebra[F, X, ?], y, Unit] =>
+        case view: ViewL.View[F, X, y, Unit] =>
           view.step match {
             case output: Output[F, X] =>
               Algebra.output[G, X](output.values).transformWith {
@@ -491,7 +456,7 @@ private[fs2] object Algebra {
                   // Cast is safe here, as at this point the evaluation of this Step will end
                   // and the remainder of the free will be passed as a result in Bind. As such
                   // next Step will have this to evaluate, and will try to translate again.
-                  view.next(r).asInstanceOf[FreeC[Algebra[G, X, ?], Unit]]
+                  view.next(r).asInstanceOf[FreeC[G, X, Unit]]
 
                 case r @ Result.Fail(err) => translateStep(view.next(r), isMainLevel)
 
@@ -499,20 +464,15 @@ private[fs2] object Algebra {
               }
 
             case step: Step[F, x] =>
-              FreeC
-                .Eval[Algebra[G, X, ?], Option[(Chunk[x], Token, FreeC[Algebra[G, x, ?], Unit])]](
-                  Step[G, x](
-                    stream = translateStep[x](step.stream, false),
-                    scope = step.scope
-                  )
-                )
-                .transformWith { r =>
-                  translateStep[X](view.next(r.asInstanceOf[Result[y]]), isMainLevel)
-                }
+              Step[G, x](
+                stream = translateStep[x](step.stream, false),
+                scope = step.scope
+              ).transformWith { r =>
+                translateStep[X](view.next(r.asInstanceOf[Result[y]]), isMainLevel)
+              }
 
             case alg: AlgEffect[F, r] =>
-              FreeC
-                .Eval[Algebra[G, X, ?], r](translateAlgEffect(alg, concurrent, fK))
+              translateAlgEffect(alg, concurrent, fK)
                 .transformWith(r => translateStep(view.next(r), isMainLevel))
 
           }

--- a/core/shared/src/main/scala/fs2/internal/FreeC.scala
+++ b/core/shared/src/main/scala/fs2/internal/FreeC.scala
@@ -1,6 +1,5 @@
 package fs2.internal
 
-import cats.{~>}
 import cats.effect.ExitCase
 import fs2.{CompositeFailure, INothing}
 import FreeC._
@@ -22,11 +21,11 @@ import scala.util.control.NonFatal
   * Typically the [[FreeC]] user provides interpretation of FreeC in form of [[ViewL]] structure, that allows to step
   * FreeC via series of Results ([[Result.Pure]], [[Result.Fail]] and [[Result.Interrupted]]) and FreeC step ([[ViewL.View]])
   */
-private[fs2] sealed abstract class FreeC[F[_], +R] {
+private[fs2] abstract class FreeC[F[_], +O, +R] {
 
-  def flatMap[R2](f: R => FreeC[F, R2]): FreeC[F, R2] =
-    new Bind[F, R, R2](this) {
-      def cont(e: Result[R]): FreeC[F, R2] = e match {
+  def flatMap[O2 >: O, R2](f: R => FreeC[F, O2, R2]): FreeC[F, O2, R2] =
+    new Bind[F, O2, R, R2](this) {
+      def cont(e: Result[R]): FreeC[F, O2, R2] = e match {
         case Result.Pure(r) =>
           try f(r)
           catch { case NonFatal(e) => FreeC.Result.Fail(e) }
@@ -35,30 +34,30 @@ private[fs2] sealed abstract class FreeC[F[_], +R] {
       }
     }
 
-  def append[R2](post: => FreeC[F, R2]): FreeC[F, R2] =
-    new Bind[F, R, R2](this) {
-      def cont(r: Result[R]): FreeC[F, R2] = r match {
+  def append[O2 >: O, R2](post: => FreeC[F, O2, R2]): FreeC[F, O2, R2] =
+    new Bind[F, O2, R, R2](this) {
+      def cont(r: Result[R]): FreeC[F, O2, R2] = r match {
         case r: Result.Pure[F, _]        => post
         case r: Result.Interrupted[F, _] => r
         case r: Result.Fail[F]           => r
       }
     }
 
-  def transformWith[R2](f: Result[R] => FreeC[F, R2]): FreeC[F, R2] =
-    new Bind[F, R, R2](this) {
-      def cont(r: Result[R]): FreeC[F, R2] =
+  def transformWith[O2 >: O, R2](f: Result[R] => FreeC[F, O2, R2]): FreeC[F, O2, R2] =
+    new Bind[F, O2, R, R2](this) {
+      def cont(r: Result[R]): FreeC[F, O2, R2] =
         try f(r)
         catch { case NonFatal(e) => FreeC.Result.Fail(e) }
     }
 
-  def map[R2](f: R => R2): FreeC[F, R2] =
-    new Bind[F, R, R2](this) {
-      def cont(e: Result[R]): FreeC[F, R2] = Result.map(e)(f).asFreeC[F]
+  def map[O2 >: O, R2](f: R => R2): FreeC[F, O2, R2] =
+    new Bind[F, O2, R, R2](this) {
+      def cont(e: Result[R]): FreeC[F, O2, R2] = Result.map(e)(f).asFreeC[F]
     }
 
-  def handleErrorWith[R2 >: R](h: Throwable => FreeC[F, R2]): FreeC[F, R2] =
-    new Bind[F, R2, R2](this) {
-      def cont(e: Result[R2]): FreeC[F, R2] = e match {
+  def handleErrorWith[O2 >: O, R2 >: R](h: Throwable => FreeC[F, O2, R2]): FreeC[F, O2, R2] =
+    new Bind[F, O2, R2, R2](this) {
+      def cont(e: Result[R2]): FreeC[F, O2, R2] = e match {
         case Result.Fail(e) =>
           try h(e)
           catch { case NonFatal(e) => FreeC.Result.Fail(e) }
@@ -66,7 +65,7 @@ private[fs2] sealed abstract class FreeC[F[_], +R] {
       }
     }
 
-  def asHandler(e: Throwable): FreeC[F, R] = ViewL(this) match {
+  def asHandler(e: Throwable): FreeC[F, O, R] = ViewL(this) match {
     case Result.Pure(_)  => Result.Fail(e)
     case Result.Fail(e2) => Result.Fail(CompositeFailure(e2, e))
     case Result.Interrupted(ctx, err) =>
@@ -74,37 +73,28 @@ private[fs2] sealed abstract class FreeC[F[_], +R] {
     case v @ ViewL.View(_) => v.next(Result.Fail(e))
   }
 
-  def viewL[R2 >: R]: ViewL[F, R2] = ViewL(this)
+  def viewL[O2 >: O, R2 >: R]: ViewL[F, O2, R2] = ViewL(this)
 
-  def translate[G[_]](f: F ~> G): FreeC[G, R] = suspend {
-    viewL match {
-      case v: ViewL.View[F, x, R] =>
-        new Bind[G, x, R](Eval(v.step).translate(f)) {
-          def cont(e: Result[x]) = v.next(e).translate(f)
-        }
-      case r @ Result.Pure(_)           => r.asFreeC[G]
-      case r @ Result.Fail(_)           => r.asFreeC[G]
-      case r @ Result.Interrupted(_, _) => r.asFreeC[G]
-    }
-  }
+  def mapOutput[P](f: O => P): FreeC[F, P, R]
 }
 
 private[fs2] object FreeC {
 
-  def unit[F[_]]: FreeC[F, Unit] = Result.unit.asFreeC
+  def unit[F[_]]: FreeC[F, INothing, Unit] = Result.unit.asFreeC
 
-  def pure[F[_], A](a: A): FreeC[F, A] = Result.Pure(a)
+  def pure[F[_], A](a: A): FreeC[F, INothing, A] = Result.Pure(a)
 
-  def eval[F[_], A](f: F[A]): FreeC[F, A] = Eval(f)
+  def raiseError[F[_]](rsn: Throwable): FreeC[F, INothing, INothing] = Result.Fail(rsn)
 
-  def raiseError[F[_]](rsn: Throwable): FreeC[F, INothing] = Result.Fail(rsn)
-
-  def interrupted[F[_], X](interruptContext: X, failure: Option[Throwable]): FreeC[F, INothing] =
+  def interrupted[F[_], X](
+      interruptContext: X,
+      failure: Option[Throwable]
+  ): FreeC[F, INothing, INothing] =
     Result.Interrupted(interruptContext, failure)
 
   sealed trait Result[+R] { self =>
 
-    def asFreeC[F[_]]: FreeC[F, R] = self.asInstanceOf[FreeC[F, R]]
+    def asFreeC[F[_]]: FreeC[F, INothing, R] = self.asInstanceOf[FreeC[F, INothing, R]]
 
     def asExitCase: ExitCase[Throwable] = self match {
       case Result.Pure(_)           => ExitCase.Completed
@@ -112,6 +102,13 @@ private[fs2] object FreeC {
       case Result.Interrupted(_, _) => ExitCase.Canceled
     }
 
+  }
+
+  sealed abstract class ResultC[F[_], +R]
+      extends FreeC[F, INothing, R]
+      with ViewL[F, INothing, R]
+      with Result[R] {
+    override def mapOutput[P](f: INothing => P): FreeC[F, P, R] = this
   }
 
   object Result {
@@ -128,25 +125,18 @@ private[fs2] object FreeC {
     def fromEither[R](either: Either[Throwable, R]): Result[R] =
       either.fold(Result.Fail(_), Result.Pure(_))
 
-    def unapply[F[_], R](freeC: FreeC[F, R]): Option[Result[R]] = freeC match {
+    def unapply[F[_], R](freeC: FreeC[F, _, R]): Option[Result[R]] = freeC match {
       case r @ Result.Pure(_)           => Some(r: Result[R])
       case r @ Result.Fail(_)           => Some(r: Result[R])
       case r @ Result.Interrupted(_, _) => Some(r: Result[R])
       case _                            => None
     }
 
-    final case class Pure[F[_], R](r: R) extends FreeC[F, R] with Result[R] with ViewL[F, R] {
-      override def translate[G[_]](f: F ~> G): FreeC[G, R] =
-        this.asInstanceOf[FreeC[G, R]]
+    final case class Pure[F[_], R](r: R) extends ResultC[F, R] {
       override def toString: String = s"FreeC.Pure($r)"
     }
 
-    final case class Fail[F[_]](error: Throwable)
-        extends FreeC[F, INothing]
-        with Result[INothing]
-        with ViewL[F, INothing] {
-      override def translate[G[_]](f: F ~> G): FreeC[G, INothing] =
-        this.asInstanceOf[FreeC[G, INothing]]
+    final case class Fail[F[_]](error: Throwable) extends ResultC[F, INothing] {
       override def toString: String = s"FreeC.Fail($error)"
     }
 
@@ -161,82 +151,84 @@ private[fs2] object FreeC {
       *                      signalling of the errors may be deferred until the Interruption resumes.
       */
     final case class Interrupted[F[_], X](context: X, deferredError: Option[Throwable])
-        extends FreeC[F, INothing]
-        with Result[INothing]
-        with ViewL[F, INothing] {
-      override def translate[G[_]](f: F ~> G): FreeC[G, INothing] =
-        this.asInstanceOf[FreeC[G, INothing]]
+        extends ResultC[F, INothing] {
       override def toString: String =
         s"FreeC.Interrupted($context, ${deferredError.map(_.getMessage)})"
     }
 
     private[FreeC] def map[A, B](fa: Result[A])(f: A => B): Result[B] = fa match {
       case Result.Pure(r) =>
-        try {
-          Result.Pure(f(r))
-        } catch { case NonFatal(err) => Result.Fail(err) }
+        try Result.Pure(f(r))
+        catch { case NonFatal(err) => Result.Fail(err) }
       case failure @ Result.Fail(_)               => failure.asInstanceOf[Result[B]]
       case interrupted @ Result.Interrupted(_, _) => interrupted.asInstanceOf[Result[B]]
     }
 
   }
 
-  final case class Eval[F[_], R](fr: F[R]) extends FreeC[F, R] {
-    override def translate[G[_]](f: F ~> G): FreeC[G, R] =
-      suspend {
-        try Eval(f(fr))
-        catch { case NonFatal(t) => Result.Fail[G](t) }
-      }
-    override def toString: String = s"FreeC.Eval($fr)"
-  }
+  abstract class Eval[F[_], +O, +R] extends FreeC[F, O, R]
 
-  abstract class Bind[F[_], X, R](val step: FreeC[F, X]) extends FreeC[F, R] {
-    def cont(r: Result[X]): FreeC[F, R]
-    def delegate: Bind[F, X, R] = this
+  abstract class Bind[F[_], O, X, R](val step: FreeC[F, O, X]) extends FreeC[F, O, R] {
+    def cont(r: Result[X]): FreeC[F, O, R]
+    def delegate: Bind[F, O, X, R] = this
+
+    override def mapOutput[P](f: O => P): FreeC[F, P, R] = suspend {
+      viewL match {
+        case v: ViewL.View[F, O, x, R] =>
+          new Bind[F, P, x, R](v.step.mapOutput(f)) {
+            def cont(e: Result[x]) = v.next(e).mapOutput(f)
+          }
+        case r @ Result.Pure(_)           => r
+        case r @ Result.Fail(_)           => r
+        case r @ Result.Interrupted(_, _) => r
+      }
+    }
+
     override def toString: String = s"FreeC.Bind($step)"
   }
 
-  def suspend[F[_], R](fr: => FreeC[F, R]): FreeC[F, R] =
-    new Bind[F, Unit, R](unit[F]) {
-      def cont(r: Result[Unit]): FreeC[F, R] = fr
+  def suspend[F[_], O, R](fr: => FreeC[F, O, R]): FreeC[F, O, R] =
+    new Bind[F, O, Unit, R](unit[F]) {
+      def cont(r: Result[Unit]): FreeC[F, O, R] = fr
     }
 
   /**
     * Unrolled view of a `FreeC` structure. may be `Result` or `EvalBind`
     */
-  sealed trait ViewL[F[_], +R]
+  sealed trait ViewL[F[_], +O, +R]
 
   object ViewL {
 
     /** unrolled view of FreeC `bind` structure **/
-    sealed abstract case class View[F[_], X, R](step: F[X]) extends ViewL[F, R] {
-      def next(r: Result[X]): FreeC[F, R]
+    sealed abstract case class View[F[_], O, X, R](step: Eval[F, O, X]) extends ViewL[F, O, R] {
+      def next(r: Result[X]): FreeC[F, O, R]
     }
 
-    private[ViewL] final class EvalView[F[_], R](step: F[R]) extends View[F, R, R](step) {
-      def next(r: Result[R]): FreeC[F, R] = r.asFreeC[F]
+    private[ViewL] final class EvalView[F[_], O, R](step: Eval[F, O, R])
+        extends View[F, O, R, R](step) {
+      def next(r: Result[R]): FreeC[F, O, R] = r.asFreeC[F]
     }
 
-    private[fs2] def apply[F[_], R](free: FreeC[F, R]): ViewL[F, R] = mk(free)
+    private[fs2] def apply[F[_], O, R](free: FreeC[F, O, R]): ViewL[F, O, R] = mk(free)
 
     @tailrec
-    private def mk[F[_], Z](free: FreeC[F, Z]): ViewL[F, Z] =
+    private def mk[F[_], O, Z](free: FreeC[F, O, Z]): ViewL[F, O, Z] =
       free match {
-        case e: Eval[F, Z] => new EvalView[F, Z](e.fr)
-        case b: FreeC.Bind[F, y, Z] =>
+        case e: Eval[F, O, Z] => new EvalView[F, O, Z](e)
+        case b: FreeC.Bind[F, O, y, Z] =>
           b.step match {
             case Result(r) => mk(b.cont(r))
-            case Eval(fr) =>
-              new ViewL.View[F, y, Z](fr) {
-                def next(r: Result[y]): FreeC[F, Z] = b.cont(r)
+            case e: FreeC.Eval[F, O, y] =>
+              new ViewL.View[F, O, y, Z](e) {
+                def next(r: Result[y]): FreeC[F, O, Z] = b.cont(r)
               }
-            case bb: FreeC.Bind[F, x, _] =>
-              val nb = new Bind[F, x, Z](bb.step) {
-                private[this] val bdel: Bind[F, y, Z] = b.delegate
-                def cont(zr: Result[x]): FreeC[F, Z] =
-                  new Bind[F, y, Z](bb.cont(zr)) {
-                    override val delegate: Bind[F, y, Z] = bdel
-                    def cont(yr: Result[y]): FreeC[F, Z] = delegate.cont(yr)
+            case bb: FreeC.Bind[F, O, x, _] =>
+              val nb = new Bind[F, O, x, Z](bb.step) {
+                private[this] val bdel: Bind[F, O, y, Z] = b.delegate
+                def cont(zr: Result[x]): FreeC[F, O, Z] =
+                  new Bind[F, O, y, Z](bb.cont(zr)) {
+                    override val delegate: Bind[F, O, y, Z] = bdel
+                    def cont(yr: Result[y]): FreeC[F, O, Z] = delegate.cont(yr)
                   }
               }
               mk(nb)
@@ -248,9 +240,11 @@ private[fs2] object FreeC {
 
   }
 
-  def bracketCase[F[_], A, B](
-      acquire: FreeC[F, A]
-  )(use: A => FreeC[F, B])(release: (A, ExitCase[Throwable]) => FreeC[F, Unit]): FreeC[F, B] =
+  def bracketCase[F[_], O, A, B](
+      acquire: FreeC[F, O, A],
+      use: A => FreeC[F, O, B],
+      release: (A, ExitCase[Throwable]) => FreeC[F, O, Unit]
+  ): FreeC[F, O, B] =
     acquire.flatMap { a =>
       val used =
         try use(a)


### PR DESCRIPTION
Continuation of https://github.com/functional-streams-for-scala/fs2/pull/1598, which was automatically closed by Github  due to the deletion of the `series/1.1` branch.

------------------

This unifies the two ADT in the internal stream implementation: `FreeC[F[_], R]`, the Free monad with catch and interruption; and `Algebra[F[_], O, R]`, for the scope-handling and output instructions. These are combined using the approximate type aliae of `PullF, O, R]` as `FreeC[Algebra[F, O, ?], R]`. Notably, an object of type `Algebra[F, O, R]` can only appear in a FreeC through the `FreeC.Eval` class. This allows us to unify these two ADTs by doing the following:

- Add an output parameter `O` (stream output) to the `FreeC` ADT, and its subclasses; as well as to the `ViewL` trait (for unrolling).
- Turn `FreeC.Eval` into an abstract class that replaces the previous `Algebra` trait, so that all subclasses of Algebra become subclasses of `FreeC.Eval`. Because FreeC and Algebra ADTs are in separate files, we unseal it. 
- We replace the `ViewL` subclasses from containing a `F[R]` to containing an `Eval[F, R]`. 

As a result, a Pull is no longer an alias for `FreeC[Algebra[F, O, ?], Unit]`, but for `FreeC[F, O, R]` instead. 

With the previous 2-layered representation, there was a need to have in the `Algebra` object a few methods to lift simple data and fill the type parameters. With the new representations, those methods are not needed and we can remove them in favour of the object they build. That is the case of the private methods `openScope` and `step`.  



#### Translate to mapOutput

Before this change, the implementation of Stream[F, A].map[B](f: A => B) had to work at two levels: one being a `FunctionK` between two type-instances of Algebra, which would differ on the output type. To apply this transformation through the Stream, the `FreeC` ADT had a `translate` method. After the changes, now we do not need that `FunctionK` wrapper, and we can just replace the translate method of FreeC with a mapOutput method. 