### PR TITLE
Optimise Chunk.concat

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/ChunkBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/ChunkBenchmark.scala
@@ -1,0 +1,42 @@
+package fs2
+package benchmark
+
+import cats.effect.IO
+import org.openjdk.jmh.annotations.{
+  Benchmark,
+  BenchmarkMode,
+  Mode,
+  OutputTimeUnit,
+  Param,
+  Scope,
+  Setup,
+  State
+}
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Thread)
+class ChunkBenchmark {
+  @Param(Array("16", "256", "4096"))
+  var chunkSize: Int = _
+
+  @Param(Array("1", "20", "50", "100"))
+  var chunkCount: Int = _
+
+  case class Obj(dummy: Boolean)
+  object Obj {
+    def create: Obj = Obj(true)
+  }
+
+  var chunkSeq: Seq[Chunk[Obj]] = _
+  var sizeHint: Int = _
+
+  @Setup
+  def setup() = {
+    chunkSeq = Seq.range(0, chunkCount).map(_ => Chunk.seq(Seq.fill(chunkSize)(Obj.create)))
+    sizeHint = chunkSeq.foldLeft(0)(_ + _.size)
+  }
+    
+  @Benchmark
+  def concat(): Unit =
+    Chunk.concat(chunkSeq, sizeHint)
+}

--- a/benchmark/src/main/scala/fs2/benchmark/ChunkBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/ChunkBenchmark.scala
@@ -1,18 +1,7 @@
 package fs2
 package benchmark
 
