### PR TITLE
Stream/Pull Internals: purge fromFreeC/get converters.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -205,6 +205,16 @@ lazy val mimaSettings = Seq(
     }.toSet
   },
   mimaBinaryIssueFilters ++= Seq(
+    // These methods were only used internally between Stream and Pull: they were private to fs2.
+    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.Stream.fromFreeC"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.Stream.get$extension"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.Stream#IdOps.self$extension"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.Pull.get$extension"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.Pull.get"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.Stream.get$extension"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.Stream.get"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.Pull.fromFreeC"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.Pull.get$extension"),
     // No bincompat on internal package
     ProblemFilters.exclude[Problem]("fs2.internal.*"),
     // Mima reports all ScalaSignature changes as errors, despite the fact that they don't cause bincompat issues when version swapping (see https://github.com/lightbend/mima/issues/361)

--- a/core/jvm/src/main/scala/fs2/compress.scala
+++ b/core/jvm/src/main/scala/fs2/compress.scala
@@ -250,9 +250,9 @@ object compress {
                 }
 
               if (len > 0)
-                Stream.chunk(Chunk.bytes(inner, 0, len)).covary[F] ++ stepDecompress
+                Stream.chunk(Chunk.bytes(inner, 0, len)) ++ stepDecompress
               else
-                Stream.empty[F]
+                Stream.empty
             }
 
             // Note: It is possible for this to fail with a non-progressive error

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -24,16 +24,15 @@ import fs2.internal.Algebra.Eval
   * `raiseError` is caught by `handleErrorWith`:
   *   - `handleErrorWith(raiseError(e))(f) == f(e)`
   */
