### PR TITLE
Support setting needClientAuth with TLSParameters

### DIFF
--- a/io/src/main/scala/fs2/io/tls/TLSParameters.scala
+++ b/io/src/main/scala/fs2/io/tls/TLSParameters.scala
@@ -39,8 +39,10 @@ sealed trait TLSParameters {
     serverNames.foreach(sn => p.setServerNames(sn.asJava))
     sniMatchers.foreach(sm => p.setSNIMatchers(sm.asJava))
     p.setUseCipherSuitesOrder(useCipherSuitesOrder)
-    p.setNeedClientAuth(needClientAuth)
-    p.setWantClientAuth(wantClientAuth)
+    if (needClientAuth)
+      p.setNeedClientAuth(needClientAuth)
+    else if (wantClientAuth)
+      p.setWantClientAuth(wantClientAuth)
     p
   }
 }

--- a/io/src/test/scala/fs2/io/tls/TLSParametersSpec.scala
+++ b/io/src/test/scala/fs2/io/tls/TLSParametersSpec.scala
@@ -1,0 +1,31 @@
+package fs2
+package io
+package tls
+
+class TLSParametersSpec extends TLSSpec {
+  "toSSLParameters" - {
+    "no client auth when wantClientAuth=false and needClientAuth=false" in {
+      val params = TLSParameters(wantClientAuth = false, needClientAuth = false).toSSLParameters
+      params.getWantClientAuth shouldBe false
+      params.getNeedClientAuth shouldBe false
+    }
+
+    "wantClientAuth when wantClientAuth=true and needClientAuth=false" in {
+      val params = TLSParameters(wantClientAuth = true, needClientAuth = false).toSSLParameters
+      params.getWantClientAuth shouldBe true
+      params.getNeedClientAuth shouldBe false
+    }
+
+    "needClientAuth when wantClientAuth=false and needClientAuth=true" in {
+      val params = TLSParameters(wantClientAuth = false, needClientAuth = true).toSSLParameters
+      params.getWantClientAuth shouldBe false
+      params.getNeedClientAuth shouldBe true
+    }
+
+    "needClientAuth when wantClientAuth=true and needClientAuth=true" in {
+      val params = TLSParameters(wantClientAuth = true, needClientAuth = true).toSSLParameters
+      params.getWantClientAuth shouldBe false
+      params.getNeedClientAuth shouldBe true
+    }
+  }
+}


### PR DESCRIPTION
Calling `setWantClientAuth` clears `setNeedClientAuth` and vice versa.  Since `setWantClientAuth` is called last, `getNeedClientAuth` is never true.

Changes so if `needClientAuth` is true, it is set on `SSLParameters`, regardless of `wantClientAuth`.  If `needClientAuth` is false, `wantClientAuth` wins.  The default of both `SSLParameters` and `TLSParameters` is that neither is set.