### PR TITLE
A Stream can pull anything.

### DIFF
--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -38,13 +38,10 @@ final class Pull[+F[_], +O, +R] private[fs2] (private val free: FreeC[F, O, R]) 
   /**
     * Interpret this `Pull` to produce a `Stream`.
     *
-    * May only be called on pulls which return a `Unit` result type. Use `p.void.stream` to explicitly
+    * May only be called on pulls which return a `Unit` result type. Use `p.stream` to explicitly
     * ignore the result type of the pull.
     */
-  def stream(implicit ev: R <:< Unit): Stream[F, O] = {
-    val _ = ev
-    new Stream(free.asInstanceOf[FreeC[F, O, Unit]])
-  }
+  def stream: Stream[F, O] = new Stream(free)
 
   /** Applies the resource of this pull to `f` and returns the result. */
   def flatMap[F2[x] >: F[x], O2 >: O, R2](f: R => Pull[F2, O2, R2]): Pull[F2, O2, R2] =

--- a/core/shared/src/main/scala/fs2/concurrent/Signal.scala
+++ b/core/shared/src/main/scala/fs2/concurrent/Signal.scala
@@ -74,7 +74,7 @@ object Signal extends SignalLowPriorityImplicits {
         Pull.output1[F, PullOutput]((x, y, restOfXs, restOfYs)): Pull[F, PullOutput, Unit]
       }
     } yield ()
-    firstPull.value.void.stream
+    firstPull.value.stream
       .flatMap {
         case (x, y, restOfXs, restOfYs) =>
           restOfXs.either(restOfYs).scan((x, y)) {

--- a/core/shared/src/main/scala/fs2/fs2.scala
+++ b/core/shared/src/main/scala/fs2/fs2.scala
@@ -34,4 +34,10 @@ package object fs2 {
     * Alias for `Nothing` which works better with type inference.
     */
   type INothing <: Nothing
+
+  /**
+    * Alias for `Any` which may work better with type inference.
+    */
+  type IAny >: Any
+
 }

--- a/core/shared/src/test/scala/fs2/CompilationTest.scala
+++ b/core/shared/src/test/scala/fs2/CompilationTest.scala
@@ -13,8 +13,8 @@ object ThisModuleShouldCompile {
   /* Some checks that `.pull` can be used without annotations */
   Stream(1, 2, 3, 4).through(_.take(2))
   Stream.eval(IO.pure(1)).through(_.take(2))
-  Stream(1, 2, 3).covary[IO].pull.uncons1.void.stream
-  Stream.eval(IO.pure(1)).pull.uncons1.void.stream
+  Stream(1, 2, 3).covary[IO].pull.uncons1.stream
+  Stream.eval(IO.pure(1)).pull.uncons1.stream
 
   /* Also in a polymorphic context. */
   def a[F[_], A](s: Stream[F, A]) = s.through(_.take(2))

--- a/core/shared/src/test/scala/fs2/StreamSpec.scala
+++ b/core/shared/src/test/scala/fs2/StreamSpec.scala
@@ -3443,7 +3443,7 @@ class StreamSpec extends Fs2Spec {
       }
 
       "7 - ok to translate step leg that is forced back in to a stream" in {
-        def goStep(step: Option[Stream.StepLeg[Function0, Int]]): Pull[Function0, Int, Unit] =
+        def goStep(step: Option[Stream.StepLeg[Function0, Int]]): Pull[Function0, Int, IAny] =
           step match {
             case None => Pull.done
             case Some(step) =>

--- a/io/src/main/scala/fs2/io/file/file.scala
+++ b/io/src/main/scala/fs2/io/file/file.scala
@@ -24,7 +24,7 @@ package object file {
       chunkSize: Int
   ): Stream[F, Byte] =
     Stream.resource(ReadCursor.fromPath(path, blocker)).flatMap { cursor =>
-      cursor.readAll(chunkSize).void.stream
+      cursor.readAll(chunkSize).stream
     }
 
   /**
@@ -40,7 +40,7 @@ package object file {
       end: Long
   ): Stream[F, Byte] =
     Stream.resource(ReadCursor.fromPath(path, blocker)).flatMap { cursor =>
-      cursor.seek(start).readUntil(chunkSize, end).void.stream
+      cursor.seek(start).readUntil(chunkSize, end).stream
     }
 
   /**
@@ -61,7 +61,7 @@ package object file {
       pollDelay: FiniteDuration = 1.second
   ): Stream[F, Byte] =
     Stream.resource(ReadCursor.fromPath(path, blocker)).flatMap { cursor =>
-      cursor.seek(offset).tail(chunkSize, pollDelay).void.stream
+      cursor.seek(offset).tail(chunkSize, pollDelay).stream
     }
 
   /**
@@ -77,7 +77,7 @@ package object file {
     in =>
       Stream
         .resource(WriteCursor.fromPath(path, blocker, flags))
-        .flatMap(_.writeAll(in).void.stream)
+        .flatMap(_.writeAll(in).stream)
 
   /**
     * Writes all data to a sequence of files, each limited in size to `limit`.

--- a/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscription.scala
+++ b/reactive-streams/src/main/scala/fs2/interop/reactivestreams/StreamSubscription.scala
@@ -32,7 +32,7 @@ private[reactivestreams] final class StreamSubscription[F[_], A](
   def unsafeStart(): Unit = {
     def subscriptionPipe: Pipe[F, A, A] =
       in => {
-        def go(s: Stream[F, A]): Pull[F, A, Unit] =
+        def go(s: Stream[F, A]): Pull[F, A, IAny] =
           Pull.eval(requests.dequeue1).flatMap {
             case Infinite => s.pull.echo
             case Finite(n) =>


### PR DESCRIPTION
A `Stream[F, O]` is defined as a wrap on a `FreeC[F, O, Unit]`. The Unit type indicates that the "Result" of the `FreeC` computation that produces the stream has no relevant information: all that matters of the Stream is the output. 

We can also express that idea by marking that return type as an `Any`, the top type, which is another way to indicate that no useful information can come off the Result of the inner `FreeC`. One benefit is that we do not need the spurious conversions of the `FreeC` with `void`, just to wrap it back into a Stream. 