### PR TITLE
Replace some ShouldMatchers with assertions

### DIFF
--- a/core/jvm/src/test/scala/fs2/CompressSpec.scala
+++ b/core/jvm/src/test/scala/fs2/CompressSpec.scala
@@ -89,7 +89,7 @@ class CompressSpec extends Fs2Spec {
         .through(compress.inflate())
         .compile
         .toVector
-        .asserting(_ == s.toVector)
+        .assert(_ == s.toVector)
     }
 
     "deflate.compresses input" in {
@@ -111,7 +111,7 @@ class CompressSpec extends Fs2Spec {
         .through(compress.gunzip[IO](8192))
         .compile
         .toVector
-        .asserting(_ == s.toVector)
+        .assert(_ == s.toVector)
     }
 
     "gzip |> gunzip ~= id (mutually prime chunk sizes, compression larger)" in forAll {
@@ -121,7 +121,7 @@ class CompressSpec extends Fs2Spec {
           .through(compress.gunzip[IO](509))
           .compile
           .toVector
-          .asserting(_ == s.toVector)
+          .assert(_ == s.toVector)
     }
 
     "gzip |> gunzip ~= id (mutually prime chunk sizes, decompression larger)" in forAll {
@@ -131,7 +131,7 @@ class CompressSpec extends Fs2Spec {
           .through(compress.gunzip[IO](1031))
           .compile
           .toVector
-          .asserting(_ == s.toVector)
+          .assert(_ == s.toVector)
     }
 
     "gzip |> GZIPInputStream ~= id" in forAll { s: Stream[Pure, Byte] =>

--- a/core/jvm/src/test/scala/fs2/CompressSpec.scala
+++ b/core/jvm/src/test/scala/fs2/CompressSpec.scala
@@ -52,7 +52,7 @@ class CompressSpec extends Fs2Spec {
           )
           .toVector
 
-        actual should equal(expected)
+        assert(actual == expected)
     }
 
     "inflate input" in forAll(strings, intsBetween(0, 9), booleans) {
@@ -76,7 +76,7 @@ class CompressSpec extends Fs2Spec {
             .through(inflate(nowrap = nowrap))
             .compile
             .toVector
-          actualInflated should equal(Right(expectedInflated))
+          assert(actualInflated == Right(expectedInflated))
         }
 
         expectEqual(actualDeflated.toArray, expectedDeflated.toArray)
@@ -89,7 +89,7 @@ class CompressSpec extends Fs2Spec {
         .through(compress.inflate())
         .compile
         .toVector
-        .asserting(_ shouldBe s.toVector)
+        .asserting(_ == s.toVector)
     }
 
     "deflate.compresses input" in {
@@ -102,7 +102,7 @@ class CompressSpec extends Fs2Spec {
       val compressed =
         Stream.chunk(Chunk.bytes(uncompressed)).through(deflate(9)).toVector
 
-      compressed.length should be < uncompressed.length
+      assert(compressed.length < uncompressed.length)
     }
 
     "gzip |> gunzip ~= id" in forAll { s: Stream[Pure, Byte] =>
@@ -111,7 +111,7 @@ class CompressSpec extends Fs2Spec {
         .through(compress.gunzip[IO](8192))
         .compile
         .toVector
-        .asserting(_ shouldBe s.toVector)
+        .asserting(_ == s.toVector)
     }
 
     "gzip |> gunzip ~= id (mutually prime chunk sizes, compression larger)" in forAll {
@@ -121,7 +121,7 @@ class CompressSpec extends Fs2Spec {
           .through(compress.gunzip[IO](509))
           .compile
           .toVector
-          .asserting(_ shouldBe s.toVector)
+          .asserting(_ == s.toVector)
     }
 
     "gzip |> gunzip ~= id (mutually prime chunk sizes, decompression larger)" in forAll {
@@ -131,7 +131,7 @@ class CompressSpec extends Fs2Spec {
           .through(compress.gunzip[IO](1031))
           .compile
           .toVector
-          .asserting(_ shouldBe s.toVector)
+          .asserting(_ == s.toVector)
     }
 
     "gzip |> GZIPInputStream ~= id" in forAll { s: Stream[Pure, Byte] =>
@@ -150,7 +150,7 @@ class CompressSpec extends Fs2Spec {
         read = gzis.read()
       }
 
-      buffer.toVector shouldBe s.toVector
+      assert(buffer.toVector == s.toVector)
     }
 
     "gzip.compresses input" in {
@@ -166,7 +166,7 @@ class CompressSpec extends Fs2Spec {
         .compile
         .toVector
 
-      compressed.length should be < uncompressed.length
+      assert(compressed.length < uncompressed.length)
     }
   }
 }

--- a/core/jvm/src/test/scala/fs2/HashSpec.scala
+++ b/core/jvm/src/test/scala/fs2/HashSpec.scala
@@ -68,7 +68,7 @@ class HashSpec extends Fs2Spec {
     (for {
       once <- s.compile.toVector
       oneHundred <- Vector.fill(100)(s.compile.toVector).parSequence
-    } yield (once, oneHundred)).asserting {
+    } yield (once, oneHundred)).assert {
       case (once, oneHundred) => oneHundred == Vector.fill(100)(once)
     }
   }

--- a/core/jvm/src/test/scala/fs2/HashSpec.scala
+++ b/core/jvm/src/test/scala/fs2/HashSpec.scala
@@ -22,7 +22,7 @@ class HashSpec extends Fs2Spec {
           .foldLeft(Stream.empty.covaryOutput[Byte])((acc, c) => acc ++ Stream.chunk(Chunk.bytes(c))
           )
 
-    s.through(h).toList shouldBe digest(algo, str)
+    assert(s.through(h).toList == digest(algo, str))
   }
 
   "digests" - {
@@ -47,13 +47,16 @@ class HashSpec extends Fs2Spec {
   }
 
   "empty input" in {
-    Stream.empty.through(sha1).toList should have size (20)
+    assert(Stream.empty.through(sha1).toList.size == 20)
   }
 
   "zero or one output" in forAll { (lb: List[Array[Byte]]) =>
-    lb.foldLeft(Stream.empty.covaryOutput[Byte])((acc, b) => acc ++ Stream.chunk(Chunk.bytes(b)))
+    val size = lb
+      .foldLeft(Stream.empty.covaryOutput[Byte])((acc, b) => acc ++ Stream.chunk(Chunk.bytes(b)))
       .through(sha1)
-      .toList should have size (20)
+      .toList
+      .size
+    assert(size == 20)
   }
 
   "thread-safety" in {
@@ -66,7 +69,7 @@ class HashSpec extends Fs2Spec {
       once <- s.compile.toVector
       oneHundred <- Vector.fill(100)(s.compile.toVector).parSequence
     } yield (once, oneHundred)).asserting {
-      case (once, oneHundred) => oneHundred shouldBe Vector.fill(100)(once)
+      case (once, oneHundred) => oneHundred == Vector.fill(100)(once)
     }
   }
 }

--- a/core/shared/src/test/scala/fs2/Fs2Spec.scala
+++ b/core/shared/src/test/scala/fs2/Fs2Spec.scala
@@ -8,7 +8,7 @@ import cats.effect.{ContextShift, Fiber, IO, Sync, Timer}
 import cats.implicits._
 
 import org.scalactic.{Prettifier, source}
-import org.scalatest.{Args, Assertion, Matchers, Status, Succeeded}
+import org.scalatest.{Args, Assertion, Assertions, Matchers, Status, Succeeded}
 import org.scalatest.concurrent.AsyncTimeLimitedTests
 import org.scalatest.freespec.AsyncFreeSpec
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
@@ -106,10 +106,10 @@ abstract class Fs2Spec
       * IO(1).asserting(_ == 1)
       * }}}
       */
-    def asserting(
+    def assert(
         f: A => Boolean
     )(implicit prettifier: Prettifier, pos: source.Position, F: Sync[F]): F[Assertion] =
-      self.flatMap(a => F.delay(assert(f(a))))
+      self.flatMap(a => F.delay(Assertions.assert(f(a))))
 
     /**
       * Asserts that the `F[A]` completes with an `A` and no exception is thrown.

--- a/core/shared/src/test/scala/fs2/Fs2Spec.scala
+++ b/core/shared/src/test/scala/fs2/Fs2Spec.scala
@@ -7,6 +7,7 @@ import cats.{Functor, Monad}
 import cats.effect.{ContextShift, Fiber, IO, Sync, Timer}
 import cats.implicits._
 
+import org.scalactic.{Prettifier, source}
 import org.scalatest.{Args, Assertion, Matchers, Status, Succeeded}
 import org.scalatest.concurrent.AsyncTimeLimitedTests
 import org.scalatest.freespec.AsyncFreeSpec
@@ -97,6 +98,18 @@ abstract class Fs2Spec
       */
     def asserting(f: A => Assertion)(implicit F: Sync[F]): F[Assertion] =
       self.flatMap(a => F.delay(f(a)))
+
+    /**
+      * Asserts that the `F[A]` completes with an `A` which passes the supplied function.
+      *
+      * @example {{{
+      * IO(1).asserting(_ == 1)
+      * }}}
+      */
+    def asserting(
+        f: A => Boolean
+    )(implicit prettifier: Prettifier, pos: source.Position, F: Sync[F]): F[Assertion] =
+      self.flatMap(a => F.delay(assert(f(a))))
 
     /**
       * Asserts that the `F[A]` completes with an `A` and no exception is thrown.

--- a/core/shared/src/test/scala/fs2/concurrent/BalanceSpec.scala
+++ b/core/shared/src/test/scala/fs2/concurrent/BalanceSpec.scala
@@ -16,7 +16,7 @@ class BalanceSpec extends Fs2Spec {
           .balanceThrough(chunkSize = chunkSize, maxConcurrent = concurrent)(_.map(_.toLong))
           .compile
           .toVector
-          .asserting(_.sorted shouldBe expected)
+          .asserting(_.sorted == expected)
       }
     }
   }

--- a/core/shared/src/test/scala/fs2/concurrent/BalanceSpec.scala
+++ b/core/shared/src/test/scala/fs2/concurrent/BalanceSpec.scala
@@ -16,7 +16,7 @@ class BalanceSpec extends Fs2Spec {
           .balanceThrough(chunkSize = chunkSize, maxConcurrent = concurrent)(_.map(_.toLong))
           .compile
           .toVector
-          .asserting(_.sorted == expected)
+          .assert(_.sorted == expected)
       }
     }
   }

--- a/core/shared/src/test/scala/fs2/concurrent/QueueSpec.scala
+++ b/core/shared/src/test/scala/fs2/concurrent/QueueSpec.scala
@@ -21,7 +21,7 @@ class QueueSpec extends Fs2Spec {
           }
           .compile
           .toList
-          .asserting(_ shouldBe expected)
+          .asserting(_ == expected)
       }
     }
     "circularBuffer" in {
@@ -37,7 +37,7 @@ class QueueSpec extends Fs2Spec {
           }
           .compile
           .toList
-          .asserting(_ shouldBe expected)
+          .asserting(_ == expected)
       }
     }
     "dequeueAvailable" in {
@@ -72,7 +72,7 @@ class QueueSpec extends Fs2Spec {
           }
           .compile
           .toList
-          .asserting(_ shouldBe expected)
+          .asserting(_ == expected)
       }
     }
     "dequeueBatch circularBuffer" in {
@@ -90,7 +90,7 @@ class QueueSpec extends Fs2Spec {
           }
           .compile
           .toList
-          .asserting(_ shouldBe expected)
+          .asserting(_ == expected)
       }
     }
 
@@ -104,7 +104,7 @@ class QueueSpec extends Fs2Spec {
               q.enqueue1(2) >>
               q.dequeue1
           }
-          .asserting(_ shouldBe 1)
+          .asserting(_ == 1)
       }
 
       "cancel" in {
@@ -116,7 +116,7 @@ class QueueSpec extends Fs2Spec {
               q.enqueue1(2) >>
               q.dequeue1
           }
-          .asserting(_ shouldBe 1)
+          .asserting(_ == 1)
       }
     }
 
@@ -127,7 +127,7 @@ class QueueSpec extends Fs2Spec {
         .take(1)
         .compile
         .toList
-        .asserting(_ shouldBe List(0))
+        .asserting(_ == List(0))
     }
 
     "size stream is discrete" in {
@@ -143,7 +143,7 @@ class QueueSpec extends Fs2Spec {
         .interruptWhen(Stream.sleep[IO](2.seconds).as(true))
         .compile
         .toList
-        .asserting(_.size shouldBe <=(11)) // if the stream won't be discrete we will get much more size notifications
+        .asserting(_.size <= 11) // if the stream won't be discrete we will get much more size notifications
     }
 
     "peek1" in {
@@ -160,7 +160,7 @@ class QueueSpec extends Fs2Spec {
         )
         .compile
         .toList
-        .asserting(_.flatten shouldBe List(42, 42))
+        .asserting(_.flatten == List(42, 42))
     }
 
     "peek1 with dequeue1" in {
@@ -180,7 +180,7 @@ class QueueSpec extends Fs2Spec {
         )
         .compile
         .toList
-        .asserting(_.flatten shouldBe List((42, 42), (43, 43), (44, 44)))
+        .asserting(_.flatten == List((42, 42), (43, 43), (44, 44)))
     }
 
     "peek1 bounded queue" in {
@@ -199,7 +199,7 @@ class QueueSpec extends Fs2Spec {
         )
         .compile
         .toList
-        .asserting(_.flatten shouldBe List(false, 42, 42, 42))
+        .asserting(_.flatten == List(false, 42, 42, 42))
     }
 
     "peek1 circular buffer" in {
@@ -218,7 +218,7 @@ class QueueSpec extends Fs2Spec {
         )
         .compile
         .toList
-        .asserting(_.flatten shouldBe List(true, 42, 42, 43))
+        .asserting(_.flatten == List(true, 42, 42, 43))
     }
   }
 }

--- a/core/shared/src/test/scala/fs2/concurrent/QueueSpec.scala
+++ b/core/shared/src/test/scala/fs2/concurrent/QueueSpec.scala
@@ -21,7 +21,7 @@ class QueueSpec extends Fs2Spec {
           }
           .compile
           .toList
-          .asserting(_ == expected)
+          .assert(_ == expected)
       }
     }
     "circularBuffer" in {
@@ -37,7 +37,7 @@ class QueueSpec extends Fs2Spec {
           }
           .compile
           .toList
-          .asserting(_ == expected)
+          .assert(_ == expected)
       }
     }
     "dequeueAvailable" in {
@@ -72,7 +72,7 @@ class QueueSpec extends Fs2Spec {
           }
           .compile
           .toList
-          .asserting(_ == expected)
+          .assert(_ == expected)
       }
     }
     "dequeueBatch circularBuffer" in {
@@ -90,7 +90,7 @@ class QueueSpec extends Fs2Spec {
           }
           .compile
           .toList
-          .asserting(_ == expected)
+          .assert(_ == expected)
       }
     }
 
@@ -104,7 +104,7 @@ class QueueSpec extends Fs2Spec {
               q.enqueue1(2) >>
               q.dequeue1
           }
-          .asserting(_ == 1)
+          .assert(_ == 1)
       }
 
       "cancel" in {
@@ -116,7 +116,7 @@ class QueueSpec extends Fs2Spec {
               q.enqueue1(2) >>
               q.dequeue1
           }
-          .asserting(_ == 1)
+          .assert(_ == 1)
       }
     }
 
@@ -127,7 +127,7 @@ class QueueSpec extends Fs2Spec {
         .take(1)
         .compile
         .toList
-        .asserting(_ == List(0))
+        .assert(_ == List(0))
     }
 
     "size stream is discrete" in {
@@ -143,7 +143,7 @@ class QueueSpec extends Fs2Spec {
         .interruptWhen(Stream.sleep[IO](2.seconds).as(true))
         .compile
         .toList
-        .asserting(_.size <= 11) // if the stream won't be discrete we will get much more size notifications
+        .assert(_.size <= 11) // if the stream won't be discrete we will get much more size notifications
     }
 
     "peek1" in {
@@ -160,7 +160,7 @@ class QueueSpec extends Fs2Spec {
         )
         .compile
         .toList
-        .asserting(_.flatten == List(42, 42))
+        .assert(_.flatten == List(42, 42))
     }
 
     "peek1 with dequeue1" in {
@@ -180,7 +180,7 @@ class QueueSpec extends Fs2Spec {
         )
         .compile
         .toList
-        .asserting(_.flatten == List((42, 42), (43, 43), (44, 44)))
+        .assert(_.flatten == List((42, 42), (43, 43), (44, 44)))
     }
 
     "peek1 bounded queue" in {
@@ -199,7 +199,7 @@ class QueueSpec extends Fs2Spec {
         )
         .compile
         .toList
-        .asserting(_.flatten == List(false, 42, 42, 42))
+        .assert(_.flatten == List(false, 42, 42, 42))
     }
 
     "peek1 circular buffer" in {
@@ -218,7 +218,7 @@ class QueueSpec extends Fs2Spec {
         )
         .compile
         .toList
-        .asserting(_.flatten == List(true, 42, 42, 43))
+        .assert(_.flatten == List(true, 42, 42, 43))
     }
   }
 }


### PR DESCRIPTION
Part of #1764

Introducing `.asserting(_ == expected)` helper method and replacing ShouldMachers with assertions in: QueueSpec, BalanceSpec, CompressSpec, HashSpec.