### PR TITLE
Fixed NoSuchMethodError in text.base64Decode when run on JDK8

### DIFF
--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -1,6 +1,6 @@
 package fs2
 
-import java.nio.CharBuffer
+import java.nio.{Buffer, CharBuffer}
 import java.nio.charset.Charset
 
 import scala.annotation.tailrec
@@ -365,12 +365,14 @@ object text {
           .append(alphabet.toChar(fourth))
         idx = idx + 3
       }
+      (bldr: Buffer).flip
+      val out = bldr.toString
       if (mod == 0) {
-        (bldr.flip.toString, ByteVector.empty)
+        (out, ByteVector.empty)
       } else if (mod == 1) {
-        (bldr.flip.toString, ByteVector(bytes(idx)))
+        (out, ByteVector(bytes(idx)))
       } else {
-        (bldr.flip.toString, ByteVector(bytes(idx), bytes(idx + 1)))
+        (out, ByteVector(bytes(idx), bytes(idx + 1)))
       }
     }
 


### PR DESCRIPTION
Using `text.base64Encode` on JDK8 throws:

```scala
java.lang.NoSuchMethodError: java.nio.CharBuffer.flip()Ljava/nio/CharBuffer;
 	at fs2.text$.encode$1(text.scala:369)
 	at fs2.text$.$anonfun$base64Encode$1(text.scala:380)
 	at fs2.text$.$anonfun$base64Encode$1$adapted(text.scala:378)
 	at fs2.Pull$.$anonfun$flatMap$1(Pull.scala:51)
```

This is another instance of #1357.