### PR TITLE
Make writeAll return a Nothing-stream

### DIFF
--- a/io/src/main/scala/fs2/io/file/file.scala
+++ b/io/src/main/scala/fs2/io/file/file.scala
@@ -68,12 +68,14 @@ package object file {
     * Writes all data to the file at the specified `java.nio.file.Path`.
     *
     * Adds the WRITE flag to any other `OpenOption` flags specified. By default, also adds the CREATE flag.
+    *
+    * The returned stream contains no elements.
     */
   def writeAll[F[_]: Sync: ContextShift](
       path: Path,
       blocker: Blocker,
       flags: Seq[StandardOpenOption] = List(StandardOpenOption.CREATE)
-  ): Pipe[F, Byte, Unit] =
+  ): Pipe[F, Byte, Nothing] =
     in =>
       Stream
         .resource(WriteCursor.fromPath(path, blocker, flags))

--- a/io/src/test/scala/fs2/io/file/BaseFileSpec.scala
+++ b/io/src/test/scala/fs2/io/file/BaseFileSpec.scala
@@ -36,7 +36,7 @@ class BaseFileSpec extends Fs2Spec {
   protected def modify(file: Path): Stream[IO, Unit] =
     Stream.eval(IO(Files.write(file, Array[Byte](0, 1, 2, 3))).void)
 
-  protected def modifyLater(file: Path, blocker: Blocker): Stream[IO, Unit] =
+  protected def modifyLater(file: Path, blocker: Blocker): Stream[IO, Nothing] =
     Stream
       .range(0, 4)
       .map(_.toByte)

--- a/io/src/test/scala/fs2/io/file/FileSpec.scala
+++ b/io/src/test/scala/fs2/io/file/FileSpec.scala
@@ -69,8 +69,9 @@ class FileSpec extends BaseFileSpec {
               Stream("Hello", " world!")
                 .covary[IO]
                 .through(text.utf8Encode)
-                .through(file.writeAll[IO](path, bec))
-                .drain ++ file.readAll[IO](path, bec, 4096).through(text.utf8Decode)
+                .through(file.writeAll[IO](path, bec)) ++ file
+                .readAll[IO](path, bec, 4096)
+                .through(text.utf8Decode)
             )
         }
         .compile
@@ -86,8 +87,8 @@ class FileSpec extends BaseFileSpec {
             .flatMap { path =>
               val src = Stream("Hello", " world!").covary[IO].through(text.utf8Encode)
 
-              src.through(file.writeAll[IO](path, bec)).drain ++
-                src.through(file.writeAll[IO](path, bec, List(StandardOpenOption.APPEND))).drain ++
+              src.through(file.writeAll[IO](path, bec)) ++
+                src.through(file.writeAll[IO](path, bec, List(StandardOpenOption.APPEND))) ++
                 file.readAll[IO](path, bec, 4096).through(text.utf8Decode)
             }
         }


### PR DESCRIPTION
`writeAll` returns a stream of zero elements, so it might as well return `Nothing` to avoid confusion (someone mentioned to me recently that they were surprised they didn't get even one element from a stream piped through it).

I think it'll be binary compatible because of type erasure (plus, the stream was empty anyway, and the Unit type matched only thanks to covariance).