-final class Pull[+F[_], +O, +R] private (private[fs2] val free: FreeC[F, O, R]) extends AnyVal {
-  private[fs2] def get[F2[x] >: F[x], O2 >: O, R2 >: R]: FreeC[F2, O2, R2] =
-    free
+final class Pull[+F[_], +O, +R] private[fs2] (private[fs2] val free: FreeC[F, O, R])
+    extends AnyVal {
 
   /** Alias for `_.map(_ => o2)`. */
   def as[R2](r2: R2): Pull[F, O, R2] = map(_ => r2)
 
   /** Returns a pull with the result wrapped in `Right`, or an error wrapped in `Left` if the pull has failed. */
   def attempt: Pull[F, O, Either[Throwable, R]] =
-    Pull.fromFreeC(get[F, O, R].map(r => Right(r)).handleErrorWith(t => Result.Pure(Left(t))))
+    new Pull(free.map(r => Right(r)).handleErrorWith(t => Result.Pure(Left(t))))
 
   /**
     * Interpret this `Pull` to produce a `Stream`.
@@ -43,12 +42,12 @@ final class Pull[+F[_], +O, +R] private (private[fs2] val free: FreeC[F, O, R]) 
     */
   def stream(implicit ev: R <:< Unit): Stream[F, O] = {
     val _ = ev
-    Stream.fromFreeC(this.asInstanceOf[Pull[F, O, Unit]].get)
+    new Stream(free.asInstanceOf[FreeC[F, O, Unit]])
   }
 
   /** Applies the resource of this pull to `f` and returns the result. */
   def flatMap[F2[x] >: F[x], O2 >: O, R2](f: R => Pull[F2, O2, R2]): Pull[F2, O2, R2] =
-    Pull.fromFreeC(get[F2, O2, R].flatMap(r => f(r).get))
+    new Pull(free.flatMap(r => f(r).free))
 
   /** Alias for `flatMap(_ => p2)`. */
   def >>[F2[x] >: F[x], O2 >: O, R2](p2: => Pull[F2, O2, R2]): Pull[F2, O2, R2] =
@@ -67,10 +66,10 @@ final class Pull[+F[_], +O, +R] private (private[fs2] val free: FreeC[F, O, R]) 
   def covaryResource[R2 >: R]: Pull[F, O, R2] = this
 
   /** Applies the resource of this pull to `f` and returns the result in a new `Pull`. */
-  def map[R2](f: R => R2): Pull[F, O, R2] = Pull.fromFreeC(get.map(f))
+  def map[R2](f: R => R2): Pull[F, O, R2] = new Pull(free.map(f))
 
   /** Applies the outputs of this pull to `f` and returns the result in a new `Pull`. */
-  def mapOutput[O2](f: O => O2): Pull[F, O2, R] = Pull.mapOutput(this)(f)
+  def mapOutput[O2](f: O => O2): Pull[F, O2, R] = new Pull(free.mapOutput(f))
 
   /** Run `p2` after `this`, regardless of errors during `this`, then reraise any errors encountered during `this`. */
   def onComplete[F2[x] >: F[x], O2 >: O, R2 >: R](p2: => Pull[F2, O2, R2]): Pull[F2, O2, R2] =
@@ -80,22 +79,20 @@ final class Pull[+F[_], +O, +R] private (private[fs2] val free: FreeC[F, O, R]) 
   def handleErrorWith[F2[x] >: F[x], O2 >: O, R2 >: R](
       h: Throwable => Pull[F2, O2, R2]
   ): Pull[F2, O2, R2] =
-    Pull.fromFreeC(get[F2, O2, R2].handleErrorWith(e => h(e).get))
+    new Pull(free.handleErrorWith(e => h(e).free))
 
   /** Discards the result type of this pull. */
   def void: Pull[F, O, Unit] = as(())
 }
 
 object Pull extends PullLowPriority {
-  @inline private[fs2] def fromFreeC[F[_], O, R](free: FreeC[F, O, R]): Pull[F, O, R] =
-    new Pull(free.asInstanceOf[FreeC[Nothing, O, R]])
 
   /**
     * Like [[eval]] but if the effectful value fails, the exception is returned in a `Left`
     * instead of failing the pull.
     */
   def attemptEval[F[_], R](fr: F[R]): Pull[F, INothing, Either[Throwable, R]] =
-    fromFreeC(
+    new Pull(
       Eval[F, R](fr)
         .map(r => Right(r): Either[Throwable, R])
         .handleErrorWith(t => Result.Pure[Either[Throwable, R]](Left(t)))
@@ -107,7 +104,7 @@ object Pull extends PullLowPriority {
 
   /** Evaluates the supplied effectful value and returns the result as the resource of the returned pull. */
   def eval[F[_], R](fr: F[R]): Pull[F, INothing, R] =
-    fromFreeC(Eval[F, R](fr))
+    new Pull(Eval[F, R](fr))
 
   /**
     * Repeatedly uses the output of the pull as input for the next step of the pull.
@@ -116,20 +113,17 @@ object Pull extends PullLowPriority {
   def loop[F[_], O, R](using: R => Pull[F, O, Option[R]]): R => Pull[F, O, Option[R]] =
     r => using(r).flatMap { _.map(loop(using)).getOrElse(Pull.pure(None)) }
 
-  private def mapOutput[F[_], O, O2, R](p: Pull[F, O, R])(f: O => O2): Pull[F, O2, R] =
-    Pull.fromFreeC(p.get[F, O, R].mapOutput(f))
-
   /** Outputs a single value. */
   def output1[F[x] >: Pure[x], O](o: O): Pull[F, O, Unit] =
     new Pull(Algebra.output1[O](o))
 
   /** Outputs a chunk of values. */
   def output[F[x] >: Pure[x], O](os: Chunk[O]): Pull[F, O, Unit] =
-    if (os.isEmpty) Pull.done else fromFreeC(Algebra.Output[O](os))
+    if (os.isEmpty) Pull.done else new Pull(Algebra.Output[O](os))
 
   /** Pull that outputs nothing and has result of `r`. */
   def pure[F[x] >: Pure[x], R](r: R): Pull[F, INothing, R] =
-    fromFreeC[F, INothing, R](Result.Pure(r))
+    new Pull(Result.Pure(r))
 
   /**
     * Reads and outputs nothing, and fails with the given error.
@@ -162,7 +156,7 @@ object Pull extends PullLowPriority {
     * allowing use of a mutable value in pull computations.
     */
   def suspend[F[x] >: Pure[x], O, R](p: => Pull[F, O, R]): Pull[F, O, R] =
-    fromFreeC(FreeC.suspend(p.get))
+    new Pull(FreeC.suspend(p.free))
 
   /** `Sync` instance for `Pull`. */
   implicit def syncInstance[F[_], O](
@@ -183,8 +177,8 @@ object Pull extends PullLowPriority {
       def bracketCase[A, B](acquire: Pull[F, O, A])(
           use: A => Pull[F, O, B]
       )(release: (A, ExitCase[Throwable]) => Pull[F, O, Unit]): Pull[F, O, B] =
-        Pull.fromFreeC(
-          FreeC.bracketCase(acquire.get, (a: A) => use(a).get, (a: A, c) => release(a, c).get)
+        new Pull(
+          FreeC.bracketCase(acquire.free, (a: A) => use(a).free, (a: A, c) => release(a, c).free)
         )
     }
 

--- a/core/shared/src/test/scala/fs2/StreamSpec.scala
+++ b/core/shared/src/test/scala/fs2/StreamSpec.scala
@@ -217,7 +217,7 @@ class StreamSpec extends Fs2Spec {
           IO.suspend {
             var o: Vector[Int] = Vector.empty
             (0 until 10)
-              .foldLeft(Stream.emit(1).map(_ => throw new Err).covaryAll[IO, Int]) { (acc, i) =>
+              .foldLeft(Stream.emit(1).map(_ => throw new Err): Stream[IO, Int]) { (acc, i) =>
                 Stream.emit(i) ++ Stream.bracket(IO(i))(i => IO { o = o :+ i }).flatMap(_ => acc)
               }
               .attempt


### PR DESCRIPTION
The internal methods `fromFreeC` and `get` of Pull and Stream were needed at first to convert between the wrapped `FreeC` and them. This conversion was needed due to the difference between `FreeC` invariant type-parameter `F[_]`, and Stream/Pull covariant `+F[_]`. Now that `FreeC` is also covariant on F[_], we can drop these converters. Also, a few uses of `covary` and extra type parameters can be simplified as well.

Since these methods were private to fs2, but not entirely private, it turns out that Mima detects them as missing methods. We have to mark them as exceptions in the build