### PR TITLE
Add `evalFilterNot` and `evalFilterNotAsync`

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1039,6 +1039,26 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Nothing, O, Unit]
     }.flatten
 
   /**
+   * Like `filterNot`, but allows filtering based on an effect.
+   *
+   * Note: The result Stream will consist of chunks that are empty or 1-element-long.
+   * If you want to operate on chunks after using it, consider buffering, e.g. by using [[buffer]].
+   */
+  def evalFilterNot[F2[x] >: F[x]: Functor](f: O => F2[Boolean]): Stream[F2, O] =
+    flatMap(o => Stream.eval(f(o)).ifM(Stream.empty, Stream.emit(o)))
+
+  /**
+   * Like `filterNot`, but allows filtering based on an effect, with up to [[maxConcurrent]] concurrently running effects.
+   * The ordering of emitted elements is unchanged.
+   */
+  def evalFilterNotAsync[F2[x] >: F[x]: Concurrent](
+    maxConcurrent: Int
+  )(f: O => F2[Boolean]): Stream[F2, O] =
+    parEvalMap[F2, Stream[F2, O]](maxConcurrent) { o =>
+      f(o).map(if (_) Stream.empty else Stream.emit(o))
+    }.flatten
+
+  /**
     * Like `filter`, but the predicate `f` depends on the previously emitted and
     * current elements.
     *


### PR DESCRIPTION
A recent PR #1619 added `evalFilter` and `evalFilterAsync`, here I'm added their cousins `evalFilterNot` and `evalFilterNotAsync`.

This is an optimisations instead of doing something like
```
_.evalFilter(foo.map(!_))
```
we simply do the more obvious
```
_.evalFilterNot(foo)
```

Only issue I see is the name of `evalFilterNotAsync` being bad. But it's follows the same pattern so not sure what else to call it...

P.S. I am expecting the tests to fail on this first commit. Specifically hoping only one of them fails and I'll fix it once it does.