### PR TITLE
Algebra: open visibility of Algebra subclasses 

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/FreeCBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/FreeCBenchmark.scala
@@ -16,7 +16,7 @@ class FreeCBenchmark {
   @Benchmark
   def nestedMaps = {
     val nestedMapsFreeC =
-      (0 to N).foldLeft(FreeC.pure[IO, Int](0): FreeC[IO, INothing, Int]) { (acc, i) =>
+      (0 to N).foldLeft(Result.Pure[IO, Int](0): FreeC[IO, INothing, Int]) { (acc, i) =>
         acc.map(_ + i)
       }
     run(nestedMapsFreeC)
@@ -25,8 +25,8 @@ class FreeCBenchmark {
   @Benchmark
   def nestedFlatMaps = {
     val nestedFlatMapsFreeC =
-      (0 to N).foldLeft(FreeC.pure[IO, Int](0): FreeC[IO, INothing, Int]) { (acc, i) =>
-        acc.flatMap(j => FreeC.pure(i + j))
+      (0 to N).foldLeft(Result.Pure[IO, Int](0): FreeC[IO, INothing, Int]) { (acc, i) =>
+        acc.flatMap(j => Result.Pure(i + j))
       }
     run(nestedFlatMapsFreeC)
   }


### PR DESCRIPTION
The subclasses of Algebra, like Output, Eval, or Acquire,
were private to the Algebra object, but that is private to fs2.

Since we no longer have the nested types, we can remove and unfold
the internal factory methods, and just call the case classes.