### PR TITLE
Use preallocated array instead of mutable.Buffer in more places

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/StreamBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/StreamBenchmark.scala
@@ -92,4 +92,24 @@ class StreamBenchmark {
   @Benchmark @BenchmarkMode(Array(Mode.AverageTime)) @OutputTimeUnit(TimeUnit.NANOSECONDS)
   def emitsThenFlatMap(N: Int): Vector[Int] =
     Stream.emits(0 until N).flatMap(Stream(_)).toVector
+
+  @GenerateN(1, 10, 100, 1000, 10000)
+  @Benchmark
+  def sliding(N: Int) =
+    Stream.emits(0 until 16384).sliding(N).covary[IO].compile.drain.unsafeRunSync
+
+  @GenerateN(1, 10, 100, 1000, 10000)
+  @Benchmark
+  def mapAccumulate(N: Int) =
+    Stream
+      .emits(0 until N)
+      .mapAccumulate(0) {
+        case (acc, i) =>
+          val added = acc + i
+          (added, added)
+      }
+      .covary[IO]
+      .compile
+      .drain
+      .unsafeRunSync
 }


### PR DESCRIPTION
Sort of related to the previous PR (#1712)

Benchmark results:
```
sliding before
[info] Benchmark                       Mode  Cnt     Score     Error  Units
[info] StreamBenchmark.sliding_1      thrpt    3  2896.600 ± 125.799  ops/s
[info] StreamBenchmark.sliding_10     thrpt    3  2642.172 ± 102.039  ops/s
[info] StreamBenchmark.sliding_100    thrpt    3  2576.285 ±  30.050  ops/s
[info] StreamBenchmark.sliding_1000   thrpt    3  2488.486 ±  50.568  ops/s
[info] StreamBenchmark.sliding_10000  thrpt    3  2119.792 ± 102.849  ops/s

sliding after
[info] Benchmark                       Mode  Cnt     Score     Error  Units
[info] StreamBenchmark.sliding_1      thrpt    3  3234.381 ±  85.597  ops/s
[info] StreamBenchmark.sliding_10     thrpt    3  2853.583 ± 140.551  ops/s
[info] StreamBenchmark.sliding_100    thrpt    3  2811.535 ±  56.962  ops/s
[info] StreamBenchmark.sliding_1000   thrpt    3  2684.175 ± 127.533  ops/s
[info] StreamBenchmark.sliding_10000  thrpt    3  3045.157 ±  40.876  ops/s

mapAcc before
[info] Benchmark                             Mode  Cnt       Score       Error  Units
[info] StreamBenchmark.mapAccumulate_1      thrpt    3  536956.507 ±  8650.424  ops/s
[info] StreamBenchmark.mapAccumulate_10     thrpt    3  516126.127 ± 10377.290  ops/s
[info] StreamBenchmark.mapAccumulate_100    thrpt    3  317047.218 ±  5501.061  ops/s
[info] StreamBenchmark.mapAccumulate_1000   thrpt    3   64845.439 ±   492.479  ops/s
[info] StreamBenchmark.mapAccumulate_10000  thrpt    3    6908.020 ±   724.561  ops/s

mapAcc after
[info] Benchmark                             Mode  Cnt       Score       Error  Units
[info] StreamBenchmark.mapAccumulate_1      thrpt    3  531419.735 ± 10382.319  ops/s
[info] StreamBenchmark.mapAccumulate_10     thrpt    3  518652.422 ±  9754.697  ops/s
[info] StreamBenchmark.mapAccumulate_100    thrpt    3  370000.808 ±  8565.782  ops/s
[info] StreamBenchmark.mapAccumulate_1000   thrpt    3   78581.402 ±  1441.846  ops/s
[info] StreamBenchmark.mapAccumulate_10000  thrpt    3    8735.529 ±    34.278  ops/s
```

There are a couple more places where we could use `Array` instead of `mutable.Buffer`, but some aren't good candidates, like `filter` and `collect` since they can return a smaller Chunk than the current one, hence pre-allocating an array the size of the current Chunk would be wasteful and probably a leak?

I think we can also apply a similar optimisation for `Chunk.flatMap` but it's slightly more tricky and seems like a very uncommonly used function, at least in the fs2 codebase (only `Stream.repartition` uses it).