-import cats.effect.IO
-import org.openjdk.jmh.annotations.{
-  Benchmark,
-  BenchmarkMode,
-  Mode,
-  OutputTimeUnit,
-  Param,
-  Scope,
-  Setup,
-  State
-}
-import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations.{Benchmark, Param, Scope, Setup, State}
 
 @State(Scope.Thread)
 class ChunkBenchmark {

--- a/benchmark/src/main/scala/fs2/benchmark/ChunkBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/ChunkBenchmark.scala
@@ -35,7 +35,7 @@ class ChunkBenchmark {
     chunkSeq = Seq.range(0, chunkCount).map(_ => Chunk.seq(Seq.fill(chunkSize)(Obj.create)))
     sizeHint = chunkSeq.foldLeft(0)(_ + _.size)
   }
-    
+
   @Benchmark
   def concat(): Unit =
     Chunk.concat(chunkSeq, sizeHint)

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -1347,7 +1347,7 @@ object Chunk extends CollectorK[Chunk] {
   def chars(values: Array[Char]): Chunk[Char] =
     Chars(values, 0, values.length)
 
-  /** Creates a chunk backed by a subsequence of an array of doubles. */
+  /** Creates a chunk backed by a subsequence of an array of chars. */
   def chars(values: Array[Char], offset: Int, length: Int): Chunk[Char] =
     Chars(values, offset, length)
 

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -1383,11 +1383,10 @@ object Chunk extends CollectorK[Chunk] {
   }
 
   /** Concatenates the specified sequence of chunks in to a single chunk, avoiding boxing. */
-  def concat[A](chunks: GSeq[Chunk[A]]): Chunk[A] = {
+  def concat[A](chunks: GSeq[Chunk[A]]): Chunk[A] =
     concat(chunks, chunks.foldLeft(0)(_ + _.size))
-  }
 
-  def concat[A](chunks: GSeq[Chunk[A]], totalSize: Int): Chunk[A] = 
+  def concat[A](chunks: GSeq[Chunk[A]], totalSize: Int): Chunk[A] =
     if (chunks.isEmpty) {
       Chunk.empty
     } else if (chunks.forall(c => c.knownElementType[Boolean] || c.forall(_.isInstanceOf[Boolean]))) {
@@ -1418,7 +1417,7 @@ object Chunk extends CollectorK[Chunk] {
 
   /** Concatenates the specified sequence of boolean chunks in to a single chunk. */
   def concatBooleans(chunks: GSeq[Chunk[Boolean]]): Chunk[Boolean] =
-    concatBooleans(chunks, chunks.foldLeft(0)(_ + _.size))    
+    concatBooleans(chunks, chunks.foldLeft(0)(_ + _.size))
 
   def concatBooleans(chunks: GSeq[Chunk[Boolean]], totalSize: Int): Chunk[Boolean] =
     if (chunks.isEmpty) Chunk.empty

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -1383,37 +1383,47 @@ object Chunk extends CollectorK[Chunk] {
   }
 
   /** Concatenates the specified sequence of chunks in to a single chunk, avoiding boxing. */
-  def concat[A](chunks: GSeq[Chunk[A]]): Chunk[A] =
+  def concat[A](chunks: GSeq[Chunk[A]]): Chunk[A] = {
+    concat(chunks, chunks.foldLeft(0)(_ + _.size))
+  }
+
+  def concat[A](chunks: GSeq[Chunk[A]], totalSize: Int): Chunk[A] = 
     if (chunks.isEmpty) {
       Chunk.empty
     } else if (chunks.forall(c => c.knownElementType[Boolean] || c.forall(_.isInstanceOf[Boolean]))) {
-      concatBooleans(chunks.asInstanceOf[GSeq[Chunk[Boolean]]]).asInstanceOf[Chunk[A]]
+      concatBooleans(chunks.asInstanceOf[GSeq[Chunk[Boolean]]], totalSize).asInstanceOf[Chunk[A]]
     } else if (chunks.forall(c => c.knownElementType[Byte] || c.forall(_.isInstanceOf[Byte]))) {
-      concatBytes(chunks.asInstanceOf[GSeq[Chunk[Byte]]]).asInstanceOf[Chunk[A]]
+      concatBytes(chunks.asInstanceOf[GSeq[Chunk[Byte]]], totalSize).asInstanceOf[Chunk[A]]
     } else if (chunks.forall(c => c.knownElementType[Float] || c.forall(_.isInstanceOf[Float]))) {
-      concatFloats(chunks.asInstanceOf[GSeq[Chunk[Float]]]).asInstanceOf[Chunk[A]]
+      concatFloats(chunks.asInstanceOf[GSeq[Chunk[Float]]], totalSize).asInstanceOf[Chunk[A]]
     } else if (chunks.forall(c => c.knownElementType[Double] || c.forall(_.isInstanceOf[Double]))) {
-      concatDoubles(chunks.asInstanceOf[GSeq[Chunk[Double]]]).asInstanceOf[Chunk[A]]
+      concatDoubles(chunks.asInstanceOf[GSeq[Chunk[Double]]], totalSize).asInstanceOf[Chunk[A]]
     } else if (chunks.forall(c => c.knownElementType[Short] || c.forall(_.isInstanceOf[Short]))) {
-      concatShorts(chunks.asInstanceOf[GSeq[Chunk[Short]]]).asInstanceOf[Chunk[A]]
+      concatShorts(chunks.asInstanceOf[GSeq[Chunk[Short]]], totalSize).asInstanceOf[Chunk[A]]
     } else if (chunks.forall(c => c.knownElementType[Int] || c.forall(_.isInstanceOf[Int]))) {
-      concatInts(chunks.asInstanceOf[GSeq[Chunk[Int]]]).asInstanceOf[Chunk[A]]
+      concatInts(chunks.asInstanceOf[GSeq[Chunk[Int]]], totalSize).asInstanceOf[Chunk[A]]
     } else if (chunks.forall(c => c.knownElementType[Long] || c.forall(_.isInstanceOf[Long]))) {
-      concatLongs(chunks.asInstanceOf[GSeq[Chunk[Long]]]).asInstanceOf[Chunk[A]]
+      concatLongs(chunks.asInstanceOf[GSeq[Chunk[Long]]], totalSize).asInstanceOf[Chunk[A]]
     } else {
-      val size = chunks.foldLeft(0)(_ + _.size)
-      val b = collection.mutable.Buffer.newBuilder[A]
-      b.sizeHint(size)
-      chunks.foreach(c => c.foreach(a => b += a))
-      Chunk.buffer(b.result)
+      val arr = new Array[Any](totalSize)
+      var offset = 0
+      chunks.foreach { c =>
+        if (!c.isEmpty) {
+          c.copyToArray(arr, offset)
+          offset += c.size
+        }
+      }
+      Chunk.boxed(arr.asInstanceOf[Array[A]])
     }
 
   /** Concatenates the specified sequence of boolean chunks in to a single chunk. */
   def concatBooleans(chunks: GSeq[Chunk[Boolean]]): Chunk[Boolean] =
+    concatBooleans(chunks, chunks.foldLeft(0)(_ + _.size))    
+
+  def concatBooleans(chunks: GSeq[Chunk[Boolean]], totalSize: Int): Chunk[Boolean] =
     if (chunks.isEmpty) Chunk.empty
     else {
-      val size = chunks.foldLeft(0)(_ + _.size)
-      val arr = new Array[Boolean](size)
+      val arr = new Array[Boolean](totalSize)
       var offset = 0
       chunks.foreach { c =>
         if (!c.isEmpty) {
@@ -1426,10 +1436,12 @@ object Chunk extends CollectorK[Chunk] {
 
   /** Concatenates the specified sequence of byte chunks in to a single chunk. */
   def concatBytes(chunks: GSeq[Chunk[Byte]]): Chunk[Byte] =
+    concatBytes(chunks, chunks.foldLeft(0)(_ + _.size))
+
+  def concatBytes(chunks: GSeq[Chunk[Byte]], totalSize: Int): Chunk[Byte] =
     if (chunks.isEmpty) Chunk.empty
     else {
-      val size = chunks.foldLeft(0)(_ + _.size)
-      val arr = new Array[Byte](size)
+      val arr = new Array[Byte](totalSize)
       var offset = 0
       chunks.foreach { c =>
         if (!c.isEmpty) {
@@ -1442,10 +1454,12 @@ object Chunk extends CollectorK[Chunk] {
 
   /** Concatenates the specified sequence of float chunks in to a single chunk. */
   def concatFloats(chunks: GSeq[Chunk[Float]]): Chunk[Float] =
+    concatFloats(chunks, chunks.foldLeft(0)(_ + _.size))
+
+  def concatFloats(chunks: GSeq[Chunk[Float]], totalSize: Int): Chunk[Float] =
     if (chunks.isEmpty) Chunk.empty
     else {
-      val size = chunks.foldLeft(0)(_ + _.size)
-      val arr = new Array[Float](size)
+      val arr = new Array[Float](totalSize)
       var offset = 0
       chunks.foreach { c =>
         if (!c.isEmpty) {
@@ -1458,10 +1472,12 @@ object Chunk extends CollectorK[Chunk] {
 
   /** Concatenates the specified sequence of double chunks in to a single chunk. */
   def concatDoubles(chunks: GSeq[Chunk[Double]]): Chunk[Double] =
+    concatDoubles(chunks, chunks.foldLeft(0)(_ + _.size))
+
+  def concatDoubles(chunks: GSeq[Chunk[Double]], totalSize: Int): Chunk[Double] =
     if (chunks.isEmpty) Chunk.empty
     else {
-      val size = chunks.foldLeft(0)(_ + _.size)
-      val arr = new Array[Double](size)
+      val arr = new Array[Double](totalSize)
       var offset = 0
       chunks.foreach { c =>
         if (!c.isEmpty) {
@@ -1474,10 +1490,12 @@ object Chunk extends CollectorK[Chunk] {
 
   /** Concatenates the specified sequence of short chunks in to a single chunk. */
   def concatShorts(chunks: GSeq[Chunk[Short]]): Chunk[Short] =
+    concatShorts(chunks, chunks.foldLeft(0)(_ + _.size))
+
+  def concatShorts(chunks: GSeq[Chunk[Short]], totalSize: Int): Chunk[Short] =
     if (chunks.isEmpty) Chunk.empty
     else {
-      val size = chunks.foldLeft(0)(_ + _.size)
-      val arr = new Array[Short](size)
+      val arr = new Array[Short](totalSize)
       var offset = 0
       chunks.foreach { c =>
         if (!c.isEmpty) {
@@ -1490,10 +1508,12 @@ object Chunk extends CollectorK[Chunk] {
 
   /** Concatenates the specified sequence of int chunks in to a single chunk. */
   def concatInts(chunks: GSeq[Chunk[Int]]): Chunk[Int] =
+    concatInts(chunks, chunks.foldLeft(0)(_ + _.size))
+
+  def concatInts(chunks: GSeq[Chunk[Int]], totalSize: Int): Chunk[Int] =
     if (chunks.isEmpty) Chunk.empty
     else {
-      val size = chunks.foldLeft(0)(_ + _.size)
-      val arr = new Array[Int](size)
+      val arr = new Array[Int](totalSize)
       var offset = 0
       chunks.foreach { c =>
         if (!c.isEmpty) {
@@ -1506,10 +1526,12 @@ object Chunk extends CollectorK[Chunk] {
 
   /** Concatenates the specified sequence of long chunks in to a single chunk. */
   def concatLongs(chunks: GSeq[Chunk[Long]]): Chunk[Long] =
+    concatLongs(chunks, chunks.foldLeft(0)(_ + _.size))
+
+  def concatLongs(chunks: GSeq[Chunk[Long]], totalSize: Int): Chunk[Long] =
     if (chunks.isEmpty) Chunk.empty
     else {
-      val size = chunks.foldLeft(0)(_ + _.size)
-      val arr = new Array[Long](size)
+      val arr = new Array[Long](totalSize)
       var offset = 0
       chunks.foreach { c =>
         if (!c.isEmpty) {
@@ -1694,7 +1716,7 @@ object Chunk extends CollectorK[Chunk] {
     def dropRight(n: Int): Queue[A] = if (n <= 0) this else take(size - n)
 
     /** Converts this chunk queue to a single chunk, copying all chunks to a single chunk. */
-    def toChunk: Chunk[A] = Chunk.concat(chunks)
+    def toChunk: Chunk[A] = Chunk.concat(chunks, size)
 
     override def equals(that: Any): Boolean = that match {
       case that: Queue[A] => size == that.size && chunks == that.chunks

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -1343,7 +1343,7 @@ object Chunk extends CollectorK[Chunk] {
       Doubles(values, 0, values.length)
   }
 
-  /** Creates a chunk backed by an array of doubles. */
+  /** Creates a chunk backed by an array of chars. */
   def chars(values: Array[Char]): Chunk[Char] =
     Chars(values, 0, values.length)
 
@@ -1387,7 +1387,7 @@ object Chunk extends CollectorK[Chunk] {
   }
   object Chars {
     def apply(values: Array[Char]): Chars =
-    Chars(values, 0, values.length)
+      Chars(values, 0, values.length)
   }
 
   /** Creates a chunk backed by a byte vector. */

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2,7 +2,7 @@ package fs2
 
 import cats.{Eval => _, _}
 import cats.arrow.FunctionK
-import cats.data.{Chain, NonEmptyList}
+import cats.data.Chain
 import cats.effect._
 import cats.effect.concurrent._
 import cats.effect.implicits._


### PR DESCRIPTION
I ran `jmh:run -i 3 -wi 3 -f1 -t1 fs2.benchmark.ChunkBenchmark` for benchmarking.

I tried three options:
- before (current implementation)
- after (concatting done via `Array[Any]`)
- sizeHint (concatting done via `Array[Any]` + a `totalSize` parameter that avoids doing the `foldLeft` to determine the total size)

Here are the results:
```
before
[info] Benchmark              (chunkCount)  (chunkSize)   Mode  Cnt        Score        Error  Units
[info] ChunkBenchmark.concat             1           16  thrpt    3  3284142.155 ± 126490.513  ops/s
[info] ChunkBenchmark.concat             1          256  thrpt    3   473260.526 ±   7160.038  ops/s
[info] ChunkBenchmark.concat             1         4096  thrpt    3    32789.284 ±   1017.692  ops/s
[info] ChunkBenchmark.concat            20           16  thrpt    3   340847.264 ±   9499.195  ops/s
[info] ChunkBenchmark.concat            20          256  thrpt    3    24935.817 ±   1613.729  ops/s
[info] ChunkBenchmark.concat            20         4096  thrpt    3     1220.534 ±    493.120  ops/s
[info] ChunkBenchmark.concat            50           16  thrpt    3   126833.000 ±   3212.293  ops/s
[info] ChunkBenchmark.concat            50          256  thrpt    3     8982.511 ±    358.815  ops/s
[info] ChunkBenchmark.concat            50         4096  thrpt    3      430.554 ±     10.007  ops/s
[info] ChunkBenchmark.concat           100           16  thrpt    3    73317.013 ±   2234.364  ops/s
[info] ChunkBenchmark.concat           100          256  thrpt    3     4441.279 ±    413.893  ops/s
[info] ChunkBenchmark.concat           100         4096  thrpt    3      214.331 ±      4.257  ops/s
[info] ChunkBenchmark.concat          2000            1  thrpt    3    44618.582 ±    137.189  ops/s

after
[info] Benchmark              (chunkCount)  (chunkSize)   Mode  Cnt        Score        Error  Units
[info] ChunkBenchmark.concat             1           16  thrpt    3  3756793.938 ±  96298.642  ops/s
[info] ChunkBenchmark.concat             1          256  thrpt    3   726011.970 ±  38789.971  ops/s
[info] ChunkBenchmark.concat             1         4096  thrpt    3    50393.746 ±   1812.333  ops/s
[info] ChunkBenchmark.concat            20           16  thrpt    3   604061.751 ± 158657.113  ops/s
[info] ChunkBenchmark.concat            20          256  thrpt    3    44660.055 ±  17961.989  ops/s
[info] ChunkBenchmark.concat            20         4096  thrpt    3     2965.940 ±    699.276  ops/s
[info] ChunkBenchmark.concat            50           16  thrpt    3   320287.385 ±  13561.885  ops/s
[info] ChunkBenchmark.concat            50          256  thrpt    3    23875.315 ±   1041.319  ops/s
[info] ChunkBenchmark.concat            50         4096  thrpt    3      713.254 ±     18.094  ops/s
[info] ChunkBenchmark.concat           100           16  thrpt    3   163875.550 ±   3890.070  ops/s
[info] ChunkBenchmark.concat           100          256  thrpt    3    12110.938 ±    500.191  ops/s
[info] ChunkBenchmark.concat           100         4096  thrpt    3      349.634 ±      3.853  ops/s
[info] ChunkBenchmark.concat          2000            1  thrpt    3    62588.931 ±    357.599  ops/s

sizeHint
[info] Benchmark              (chunkCount)  (chunkSize)   Mode  Cnt        Score        Error  Units
[info] ChunkBenchmark.concat             1           16  thrpt    3  4109142.224 ± 232218.964  ops/s
[info] ChunkBenchmark.concat             1          256  thrpt    3   998124.583 ±  43709.896  ops/s
[info] ChunkBenchmark.concat             1         4096  thrpt    3    71019.438 ±   4468.760  ops/s
[info] ChunkBenchmark.concat            20           16  thrpt    3   602900.476 ±  29613.950  ops/s
[info] ChunkBenchmark.concat            20          256  thrpt    3    41592.014 ±    233.699  ops/s
[info] ChunkBenchmark.concat            20         4096  thrpt    3     2713.213 ±    354.821  ops/s
[info] ChunkBenchmark.concat            50           16  thrpt    3   339112.519 ±  18307.706  ops/s
[info] ChunkBenchmark.concat            50          256  thrpt    3    19158.766 ±     83.844  ops/s
[info] ChunkBenchmark.concat            50         4096  thrpt    3      573.971 ±     27.628  ops/s
[info] ChunkBenchmark.concat           100           16  thrpt    3   174644.854 ±   8583.491  ops/s
[info] ChunkBenchmark.concat           100          256  thrpt    3    11933.488 ±    157.509  ops/s
[info] ChunkBenchmark.concat           100         4096  thrpt    3      351.364 ±      3.730  ops/s
[info] ChunkBenchmark.concat          2000            1  thrpt    3    99242.645 ±   9539.513  ops/s
```

As @ChristopherDavenport  pointed out, caveat to this PR is that it's unclear how `Array[Any]` looks like in memory. If it just becomes `Array[Object]` then all's good (as you can see `A` already been determined to be a boxed object).