### PR TITLE
Rename some of the Classes of FreeC/Algebra.

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/FreeCBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/FreeCBenchmark.scala
@@ -15,7 +15,7 @@ class FreeCBenchmark {
   @Benchmark
   def nestedMaps = {
     val nestedMapsFreeC =
-      (0 to N).foldLeft(Result.Pure[Int](0): FreeC[IO, INothing, Int]) { (acc, i) =>
+      (0 to N).foldLeft(Result.Value[Int](0): FreeC[IO, INothing, Int]) { (acc, i) =>
         acc.map(_ + i)
       }
     run(nestedMapsFreeC)
@@ -24,8 +24,8 @@ class FreeCBenchmark {
   @Benchmark
   def nestedFlatMaps = {
     val nestedFlatMapsFreeC =
-      (0 to N).foldLeft(Result.Pure[Int](0): FreeC[IO, INothing, Int]) { (acc, i) =>
-        acc.flatMap(j => Result.Pure(i + j))
+      (0 to N).foldLeft(Result.Value[Int](0): FreeC[IO, INothing, Int]) { (acc, i) =>
+        acc.flatMap(j => Result.Value(i + j))
       }
     run(nestedFlatMapsFreeC)
   }
@@ -34,7 +34,7 @@ class FreeCBenchmark {
       self: FreeC[F, O, R]
   )(implicit F: MonadError[F, Throwable]): F[Option[R]] =
     self.viewL match {
-      case Result.Pure(r)             => F.pure(Some(r))
+      case Result.Value(r)            => F.pure(Some(r))
       case Result.Fail(e)             => F.raiseError(e)
       case Result.Interrupted(_, err) => err.fold[F[Option[R]]](F.pure(None)) { F.raiseError }
       case _ @ViewL.View(_)           => F.raiseError(new RuntimeException("Never get here)"))

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -32,7 +32,7 @@ final class Pull[+F[_], +O, +R] private[fs2] (private[fs2] val free: FreeC[F, O,
 
   /** Returns a pull with the result wrapped in `Right`, or an error wrapped in `Left` if the pull has failed. */
   def attempt: Pull[F, O, Either[Throwable, R]] =
-    new Pull(free.map(r => Right(r)).handleErrorWith(t => Result.Pure(Left(t))))
+    new Pull(free.map(r => Right(r)).handleErrorWith(t => Result.Value(Left(t))))
 
   /**
     * Interpret this `Pull` to produce a `Stream`.
@@ -95,7 +95,7 @@ object Pull extends PullLowPriority {
     new Pull(
       Eval[F, R](fr)
         .map(r => Right(r): Either[Throwable, R])
-        .handleErrorWith(t => Result.Pure[Either[Throwable, R]](Left(t)))
+        .handleErrorWith(t => Result.Value[Either[Throwable, R]](Left(t)))
     )
 
   /** The completed `Pull`. Reads and outputs nothing. */
@@ -123,7 +123,7 @@ object Pull extends PullLowPriority {
 
   /** Pull that outputs nothing and has result of `r`. */
   def pure[F[x] >: Pure[x], R](r: R): Pull[F, INothing, R] =
-    new Pull(Result.Pure(r))
+    new Pull(Result.Value(r))
 
   /**
     * Reads and outputs nothing, and fails with the given error.

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1170,7 +1170,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val free: FreeC[F, O, U
     new Stream(Algebra.uncons(free).flatMap {
       case Some((hd, tl)) =>
         tl match {
-          case FreeC.Result.Pure(_) if hd.size == 1 =>
+          case FreeC.Result.Value(_) if hd.size == 1 =>
             // nb: If tl is Pure, there's no need to propagate flatMap through the tail. Hence, we
             // check if hd has only a single element, and if so, process it directly instead of folding.
             // This allows recursive infinite streams of the form `def s: Stream[Pure,O] = Stream(o).flatMap { _ => s }`
@@ -1181,7 +1181,7 @@ final class Stream[+F[_], +O] private[fs2] (private[fs2] val free: FreeC[F, O, U
               if (idx == hd.size) new Stream(tl).flatMap(f).free
               else {
                 f(hd(idx)).free.transformWith {
-                  case Result.Pure(_)   => go(idx + 1)
+                  case Result.Value(_)  => go(idx + 1)
                   case Result.Fail(err) => Result.Fail(err)
                   case Result.Interrupted(scopeId: Token, err) =>
                     new Stream(Algebra.interruptBoundary(tl, scopeId, err)).flatMap(f).free


### PR DESCRIPTION
- We rename the "Result.Pure" class, which just wraps a value of the
  type `R`, to `Result.Value`, because it's just a value of type R.

- We rename the `Eval` class, which takes an `F[R]` into an `R`,
  as Lift: we are lifting an effect-ful `F[R]` into the "Stream"