### PR TITLE
Fixed Stream#to(Set) on 2.12

### DIFF
--- a/core/shared/src/main/scala-2.12/fs2/CollectorPlatform.scala
+++ b/core/shared/src/main/scala-2.12/fs2/CollectorPlatform.scala
@@ -1,9 +1,10 @@
 package fs2
 
-import scala.collection.generic.{GenericTraversableTemplate, MapFactory, TraversableFactory}
-import scala.collection.{MapLike, Traversable}
+import scala.collection.generic.{GenericTraversableTemplate, MapFactory, SetFactory, TraversableFactory}
+import scala.collection.{MapLike, SetLike, Traversable}
 
 import fs2.internal._
+import scala.collection.generic.GenericSetTemplate
 
 private[fs2] trait CollectorPlatform { self: Collector.type =>
   implicit def supportsFactory[A, C[_], B](
@@ -26,6 +27,9 @@ private[fs2] trait CollectorPlatform { self: Collector.type =>
   ): Collector.Aux[(K, V), C[K, V]] =
     make(Builder.fromMapFactory(f))
 
+  implicit def supportsSetFactory[A, C[x] <: Set[x] with SetLike[x, C[x]]](f: SetFactory[C]): Collector.Aux[A, C[A]] =
+    make(Builder.fromSetFactory(f))
+
   private[fs2] trait BuilderPlatform { self: Collector.Builder.type =>
     def fromFactory[A, C[_], B](f: Factory[A, C[B]]): Builder[A, C[B]] =
       fromBuilder(f())
@@ -38,6 +42,11 @@ private[fs2] trait CollectorPlatform { self: Collector.type =>
     def fromMapFactory[K, V, C[a, b] <: collection.Map[a, b] with MapLike[a, b, C[a, b]]](
         f: MapFactory[C]
     ): Builder[(K, V), C[K, V]] =
+      fromBuilder(f.newBuilder)
+
+    def fromSetFactory[A, C[x] <: collection.Set[x] with SetLike[x, C[x]]](
+        f: SetFactory[C]
+    ): Builder[A, C[A]] =
       fromBuilder(f.newBuilder)
   }
 }

--- a/core/shared/src/main/scala-2.12/fs2/CollectorPlatform.scala
+++ b/core/shared/src/main/scala-2.12/fs2/CollectorPlatform.scala
@@ -1,10 +1,15 @@
 package fs2
 
-import scala.collection.generic.{GenericTraversableTemplate, MapFactory, SetFactory, TraversableFactory}
+import scala.collection.generic.{
+  GenericSetTemplate,
+  GenericTraversableTemplate,
+  MapFactory,
+  SetFactory,
+  TraversableFactory
+}
 import scala.collection.{MapLike, SetLike, Traversable}
 
 import fs2.internal._
-import scala.collection.generic.GenericSetTemplate
 
 private[fs2] trait CollectorPlatform { self: Collector.type =>
   implicit def supportsFactory[A, C[_], B](
@@ -27,7 +32,9 @@ private[fs2] trait CollectorPlatform { self: Collector.type =>
   ): Collector.Aux[(K, V), C[K, V]] =
     make(Builder.fromMapFactory(f))
 
-  implicit def supportsSetFactory[A, C[x] <: Set[x] with SetLike[x, C[x]]](f: SetFactory[C]): Collector.Aux[A, C[A]] =
+  implicit def supportsSetFactory[A, C[x] <: Set[x] with SetLike[x, C[x]]](
+      f: SetFactory[C]
+  ): Collector.Aux[A, C[A]] =
     make(Builder.fromSetFactory(f))
 
   private[fs2] trait BuilderPlatform { self: Collector.Builder.type =>

--- a/core/shared/src/test/scala/fs2/CompilationTest.scala
+++ b/core/shared/src/test/scala/fs2/CompilationTest.scala
@@ -92,4 +92,6 @@ object ThisModuleShouldCompile {
   // Ensure that .to(Collector) syntax works even when target type is known (regression #1709)
   val z: List[Int] = Stream.range(0, 5).compile.to(List)
   Stream.empty[Id].covaryOutput[Byte].compile.to(Chunk): Chunk[Byte]
+
+  Stream(1, 2, 3).compile.to(Set)
 }


### PR DESCRIPTION
Brought up in Gitter: https://gitter.im/functional-streams-for-scala/fs2?at=5e315e3a40da694c5ee6bf85

`.compile.to(Set)` doesn't work on Scala 2.12. This PR fixes it by adding a `Collector` instance for any `SetFactory`.