### PR TITLE
Fixed #1709 - .to(Collector) syntax fix for 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -207,7 +207,10 @@ lazy val mimaSettings = Seq(
     // No bincompat on internal package
     ProblemFilters.exclude[Problem]("fs2.internal.*"),
     // Mima reports all ScalaSignature changes as errors, despite the fact that they don't cause bincompat issues when version swapping (see https://github.com/lightbend/mima/issues/361)
-    ProblemFilters.exclude[IncompatibleSignatureProblem]("*")
+    ProblemFilters.exclude[IncompatibleSignatureProblem]("*"),
+    // .to(sink) syntax was removed in 1.0.2 and has been hidden in all 2.x releases behind private[fs2], hence it's safe to remove
+    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.Stream.to"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.Stream.to$extension")
   )
 )
 

--- a/core/shared/src/main/scala/fs2/Collector.scala
+++ b/core/shared/src/main/scala/fs2/Collector.scala
@@ -12,9 +12,6 @@ import scodec.bits.ByteVector
   *
   * The companion object provides implicit conversions (methods starting with `supports`),
   * which adapts various collections to the `Collector` trait.
-  *
-  * The output type is a type member instead of a type parameter to avoid overloading
-  * resolution limitations with `s.compile.to[C]` vs `s.compile.to(C)`.
   */
 trait Collector[-A] {
   type Out

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -3729,7 +3729,7 @@ object Stream extends StreamLowPriority {
     @inline private def to_(c: Collector[O]): c.Out =
       self.covary[SyncIO].compile.to(c).unsafeRunSync
 
-    /** Runs this pure stream and returns the emitted elements in a collection of the specified type. Note: this method is only available on pure streams. */
+    // TODO Delete this in 3.0
     private[Stream] def to[C[_]](implicit f: Factory[O, C[O]]): C[O] = to_(f)
 
     /** Runs this pure stream and returns the emitted elements in a chunk. Note: this method is only available on pure streams. */
@@ -3788,7 +3788,7 @@ object Stream extends StreamLowPriority {
     @inline private def to_(c: Collector[O]): Either[Throwable, c.Out] =
       lift[SyncIO].compile.to(c).attempt.unsafeRunSync
 
-    /** Runs this fallible stream and returns the emitted elements in a collection of the specified type. Note: this method is only available on fallible streams. */
+    // TODO Delete this in 3.0
     private[Stream] def to[C[_]](implicit f: Factory[O, C[O]]): Either[Throwable, C[O]] = to_(f)
 
     /** Runs this fallible stream and returns the emitted elements in a chunk. Note: this method is only available on fallible streams. */
@@ -4469,13 +4469,7 @@ object Stream extends StreamLowPriority {
     @inline private def to_(collector: Collector[O]): G[collector.Out] =
       compiler(self, () => collector.newBuilder)((acc, c) => { acc += c; acc }, _.result)
 
-    /**
-      * Compiles this stream into a value of the target effect type `F` by logging
-      * the output values to a `C`, given a `Factory`.
-      *
-      * When this method has returned, the stream has not begun execution -- this method simply
-      * compiles the stream down to the target effect type.
-      */
+    // TODO Delete this in 3.0
     private[Stream] def to[C[_]](implicit f: Factory[O, C[O]]): G[C[O]] = to_(f)
 
     /**

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2637,13 +2637,6 @@ final class Stream[+F[_], +O] private (private val free: FreeC[Nothing, O, Unit]
     f(this, s2)
 
   /**
-    * Applies the given sink to this stream.
-    */
-  @deprecated("Use .through instead", "1.0.2")
-  private[fs2] def to[F2[x] >: F[x]](f: Stream[F, O] => Stream[F2, Unit]): Stream[F2, Unit] =
-    f(this)
-
-  /**
     * Translates effect type from `F` to `G` using the supplied `FunctionK`.
     *
     * Note: the resulting stream is *not* interruptible in all cases. To get an interruptible
@@ -3737,7 +3730,7 @@ object Stream extends StreamLowPriority {
       self.covary[SyncIO].compile.to(c).unsafeRunSync
 
     /** Runs this pure stream and returns the emitted elements in a collection of the specified type. Note: this method is only available on pure streams. */
-    def to[C[_]](implicit f: Factory[O, C[O]]): C[O] = to_(f)
+    private[Stream] def to[C[_]](implicit f: Factory[O, C[O]]): C[O] = to_(f)
 
     /** Runs this pure stream and returns the emitted elements in a chunk. Note: this method is only available on pure streams. */
     @deprecated("2.0.2", "Use .to(Chunk) instead")
@@ -3796,7 +3789,7 @@ object Stream extends StreamLowPriority {
       lift[SyncIO].compile.to(c).attempt.unsafeRunSync
 
     /** Runs this fallible stream and returns the emitted elements in a collection of the specified type. Note: this method is only available on fallible streams. */
-    def to[C[_]](implicit f: Factory[O, C[O]]): Either[Throwable, C[O]] = to_(f)
+    private[Stream] def to[C[_]](implicit f: Factory[O, C[O]]): Either[Throwable, C[O]] = to_(f)
 
     /** Runs this fallible stream and returns the emitted elements in a chunk. Note: this method is only available on fallible streams. */
     @deprecated("2.0.2", "Use .to(Chunk) instead")
@@ -4483,7 +4476,7 @@ object Stream extends StreamLowPriority {
       * When this method has returned, the stream has not begun execution -- this method simply
       * compiles the stream down to the target effect type.
       */
-    def to[C[_]](implicit f: Factory[O, C[O]]): G[C[O]] = to_(f)
+    private[Stream] def to[C[_]](implicit f: Factory[O, C[O]]): G[C[O]] = to_(f)
 
     /**
       * Compiles this stream in to a value of the target effect type `F` by logging

--- a/core/shared/src/main/scala/fs2/concurrent/Balance.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Balance.scala
@@ -33,7 +33,7 @@ object Balance {
     * {{{
     *   Stream(1,2,3,4).balance.map { worker =>
     *     worker.map(_.toString)
-    *   }.take(3).parJoinUnbounded.compile.to[Set].unsafeRunSync
+    *   }.take(3).parJoinUnbounded.compile.to(Set).unsafeRunSync
     * }}}
     *
     *

--- a/core/shared/src/test/scala/fs2/CompilationTest.scala
+++ b/core/shared/src/test/scala/fs2/CompilationTest.scala
@@ -1,4 +1,6 @@
-package fs2
+package notfs2
+
+import fs2._
 
 import cats.{Applicative, Id}
 import cats.effect.{ContextShift, IO, Resource, Timer}
@@ -86,4 +88,8 @@ object ThisModuleShouldCompile {
   val pure: List[Int] = Stream.range(0, 5).compile.toList
   val io: IO[List[Int]] = Stream.range(0, 5).covary[IO].compile.toList
   val resource: Resource[IO, List[Int]] = Stream.range(0, 5).covary[IO].compile.resource.toList
+
+  // Ensure that .to(Collector) syntax works even when target type is known (regression #1709)
+  val z: List[Int] = Stream.range(0, 5).compile.to(List)
+  Stream.empty[Id].covaryOutput[Byte].compile.to(Chunk): Chunk[Byte]
 }

--- a/io/src/test/scala/fs2/io/IoSpec.scala
+++ b/io/src/test/scala/fs2/io/IoSpec.scala
@@ -37,7 +37,7 @@ class IoSpec extends Fs2Spec {
         readOutputStream[IO](blocker, chunkSize)((os: OutputStream) =>
           blocker.delay[IO, Unit](os.write(bytes))
         ).compile
-          .to[Array]
+          .to(Array)
           .asserting(_ shouldEqual bytes)
       }
     }


### PR DESCRIPTION
`.to` was overloaded -- one took the `Collector` and the other took an implicit factory. When the target type was known, the 2.12 compiler was picking the factory overload. To fix, I removed the old overload -- or rather, made it `private[Stream]` so that it cannot be called but it stays around for binary compatibility reasons.

Note that in practice, any `s.compile.to[C]` can be written as `s.compile.to(C)` b/c `Collector` can be implicitly instantiated from any `Factory`. Only case where that's not true is when `C` doesn't implement `Factory` directly and instead, there's some implicit factory in scope.