### PR TITLE
Fixed ClassCastException in Chunk#toArray, fixes #1745

### DIFF
--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -247,9 +247,6 @@ abstract class Chunk[+O] extends Serializable { self =>
     arr
   }
 
-  /** Returns the elements of this chunk as an array, avoiding a copy if possible. */
-  protected[fs2] def toArrayUnsafe[O2 >: O: ClassTag]: Array[O2] = toArray
-
   /**
     * Converts this chunk to a `Chunk.Booleans`, allowing access to the underlying array of elements.
     * If this chunk is already backed by an unboxed array of booleans, this method runs in constant time.
@@ -679,10 +676,6 @@ object Chunk extends CollectorK[Chunk] {
     def size = length
     def apply(i: Int) = values(offset + i)
 
-    protected[fs2] override def toArrayUnsafe[O2 >: O: ClassTag]: Array[O2] =
-      if (offset == 0 && length == values.length) values.asInstanceOf[Array[O2]]
-      else values.slice(offset, length).asInstanceOf[Array[O2]]
-
     def copyToArray[O2 >: O](xs: Array[O2], start: Int): Unit =
       if (xs.isInstanceOf[Array[AnyRef]])
         System.arraycopy(values, offset, xs, start, length)
@@ -722,10 +715,6 @@ object Chunk extends CollectorK[Chunk] {
     def size = length
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
-
-    protected[fs2] override def toArrayUnsafe[O2 >: Boolean: ClassTag]: Array[O2] =
-      if (offset == 0 && length == values.length) values.asInstanceOf[Array[O2]]
-      else values.slice(offset, length).asInstanceOf[Array[O2]]
 
     def copyToArray[O2 >: Boolean](xs: Array[O2], start: Int): Unit =
       if (xs.isInstanceOf[Array[Boolean]])
@@ -768,10 +757,6 @@ object Chunk extends CollectorK[Chunk] {
     def size = length
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
-
-    protected[fs2] override def toArrayUnsafe[O2 >: Byte: ClassTag]: Array[O2] =
-      if (offset == 0 && length == values.length) values.asInstanceOf[Array[O2]]
-      else values.slice(offset, length).asInstanceOf[Array[O2]]
 
     def copyToArray[O2 >: Byte](xs: Array[O2], start: Int): Unit =
       if (xs.isInstanceOf[Array[Byte]])
@@ -1126,10 +1111,6 @@ object Chunk extends CollectorK[Chunk] {
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
 
-    protected[fs2] override def toArrayUnsafe[O2 >: Short: ClassTag]: Array[O2] =
-      if (offset == 0 && length == values.length) values.asInstanceOf[Array[O2]]
-      else values.slice(offset, length).asInstanceOf[Array[O2]]
-
     def copyToArray[O2 >: Short](xs: Array[O2], start: Int): Unit =
       if (xs.isInstanceOf[Array[Short]])
         System.arraycopy(values, offset, xs, start, length)
@@ -1171,10 +1152,6 @@ object Chunk extends CollectorK[Chunk] {
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
 
-    protected[fs2] override def toArrayUnsafe[O2 >: Int: ClassTag]: Array[O2] =
-      if (offset == 0 && length == values.length) values.asInstanceOf[Array[O2]]
-      else values.slice(offset, length).asInstanceOf[Array[O2]]
-
     def copyToArray[O2 >: Int](xs: Array[O2], start: Int): Unit =
       if (xs.isInstanceOf[Array[Int]])
         System.arraycopy(values, offset, xs, start, length)
@@ -1215,10 +1192,6 @@ object Chunk extends CollectorK[Chunk] {
     def size = length
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
-
-    protected[fs2] override def toArrayUnsafe[O2 >: Long: ClassTag]: Array[O2] =
-      if (offset == 0 && length == values.length) values.asInstanceOf[Array[O2]]
-      else values.slice(offset, length).asInstanceOf[Array[O2]]
 
     def copyToArray[O2 >: Long](xs: Array[O2], start: Int): Unit =
       if (xs.isInstanceOf[Array[Long]])
@@ -1262,10 +1235,6 @@ object Chunk extends CollectorK[Chunk] {
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
 
-    protected[fs2] override def toArrayUnsafe[O2 >: Float: ClassTag]: Array[O2] =
-      if (offset == 0 && length == values.length) values.asInstanceOf[Array[O2]]
-      else values.slice(offset, length).asInstanceOf[Array[O2]]
-
     def copyToArray[O2 >: Float](xs: Array[O2], start: Int): Unit =
       if (xs.isInstanceOf[Array[Float]])
         System.arraycopy(values, offset, xs, start, length)
@@ -1307,10 +1276,6 @@ object Chunk extends CollectorK[Chunk] {
     def size = length
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
-
-    protected[fs2] override def toArrayUnsafe[O2 >: Double: ClassTag]: Array[O2] =
-      if (offset == 0 && length == values.length) values.asInstanceOf[Array[O2]]
-      else values.slice(offset, length).asInstanceOf[Array[O2]]
 
     def copyToArray[O2 >: Double](xs: Array[O2], start: Int): Unit =
       if (xs.isInstanceOf[Array[Double]])
@@ -1354,10 +1319,6 @@ object Chunk extends CollectorK[Chunk] {
     def size = length
     def apply(i: Int) = values(offset + i)
     def at(i: Int) = values(offset + i)
-
-    protected[fs2] override def toArrayUnsafe[O2 >: Char: ClassTag]: Array[O2] =
-      if (offset == 0 && length == values.length) values.asInstanceOf[Array[O2]]
-      else values.slice(offset, length).asInstanceOf[Array[O2]]
 
     def copyToArray[O2 >: Char](xs: Array[O2], start: Int): Unit =
       if (xs.isInstanceOf[Array[Char]])

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -168,7 +168,7 @@ abstract class Chunk[+O] extends Serializable { self =>
       arr(i) = f(apply(i))
       i += 1
     }
-    Chunk.array(arr.asInstanceOf[Array[O2]])
+    Chunk.boxed(arr.asInstanceOf[Array[O2]])
   }
 
   /**
@@ -701,9 +701,6 @@ object Chunk extends CollectorK[Chunk] {
       if (n <= 0) Chunk.empty
       else if (n >= size) this
       else Boxed(values, offset, n)
-
-    override def toArray[O2 >: O: ClassTag]: Array[O2] =
-      values.slice(offset, offset + length).asInstanceOf[Array[O2]]
   }
   object Boxed {
     def apply[O](values: Array[O]): Boxed[O] = Boxed(values, 0, values.length)

--- a/core/shared/src/test/scala/fs2/ChunkSpec.scala
+++ b/core/shared/src/test/scala/fs2/ChunkSpec.scala
@@ -179,4 +179,26 @@ class ChunkSpec extends Fs2Spec {
     "longs" in testEmptyConcat(Chunk.concatLongs)
     "chars" in testEmptyConcat(Chunk.concatChars)
   }
+
+  "map andThen toArray" in {
+    val arr: Array[Int] = Chunk(0, 0).map(identity).toArray 
+    arr shouldBe Array(0, 0)
+  }
+
+  "mapAccumulate andThen toArray" in {
+    val arr: Array[Int] = Chunk(0, 0).mapAccumulate(0)((s, o) => (s, o))._2.toArray 
+    arr shouldBe Array(0, 0)
+  }
+
+  "scanLeft andThen toArray" in {
+    val arr: Array[Int] = Chunk(0, 0).scanLeft(0)((_, o) => o).toArray 
+    arr shouldBe Array(0, 0, 0)
+  }
+
+  "zip andThen toArray" in {
+    val arr: Array[(Int, Int)] = Chunk(0, 0).zip(Chunk(0, 0)).toArray
+    arr shouldBe Array((0, 0), (0, 0))
+    val arr2: Array[Int] = Chunk(0, 0).zip(Chunk(0, 0)).map(_._1).toArray
+    arr2 shouldBe Array(0, 0)
+  }
 }

--- a/core/shared/src/test/scala/fs2/ChunkSpec.scala
+++ b/core/shared/src/test/scala/fs2/ChunkSpec.scala
@@ -181,17 +181,17 @@ class ChunkSpec extends Fs2Spec {
   }
 
   "map andThen toArray" in {
-    val arr: Array[Int] = Chunk(0, 0).map(identity).toArray 
+    val arr: Array[Int] = Chunk(0, 0).map(identity).toArray
     arr shouldBe Array(0, 0)
   }
 
   "mapAccumulate andThen toArray" in {
-    val arr: Array[Int] = Chunk(0, 0).mapAccumulate(0)((s, o) => (s, o))._2.toArray 
+    val arr: Array[Int] = Chunk(0, 0).mapAccumulate(0)((s, o) => (s, o))._2.toArray
     arr shouldBe Array(0, 0)
   }
 
   "scanLeft andThen toArray" in {
-    val arr: Array[Int] = Chunk(0, 0).scanLeft(0)((_, o) => o).toArray 
+    val arr: Array[Int] = Chunk(0, 0).scanLeft(0)((_, o) => o).toArray
     arr shouldBe Array(0, 0, 0)
   }
 

--- a/core/shared/src/test/scala/fs2/ChunkSpec.scala
+++ b/core/shared/src/test/scala/fs2/ChunkSpec.scala
@@ -201,4 +201,10 @@ class ChunkSpec extends Fs2Spec {
     val arr2: Array[Int] = Chunk(0, 0).zip(Chunk(0, 0)).map(_._1).toArray
     arr2 shouldBe Array(0, 0)
   }
+
+  "Boxed toArray - regression #1745" in {
+    Chunk.Boxed(Array[Any](0)).asInstanceOf[Chunk[Int]].toArray[Any]
+    Chunk.Boxed(Array[Any](0)).asInstanceOf[Chunk[Int]].toArray[Int]
+    Succeeded
+  }
 }


### PR DESCRIPTION
@CremboC Could you review? Trick here is to avoid specializing `toArray` on `Boxed` -- it was making a bad assumption that the `ClassTag[O2]` passed to `toArray` was the same as used to create the underlying array.