### PR TITLE
Stream.range: add benchmark and improve implementation

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/StreamBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/StreamBenchmark.scala
@@ -8,6 +8,11 @@ import java.util.concurrent.TimeUnit
 @State(Scope.Thread)
 class StreamBenchmark {
 
+  @GenerateN(1, 4096, 665536, 67108863)
+  @Benchmark
+  def rangeFold(N: Int): Option[Long] =
+    Stream.range(0, N).fold(0L)(_ + _.toLong).compile.last
+
   @GenerateN(1, 10, 100, 1000, 10000, 100000)
   @Benchmark
   def leftAssocConcat(N: Int): Int =

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3401,13 +3401,14 @@ object Stream extends StreamLowPriority {
     * res0: List[Int] = List(10, 12, 14, 16, 18)
     * }}}
     */
-  def range[F[x] >: Pure[x]](start: Int, stopExclusive: Int, by: Int = 1): Stream[F, Int] =
-    unfold(start) { i =>
+  def range[F[x] >: Pure[x]](start: Int, stopExclusive: Int, by: Int = 1): Stream[F, Int] = {
+    def go(i: Int): Stream[F, Int] =
       if ((by > 0 && i < stopExclusive && start < stopExclusive) ||
           (by < 0 && i > stopExclusive && start > stopExclusive))
-        Some((i, i + by))
-      else None
-    }
+        emit(i) ++ go(i + by)
+      else empty
+    go(start)
+  }
 
   /**
     * Lazily produce a sequence of nonoverlapping ranges, where each range


### PR DESCRIPTION
Some changes involving the `Stream.range` factory method: 

- We introduced a small benchmark that involves creating a Stream of integers,  using the `range` operation, and then folding that Stream by adding those numbers. 
- We change the implementation of `Stream.range` to avoid using `unfold`, which is  too general (wide) for what we need in the `range` method. 

We have measured the results of this improvement with the given benchmark, using the command `jmh:run -f 1 -i 8 -wi 4 .*StreamBenchmark*. -prof gc`, and they show a reduction in memory allocation (`gc.alloc.rate.norm`) going from 2.5% for the small case `N=1`, to 4.2% for the `N=4096` case, and up to 5.2% for the large case `N=67108863`.


