### PR TITLE
Drop support for Scala 2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: scala
 
 scala:
-  - 2.11.12
   - 2.12.9
   - 2.13.0
 
@@ -29,7 +28,7 @@ script:
   - sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 -Dfs2.test.travis testJVM
   - sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 -Dfs2.test.travis testJS
   - sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 doc mimaReportBinaryIssues
-  - (test $TRAVIS_SCALA_VERSION == "2.11.12" && sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 -J-Xms2g -J-Xmx2g docs/tut) || test $TRAVIS_SCALA_VERSION == "2.12.9" || test $TRAVIS_SCALA_VERSION == "2.13.0"
+  - (test $TRAVIS_SCALA_VERSION == "2.12.9" && sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 -J-Xms2g -J-Xmx2g docs/tut) || test $TRAVIS_SCALA_VERSION == "2.13.0"
 
 after_success:
   - test $PUBLISH == "true" && test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "series/2.0" && GPG_WARN_ON_FAILURE=true sbt +publish

--- a/build.sbt
+++ b/build.sbt
@@ -34,8 +34,6 @@ lazy val commonSettings = Seq(
         List("-Xlint", "-Ywarn-unused")
       case v if v.startsWith("2.12") =>
         List("-Ypartial-unification")
-      case v if v.startsWith("2.11") =>
-        List("-Xexperimental", "-Ypartial-unification")
       case other => sys.error(s"Unsupported scala version: $other")
     }),
   scalacOptions in (Compile, console) ~= {


### PR DESCRIPTION
Lightbend released the last version of Scala 2.11 almost two years ago, and both `cats` and `cats-effect` are also dropping it.

https://github.com/typelevel/cats-effect/pull/713
https://github.com/typelevel/cats-effect/issues/667
https://github.com/typelevel/cats/pull/3051