### PR TITLE
Benchmarks: add recent memory leak

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/StreamBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/StreamBenchmark.scala
@@ -8,6 +8,11 @@ import java.util.concurrent.TimeUnit
 @State(Scope.Thread)
 class StreamBenchmark {
 
+  @GenerateN(1, 10, 100, 1000, 10000, 1000000, 10000000)
+  @Benchmark
+  def rangeFold(N: Int): Option[Long] =
+    Stream.range(0, N).fold(0L)(_ + _.toLong).compile.last
+
   @GenerateN(1, 10, 100, 1000, 10000, 100000)
   @Benchmark
   def leftAssocConcat(N: Int): Int =


### PR DESCRIPTION
There recently was a memory leak https://github.com/functional-streams-for-scala/fs2/issues/1625 introduced by some changes to the `compileLoop` method. We add as a benchmark the core part of that memory leak, in order to guide future development.
