### PR TITLE
Replace ShouldMatchers in tests with assertions

### DIFF
--- a/core/jvm/src/test/scala/fs2/CompressSpec.scala
+++ b/core/jvm/src/test/scala/fs2/CompressSpec.scala
@@ -89,7 +89,7 @@ class CompressSpec extends Fs2Spec {
         .through(compress.inflate())
         .compile
         .toVector
-        .asserting(_ == s.toVector)
+        .assert(_ == s.toVector)
     }
 
     "deflate.compresses input" in {
@@ -111,7 +111,7 @@ class CompressSpec extends Fs2Spec {
         .through(compress.gunzip[IO](8192))
         .compile
         .toVector
-        .asserting(_ == s.toVector)
+        .assert(_ == s.toVector)
     }
 
     "gzip |> gunzip ~= id (mutually prime chunk sizes, compression larger)" in forAll {
@@ -121,7 +121,7 @@ class CompressSpec extends Fs2Spec {
           .through(compress.gunzip[IO](509))
           .compile
           .toVector
-          .asserting(_ == s.toVector)
+          .assert(_ == s.toVector)
     }
 
     "gzip |> gunzip ~= id (mutually prime chunk sizes, decompression larger)" in forAll {
@@ -131,7 +131,7 @@ class CompressSpec extends Fs2Spec {
           .through(compress.gunzip[IO](1031))
           .compile
           .toVector
-          .asserting(_ == s.toVector)
+          .assert(_ == s.toVector)
     }
 
     "gzip |> GZIPInputStream ~= id" in forAll { s: Stream[Pure, Byte] =>

--- a/core/jvm/src/test/scala/fs2/CompressSpec.scala
+++ b/core/jvm/src/test/scala/fs2/CompressSpec.scala
@@ -89,7 +89,7 @@ class CompressSpec extends Fs2Spec {
         .through(compress.inflate())
         .compile
         .toVector
-        .assert(_ == s.toVector)
+        .asserting(it => assert(it == s.toVector))
     }
 
     "deflate.compresses input" in {
@@ -111,7 +111,7 @@ class CompressSpec extends Fs2Spec {
         .through(compress.gunzip[IO](8192))
         .compile
         .toVector
-        .assert(_ == s.toVector)
+        .asserting(it => assert(it == s.toVector))
     }
 
     "gzip |> gunzip ~= id (mutually prime chunk sizes, compression larger)" in forAll {
@@ -121,7 +121,7 @@ class CompressSpec extends Fs2Spec {
           .through(compress.gunzip[IO](509))
           .compile
           .toVector
-          .assert(_ == s.toVector)
+          .asserting(it => assert(it == s.toVector))
     }
 
     "gzip |> gunzip ~= id (mutually prime chunk sizes, decompression larger)" in forAll {
@@ -131,7 +131,7 @@ class CompressSpec extends Fs2Spec {
           .through(compress.gunzip[IO](1031))
           .compile
           .toVector
-          .assert(_ == s.toVector)
+          .asserting(it => assert(it == s.toVector))
     }
 
     "gzip |> GZIPInputStream ~= id" in forAll { s: Stream[Pure, Byte] =>

--- a/core/jvm/src/test/scala/fs2/CompressSpec.scala
+++ b/core/jvm/src/test/scala/fs2/CompressSpec.scala
@@ -52,7 +52,7 @@ class CompressSpec extends Fs2Spec {
           )
           .toVector
 
-        actual should equal(expected)
+        assert(actual == expected)
     }
 
     "inflate input" in forAll(strings, intsBetween(0, 9), booleans) {
@@ -76,7 +76,7 @@ class CompressSpec extends Fs2Spec {
             .through(inflate(nowrap = nowrap))
             .compile
             .toVector
-          actualInflated should equal(Right(expectedInflated))
+          assert(actualInflated == Right(expectedInflated))
         }
 
         expectEqual(actualDeflated.toArray, expectedDeflated.toArray)
@@ -89,7 +89,7 @@ class CompressSpec extends Fs2Spec {
         .through(compress.inflate())
         .compile
         .toVector
-        .asserting(_ shouldBe s.toVector)
+        .asserting(_ == s.toVector)
     }
 
     "deflate.compresses input" in {
@@ -102,7 +102,7 @@ class CompressSpec extends Fs2Spec {
       val compressed =
         Stream.chunk(Chunk.bytes(uncompressed)).through(deflate(9)).toVector
 
-      compressed.length should be < uncompressed.length
+      assert(compressed.length < uncompressed.length)
     }
 
     "gzip |> gunzip ~= id" in forAll { s: Stream[Pure, Byte] =>
@@ -111,7 +111,7 @@ class CompressSpec extends Fs2Spec {
         .through(compress.gunzip[IO](8192))
         .compile
         .toVector
-        .asserting(_ shouldBe s.toVector)
+        .asserting(_ == s.toVector)
     }
 
     "gzip |> gunzip ~= id (mutually prime chunk sizes, compression larger)" in forAll {
@@ -121,7 +121,7 @@ class CompressSpec extends Fs2Spec {
           .through(compress.gunzip[IO](509))
           .compile
           .toVector
-          .asserting(_ shouldBe s.toVector)
+          .asserting(_ == s.toVector)
     }
 
     "gzip |> gunzip ~= id (mutually prime chunk sizes, decompression larger)" in forAll {
@@ -131,7 +131,7 @@ class CompressSpec extends Fs2Spec {
           .through(compress.gunzip[IO](1031))
           .compile
           .toVector
-          .asserting(_ shouldBe s.toVector)
+          .asserting(_ == s.toVector)
     }
 
     "gzip |> GZIPInputStream ~= id" in forAll { s: Stream[Pure, Byte] =>
@@ -150,7 +150,7 @@ class CompressSpec extends Fs2Spec {
         read = gzis.read()
       }
 
-      buffer.toVector shouldBe s.toVector
+      assert(buffer.toVector == s.toVector)
     }
 
     "gzip.compresses input" in {
@@ -166,7 +166,7 @@ class CompressSpec extends Fs2Spec {
         .compile
         .toVector
 
-      compressed.length should be < uncompressed.length
+      assert(compressed.length < uncompressed.length)
     }
   }
 }

--- a/core/jvm/src/test/scala/fs2/HashSpec.scala
+++ b/core/jvm/src/test/scala/fs2/HashSpec.scala
@@ -68,7 +68,7 @@ class HashSpec extends Fs2Spec {
     (for {
       once <- s.compile.toVector
       oneHundred <- Vector.fill(100)(s.compile.toVector).parSequence
-    } yield (once, oneHundred)).asserting {
+    } yield (once, oneHundred)).assert {
       case (once, oneHundred) => oneHundred == Vector.fill(100)(once)
     }
   }

--- a/core/jvm/src/test/scala/fs2/HashSpec.scala
+++ b/core/jvm/src/test/scala/fs2/HashSpec.scala
@@ -22,7 +22,7 @@ class HashSpec extends Fs2Spec {
           .foldLeft(Stream.empty.covaryOutput[Byte])((acc, c) => acc ++ Stream.chunk(Chunk.bytes(c))
           )
 
-    s.through(h).toList shouldBe digest(algo, str)
+    assert(s.through(h).toList == digest(algo, str))
   }
 
   "digests" - {
@@ -47,13 +47,16 @@ class HashSpec extends Fs2Spec {
   }
 
   "empty input" in {
-    Stream.empty.through(sha1).toList should have size (20)
+    assert(Stream.empty.through(sha1).toList.size == 20)
   }
 
   "zero or one output" in forAll { (lb: List[Array[Byte]]) =>
-    lb.foldLeft(Stream.empty.covaryOutput[Byte])((acc, b) => acc ++ Stream.chunk(Chunk.bytes(b)))
+    val size = lb
+      .foldLeft(Stream.empty.covaryOutput[Byte])((acc, b) => acc ++ Stream.chunk(Chunk.bytes(b)))
       .through(sha1)
-      .toList should have size (20)
+      .toList
+      .size
+    assert(size == 20)
   }
 
   "thread-safety" in {
@@ -66,7 +69,7 @@ class HashSpec extends Fs2Spec {
       once <- s.compile.toVector
       oneHundred <- Vector.fill(100)(s.compile.toVector).parSequence
     } yield (once, oneHundred)).asserting {
-      case (once, oneHundred) => oneHundred shouldBe Vector.fill(100)(once)
+      case (once, oneHundred) => oneHundred == Vector.fill(100)(once)
     }
   }
 }

--- a/core/jvm/src/test/scala/fs2/HashSpec.scala
+++ b/core/jvm/src/test/scala/fs2/HashSpec.scala
@@ -68,8 +68,8 @@ class HashSpec extends Fs2Spec {
     (for {
       once <- s.compile.toVector
       oneHundred <- Vector.fill(100)(s.compile.toVector).parSequence
-    } yield (once, oneHundred)).assert {
-      case (once, oneHundred) => oneHundred == Vector.fill(100)(once)
+    } yield (once, oneHundred)).asserting {
+      case (once, oneHundred) => assert(oneHundred == Vector.fill(100)(once))
     }
   }
 }

--- a/core/shared/src/test/scala/fs2/ChunkQueueSpec.scala
+++ b/core/shared/src/test/scala/fs2/ChunkQueueSpec.scala
@@ -7,7 +7,7 @@ class ChunkQueueSpec extends Fs2Spec {
     "take" in {
       forAll { (chunks: List[Chunk[Int]], n: Int) =>
         val result = Chunk.Queue(chunks: _*).take(n)
-        result.toChunk.toList shouldBe chunks.flatMap(_.toList).take(n)
+        assert(result.toChunk.toList == chunks.flatMap(_.toList).take(n))
         result.chunks.size should be <= chunks.size
       }
     }
@@ -15,7 +15,7 @@ class ChunkQueueSpec extends Fs2Spec {
     "drop" in {
       forAll { (chunks: List[Chunk[Int]], n: Int) =>
         val result = Chunk.Queue(chunks: _*).drop(n)
-        result.toChunk.toList shouldBe chunks.flatMap(_.toList).drop(n)
+        assert(result.toChunk.toList == chunks.flatMap(_.toList).drop(n))
         result.chunks.size should be <= chunks.size
       }
     }
@@ -23,7 +23,7 @@ class ChunkQueueSpec extends Fs2Spec {
     "takeRight" in {
       forAll { (chunks: List[Chunk[Int]], n: Int) =>
         val result = Chunk.Queue(chunks: _*).takeRight(n)
-        result.toChunk.toList shouldBe chunks.flatMap(_.toList).takeRight(n)
+        assert(result.toChunk.toList == chunks.flatMap(_.toList).takeRight(n))
         result.chunks.size should be <= chunks.size
       }
     }
@@ -31,7 +31,7 @@ class ChunkQueueSpec extends Fs2Spec {
     "dropRight" in {
       forAll { (chunks: List[Chunk[Int]], n: Int) =>
         val result = Chunk.Queue(chunks: _*).dropRight(n)
-        result.toChunk.toList shouldBe chunks.flatMap(_.toList).dropRight(n)
+        assert(result.toChunk.toList == chunks.flatMap(_.toList).dropRight(n))
         result.chunks.size should be <= chunks.size
       }
     }
@@ -39,8 +39,8 @@ class ChunkQueueSpec extends Fs2Spec {
     "equals" in {
       forAll { (chunks: List[Chunk[Int]]) =>
         val cq = Chunk.Queue(chunks: _*)
-        cq shouldBe cq
-        cq shouldBe Chunk.Queue(chunks: _*)
+        assert(cq == cq)
+        assert(cq == Chunk.Queue(chunks: _*))
         if (cq.size > 1) cq.drop(1) should not be cq
         else Succeeded
       }
@@ -49,8 +49,8 @@ class ChunkQueueSpec extends Fs2Spec {
     "hashCode" in {
       forAll { (chunks: List[Chunk[Int]]) =>
         val cq = Chunk.Queue(chunks: _*)
-        cq.hashCode shouldBe cq.hashCode
-        cq.hashCode shouldBe Chunk.Queue(chunks: _*).hashCode
+        assert(cq.hashCode == cq.hashCode)
+        assert(cq.hashCode == Chunk.Queue(chunks: _*).hashCode)
         if (cq.size > 1) cq.drop(1).hashCode should not be cq.hashCode
         else Succeeded
       }

--- a/core/shared/src/test/scala/fs2/ChunkQueueSpec.scala
+++ b/core/shared/src/test/scala/fs2/ChunkQueueSpec.scala
@@ -8,7 +8,7 @@ class ChunkQueueSpec extends Fs2Spec {
       forAll { (chunks: List[Chunk[Int]], n: Int) =>
         val result = Chunk.Queue(chunks: _*).take(n)
         assert(result.toChunk.toList == chunks.flatMap(_.toList).take(n))
-        result.chunks.size should be <= chunks.size
+        assert(result.chunks.size <= chunks.size)
       }
     }
 
@@ -16,7 +16,7 @@ class ChunkQueueSpec extends Fs2Spec {
       forAll { (chunks: List[Chunk[Int]], n: Int) =>
         val result = Chunk.Queue(chunks: _*).drop(n)
         assert(result.toChunk.toList == chunks.flatMap(_.toList).drop(n))
-        result.chunks.size should be <= chunks.size
+        assert(result.chunks.size <= chunks.size)
       }
     }
 
@@ -24,7 +24,7 @@ class ChunkQueueSpec extends Fs2Spec {
       forAll { (chunks: List[Chunk[Int]], n: Int) =>
         val result = Chunk.Queue(chunks: _*).takeRight(n)
         assert(result.toChunk.toList == chunks.flatMap(_.toList).takeRight(n))
-        result.chunks.size should be <= chunks.size
+        assert(result.chunks.size <= chunks.size)
       }
     }
 
@@ -32,7 +32,7 @@ class ChunkQueueSpec extends Fs2Spec {
       forAll { (chunks: List[Chunk[Int]], n: Int) =>
         val result = Chunk.Queue(chunks: _*).dropRight(n)
         assert(result.toChunk.toList == chunks.flatMap(_.toList).dropRight(n))
-        result.chunks.size should be <= chunks.size
+        assert(result.chunks.size <= chunks.size)
       }
     }
 
@@ -41,7 +41,7 @@ class ChunkQueueSpec extends Fs2Spec {
         val cq = Chunk.Queue(chunks: _*)
         assert(cq == cq)
         assert(cq == Chunk.Queue(chunks: _*))
-        if (cq.size > 1) cq.drop(1) should not be cq
+        if (cq.size > 1) assert(cq.drop(1) != cq)
         else Succeeded
       }
     }
@@ -51,7 +51,7 @@ class ChunkQueueSpec extends Fs2Spec {
         val cq = Chunk.Queue(chunks: _*)
         assert(cq.hashCode == cq.hashCode)
         assert(cq.hashCode == Chunk.Queue(chunks: _*).hashCode)
-        if (cq.size > 1) cq.drop(1).hashCode should not be cq.hashCode
+        if (cq.size > 1) assert(cq.drop(1).hashCode != cq.hashCode)
         else Succeeded
       }
     }

--- a/core/shared/src/test/scala/fs2/ChunkSpec.scala
+++ b/core/shared/src/test/scala/fs2/ChunkSpec.scala
@@ -18,15 +18,15 @@ class ChunkSpec extends Fs2Spec {
 
   "Chunk" - {
     "chunk-formation (1)" in {
-      Chunk.empty.toList shouldBe List()
-      Chunk.singleton(23).toList shouldBe List(23)
+      assert(Chunk.empty.toList == List())
+      assert(Chunk.singleton(23).toList == List(23))
     }
 
     "chunk-formation (2)" in forAll { (c: Vector[Int]) =>
-      Chunk.seq(c).toVector shouldBe c
-      Chunk.seq(c).toList shouldBe c.toList
-      Chunk.indexedSeq(c).toVector shouldBe c
-      Chunk.indexedSeq(c).toList shouldBe c.toList
+      assert(Chunk.seq(c).toVector == c)
+      assert(Chunk.seq(c).toList == c.toList)
+      assert(Chunk.indexedSeq(c).toVector == c)
+      assert(Chunk.indexedSeq(c).toList == c.toList)
     }
 
     "Chunk.apply is optimized" in {
@@ -65,21 +65,21 @@ class ChunkSpec extends Fs2Spec {
     s"$name" - {
       implicit val implicitChunkGenerator: Generator[Chunk[A]] = genChunk
       "size" in forAll { (c: Chunk[A]) =>
-        c.size shouldBe c.toList.size
+        assert(c.size == c.toList.size)
       }
       "take" in forAll { (c: Chunk[A], n: PosZInt) =>
-        c.take(n).toVector shouldBe c.toVector.take(n)
+        assert(c.take(n).toVector == c.toVector.take(n))
       }
       "drop" in forAll { (c: Chunk[A], n: PosZInt) =>
-        c.drop(n).toVector shouldBe c.toVector.drop(n)
+        assert(c.drop(n).toVector == c.toVector.drop(n))
       }
       "isEmpty" in forAll { (c: Chunk[A]) =>
-        c.isEmpty shouldBe c.toList.isEmpty
+        assert(c.isEmpty == c.toList.isEmpty)
       }
       "toArray" in forAll { c: Chunk[A] =>
-        c.toArray.toVector shouldBe c.toVector
+        assert(c.toArray.toVector == c.toVector)
         // Do it twice to make sure the first time didn't mutate state
-        c.toArray.toVector shouldBe c.toVector
+        assert(c.toArray.toVector == c.toVector)
       }
       "copyToArray" in forAll { c: Chunk[A] =>
         val arr = new Array[A](c.size * 2)
@@ -97,7 +97,7 @@ class ChunkSpec extends Fs2Spec {
       }
       "scanLeft" in forAll { c: Chunk[A] =>
         def step(acc: List[A], item: A) = acc :+ item
-        c.scanLeft(List[A]())(step).toList shouldBe (c.toList.scanLeft(List[A]())(step))
+        assert(c.scanLeft(List[A]())(step).toList == (c.toList.scanLeft(List[A]())(step)))
       }
       "scanLeftCarry" in forAll { c: Chunk[A] =>
         def step(acc: List[A], item: A) = acc :+ item
@@ -112,7 +112,7 @@ class ChunkSpec extends Fs2Spec {
           implicit val ev: A =:= Byte = null
           val arr = new Array[Byte](c.size)
           c.toByteBuffer.get(arr, 0, c.size)
-          arr.toVector shouldBe c.toArray.toVector
+          assert(arr.toVector == c.toArray.toVector)
         }
 
       import org.scalacheck.GeneratorCompat._

--- a/core/shared/src/test/scala/fs2/CompositeFailureTest.scala
+++ b/core/shared/src/test/scala/fs2/CompositeFailureTest.scala
@@ -13,8 +13,8 @@ class CompositeFailureTest extends Fs2Spec {
         err(3),
         List(CompositeFailure(err(4), err(5)))
       )
-      compositeFailure.all.map(_.getMessage) shouldBe NonEmptyList.of("1", "2", "3", "4", "5")
-      compositeFailure.all.collect { case cf: CompositeFailure => cf } shouldBe empty
+      assert(compositeFailure.all.map(_.getMessage) == NonEmptyList.of("1", "2", "3", "4", "5"))
+      assert(compositeFailure.all.collect { case cf: CompositeFailure => cf }.isEmpty)
     }
   }
 }

--- a/core/shared/src/test/scala/fs2/Fs2Spec.scala
+++ b/core/shared/src/test/scala/fs2/Fs2Spec.scala
@@ -8,7 +8,7 @@ import cats.effect.{ContextShift, Fiber, IO, Sync, Timer}
 import cats.implicits._
 
 import org.scalactic.{Prettifier, source}
-import org.scalatest.{Args, Assertion, Matchers, Status, Succeeded}
+import org.scalatest.{Args, Assertion, Assertions, Matchers, Status, Succeeded}
 import org.scalatest.concurrent.AsyncTimeLimitedTests
 import org.scalatest.freespec.AsyncFreeSpec
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
@@ -106,10 +106,10 @@ abstract class Fs2Spec
       * IO(1).asserting(_ == 1)
       * }}}
       */
-    def asserting(
+    def assert(
         f: A => Boolean
     )(implicit prettifier: Prettifier, pos: source.Position, F: Sync[F]): F[Assertion] =
-      self.flatMap(a => F.delay(assert(f(a))))
+      self.flatMap(a => F.delay(Assertions.assert(f(a))))
 
     /**
       * Asserts that the `F[A]` completes with an `A` and no exception is thrown.

--- a/core/shared/src/test/scala/fs2/Fs2Spec.scala
+++ b/core/shared/src/test/scala/fs2/Fs2Spec.scala
@@ -7,7 +7,7 @@ import cats.{Functor, Monad}
 import cats.effect.{ContextShift, Fiber, IO, Sync, Timer}
 import cats.implicits._
 
-import org.scalatest.{Args, Assertion, Matchers, Status, Succeeded}
+import org.scalatest.{Args, Assertion, Status, Succeeded}
 import org.scalatest.concurrent.AsyncTimeLimitedTests
 import org.scalatest.freespec.AsyncFreeSpec
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
@@ -19,7 +19,6 @@ import org.typelevel.discipline.Laws
 abstract class Fs2Spec
     extends AsyncFreeSpec
     with AsyncTimeLimitedTests
-    with Matchers
     with GeneratorDrivenPropertyChecks
     with Checkers
     with MiscellaneousGenerators

--- a/core/shared/src/test/scala/fs2/Fs2Spec.scala
+++ b/core/shared/src/test/scala/fs2/Fs2Spec.scala
@@ -92,7 +92,7 @@ abstract class Fs2Spec
       * Asserts that the `F[A]` completes with an `A` which passes the supplied function.
       *
       * @example {{{
-      * IO(1).asserting(_ shouldBe 1)
+      * IO(1).asserting(it => assert(it == 1))
       * }}}
       */
     def asserting(f: A => Assertion)(implicit F: Sync[F]): F[Assertion] =

--- a/core/shared/src/test/scala/fs2/Fs2Spec.scala
+++ b/core/shared/src/test/scala/fs2/Fs2Spec.scala
@@ -136,4 +136,11 @@ abstract class Fs2Spec
   protected def checkAll(name: String, ruleSet: Laws#RuleSet): Unit =
     for ((id, prop) <- ruleSet.all.properties)
       s"${name}.${id}" in check(prop)
+
+  protected def containSameElements(s1: Seq[_], s2: Seq[_]): Boolean =
+    s1.length == s2.length && s1.diff(s2).isEmpty
+
+  protected def leftContainsAllOfRight(s1: Seq[_], s2: Seq[_]): Boolean =
+    s2.forall(s1.contains)
+
 }

--- a/core/shared/src/test/scala/fs2/Fs2Spec.scala
+++ b/core/shared/src/test/scala/fs2/Fs2Spec.scala
@@ -7,8 +7,7 @@ import cats.{Functor, Monad}
 import cats.effect.{ContextShift, Fiber, IO, Sync, Timer}
 import cats.implicits._
 
-import org.scalactic.{Prettifier, source}
-import org.scalatest.{Args, Assertion, Assertions, Matchers, Status, Succeeded}
+import org.scalatest.{Args, Assertion, Matchers, Status, Succeeded}
 import org.scalatest.concurrent.AsyncTimeLimitedTests
 import org.scalatest.freespec.AsyncFreeSpec
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
@@ -98,18 +97,6 @@ abstract class Fs2Spec
       */
     def asserting(f: A => Assertion)(implicit F: Sync[F]): F[Assertion] =
       self.flatMap(a => F.delay(f(a)))
-
-    /**
-      * Asserts that the `F[A]` completes with an `A` which passes the supplied function.
-      *
-      * @example {{{
-      * IO(1).asserting(_ == 1)
-      * }}}
-      */
-    def assert(
-        f: A => Boolean
-    )(implicit prettifier: Prettifier, pos: source.Position, F: Sync[F]): F[Assertion] =
-      self.flatMap(a => F.delay(Assertions.assert(f(a))))
 
     /**
       * Asserts that the `F[A]` completes with an `A` and no exception is thrown.

--- a/core/shared/src/test/scala/fs2/Fs2Spec.scala
+++ b/core/shared/src/test/scala/fs2/Fs2Spec.scala
@@ -7,6 +7,7 @@ import cats.{Functor, Monad}
 import cats.effect.{ContextShift, Fiber, IO, Sync, Timer}
 import cats.implicits._
 
+import org.scalactic.{Prettifier, source}
 import org.scalatest.{Args, Assertion, Matchers, Status, Succeeded}
 import org.scalatest.concurrent.AsyncTimeLimitedTests
 import org.scalatest.freespec.AsyncFreeSpec
@@ -97,6 +98,18 @@ abstract class Fs2Spec
       */
     def asserting(f: A => Assertion)(implicit F: Sync[F]): F[Assertion] =
       self.flatMap(a => F.delay(f(a)))
+
+    /**
+      * Asserts that the `F[A]` completes with an `A` which passes the supplied function.
+      *
+      * @example {{{
+      * IO(1).asserting(_ == 1)
+      * }}}
+      */
+    def asserting(
+        f: A => Boolean
+    )(implicit prettifier: Prettifier, pos: source.Position, F: Sync[F]): F[Assertion] =
+      self.flatMap(a => F.delay(assert(f(a))))
 
     /**
       * Asserts that the `F[A]` completes with an `A` and no exception is thrown.

--- a/core/shared/src/test/scala/fs2/HotswapSpec.scala
+++ b/core/shared/src/test/scala/fs2/HotswapSpec.scala
@@ -13,11 +13,13 @@ class HotswapSpec extends Fs2Spec {
             logger.logInfo("using")
           }
           .compile
-          .drain *> logger.get.asserting(
-          _ shouldBe List(
-            LogEvent.Acquired("a"),
-            LogEvent.Info("using"),
-            LogEvent.Released("a")
+          .drain *> logger.get.asserting(it =>
+          assert(
+            it == List(
+              LogEvent.Acquired("a"),
+              LogEvent.Info("using"),
+              LogEvent.Released("a")
+            )
           )
         )
       }
@@ -36,17 +38,19 @@ class HotswapSpec extends Fs2Spec {
                 logger.logInfo("using c")
           }
           .compile
-          .drain *> logger.get.asserting(
-          _ shouldBe List(
-            LogEvent.Acquired("a"),
-            LogEvent.Info("using a"),
-            LogEvent.Acquired("b"),
-            LogEvent.Released("a"),
-            LogEvent.Info("using b"),
-            LogEvent.Acquired("c"),
-            LogEvent.Released("b"),
-            LogEvent.Info("using c"),
-            LogEvent.Released("c")
+          .drain *> logger.get.asserting(it =>
+          assert(
+            it == List(
+              LogEvent.Acquired("a"),
+              LogEvent.Info("using a"),
+              LogEvent.Acquired("b"),
+              LogEvent.Released("a"),
+              LogEvent.Info("using b"),
+              LogEvent.Acquired("c"),
+              LogEvent.Released("b"),
+              LogEvent.Info("using c"),
+              LogEvent.Released("c")
+            )
           )
         )
       }
@@ -63,12 +67,14 @@ class HotswapSpec extends Fs2Spec {
                 logger.logInfo("after clear")
           }
           .compile
-          .drain *> logger.get.asserting(
-          _ shouldBe List(
-            LogEvent.Acquired("a"),
-            LogEvent.Info("using a"),
-            LogEvent.Released("a"),
-            LogEvent.Info("after clear")
+          .drain *> logger.get.asserting(it =>
+          assert(
+            it == List(
+              LogEvent.Acquired("a"),
+              LogEvent.Info("using a"),
+              LogEvent.Released("a"),
+              LogEvent.Info("after clear")
+            )
           )
         )
       }

--- a/core/shared/src/test/scala/fs2/PullSpec.scala
+++ b/core/shared/src/test/scala/fs2/PullSpec.scala
@@ -16,7 +16,7 @@ class PullSpec extends Fs2Spec {
           .compile
           .toList
           .flatMap(_ => ref.get)
-          .asserting(_ shouldBe 1)
+          .asserting(it => assert(it == 1))
       }
     }
 

--- a/core/shared/src/test/scala/fs2/PullSpec.scala
+++ b/core/shared/src/test/scala/fs2/PullSpec.scala
@@ -24,9 +24,9 @@ class PullSpec extends Fs2Spec {
       val pull: Pull[Fallible, Int, Unit] = Pull.fromEither[Fallible](either)
 
       either match {
-        case Left(l) => pull.stream.compile.toList shouldBe Left(l)
+        case Left(l) => assert(pull.stream.compile.toList == Left(l))
         case Right(r) =>
-          pull.stream.compile.toList shouldBe Right(List(r))
+          assert(pull.stream.compile.toList == Right(List(r)))
       }
     }
   }

--- a/core/shared/src/test/scala/fs2/StreamPerformanceSpec.scala
+++ b/core/shared/src/test/scala/fs2/StreamPerformanceSpec.scala
@@ -10,8 +10,10 @@ class StreamPerformanceSpec extends Fs2Spec {
     "left-associated ++" - {
       Ns.foreach { N =>
         N.toString in {
-          (1 until N).map(Stream.emit).foldLeft(Stream.emit(0))(_ ++ _).toVector shouldBe Vector
-            .range(0, N)
+          assert(
+            (1 until N).map(Stream.emit).foldLeft(Stream.emit(0))(_ ++ _).toVector == Vector
+              .range(0, N)
+          )
         }
       }
     }
@@ -19,10 +21,12 @@ class StreamPerformanceSpec extends Fs2Spec {
     "right-associated ++" - {
       Ns.foreach { N =>
         N.toString in {
-          (0 until N)
-            .map(Stream.emit)
-            .foldRight(Stream.empty: Stream[Pure, Int])(_ ++ _)
-            .toVector shouldBe Vector.range(0, N)
+          assert(
+            (0 until N)
+              .map(Stream.emit)
+              .foldRight(Stream.empty: Stream[Pure, Int])(_ ++ _)
+              .toVector == Vector.range(0, N)
+          )
         }
       }
     }
@@ -30,10 +34,12 @@ class StreamPerformanceSpec extends Fs2Spec {
     "left-associated flatMap 1" - {
       Ns.foreach { N =>
         N.toString in {
-          (1 until N)
-            .map(Stream.emit)
-            .foldLeft(Stream.emit(0))((acc, a) => acc.flatMap(_ => a))
-            .toVector shouldBe Vector(N - 1)
+          assert(
+            (1 until N)
+              .map(Stream.emit)
+              .foldLeft(Stream.emit(0))((acc, a) => acc.flatMap(_ => a))
+              .toVector == Vector(N - 1)
+          )
         }
       }
     }
@@ -42,10 +48,12 @@ class StreamPerformanceSpec extends Fs2Spec {
       Ns.foreach { N =>
         N.toString in {
           pending
-          (1 until N)
-            .map(Stream.emit)
-            .foldLeft(Stream.emit(0))((acc, _) => acc.map(_ + 1))
-            .toVector shouldBe Vector(N - 1)
+          assert(
+            (1 until N)
+              .map(Stream.emit)
+              .foldLeft(Stream.emit(0))((acc, _) => acc.map(_ + 1))
+              .toVector == Vector(N - 1)
+          )
         }
       }
     }
@@ -53,14 +61,16 @@ class StreamPerformanceSpec extends Fs2Spec {
     "left-associated eval() ++ flatMap 1" - {
       Ns.foreach { N =>
         N.toString in {
-          (1 until N)
-            .map(Stream.emit)
-            .foldLeft(Stream.emit(0).covary[IO])((acc, a) =>
-              acc.flatMap(_ => Stream.eval(IO.unit).flatMap(_ => a))
-            )
-            .compile
-            .toVector
-            .unsafeRunSync shouldBe Vector(N - 1)
+          assert(
+            (1 until N)
+              .map(Stream.emit)
+              .foldLeft(Stream.emit(0).covary[IO])((acc, a) =>
+                acc.flatMap(_ => Stream.eval(IO.unit).flatMap(_ => a))
+              )
+              .compile
+              .toVector
+              .unsafeRunSync == Vector(N - 1)
+          )
         }
       }
     }
@@ -68,11 +78,13 @@ class StreamPerformanceSpec extends Fs2Spec {
     "right-associated flatMap 1" - {
       Ns.foreach { N =>
         N.toString in {
-          (1 until N)
-            .map(Stream.emit)
-            .reverse
-            .foldLeft(Stream.emit(0))((acc, a) => a.flatMap(_ => acc))
-            .toVector shouldBe Vector(0)
+          assert(
+            (1 until N)
+              .map(Stream.emit)
+              .reverse
+              .foldLeft(Stream.emit(0))((acc, a) => a.flatMap(_ => acc))
+              .toVector == Vector(0)
+          )
         }
       }
     }
@@ -80,15 +92,17 @@ class StreamPerformanceSpec extends Fs2Spec {
     "right-associated eval() ++ flatMap 1" - {
       Ns.foreach { N =>
         N.toString in {
-          (1 until N)
-            .map(Stream.emit)
-            .reverse
-            .foldLeft(Stream.emit(0).covary[IO])((acc, a) =>
-              a.flatMap(_ => Stream.eval(IO.unit).flatMap(_ => acc))
-            )
-            .compile
-            .toVector
-            .unsafeRunSync shouldBe Vector(0)
+          assert(
+            (1 until N)
+              .map(Stream.emit)
+              .reverse
+              .foldLeft(Stream.emit(0).covary[IO])((acc, a) =>
+                a.flatMap(_ => Stream.eval(IO.unit).flatMap(_ => acc))
+              )
+              .compile
+              .toVector
+              .unsafeRunSync == Vector(0)
+          )
         }
       }
     }
@@ -96,12 +110,14 @@ class StreamPerformanceSpec extends Fs2Spec {
     "left-associated flatMap 2" - {
       Ns.foreach { N =>
         N.toString in {
-          (1 until N)
-            .map(Stream.emit)
-            .foldLeft(Stream.emit(0) ++ Stream.emit(1) ++ Stream.emit(2))((acc, a) =>
-              acc.flatMap(_ => a)
-            )
-            .toVector shouldBe Vector(N - 1, N - 1, N - 1)
+          assert(
+            (1 until N)
+              .map(Stream.emit)
+              .foldLeft(Stream.emit(0) ++ Stream.emit(1) ++ Stream.emit(2))((acc, a) =>
+                acc.flatMap(_ => a)
+              )
+              .toVector == Vector(N - 1, N - 1, N - 1)
+          )
         }
       }
     }
@@ -109,13 +125,15 @@ class StreamPerformanceSpec extends Fs2Spec {
     "right-associated flatMap 2" - {
       Ns.foreach { N =>
         N.toString in {
-          (1 until N)
-            .map(Stream.emit)
-            .reverse
-            .foldLeft(Stream.emit(0) ++ Stream.emit(1) ++ Stream.emit(2))((acc, a) =>
-              a.flatMap(_ => acc)
-            )
-            .toVector shouldBe Vector(0, 1, 2)
+          assert(
+            (1 until N)
+              .map(Stream.emit)
+              .reverse
+              .foldLeft(Stream.emit(0) ++ Stream.emit(1) ++ Stream.emit(2))((acc, a) =>
+                a.flatMap(_ => acc)
+              )
+              .toVector == Vector(0, 1, 2)
+          )
         }
       }
     }
@@ -123,15 +141,17 @@ class StreamPerformanceSpec extends Fs2Spec {
     "transduce (id)" - {
       Ns.foreach { N =>
         N.toString in {
-          (Stream
-            .chunk(Chunk.seq(0 until N)))
-            .repeatPull {
-              _.uncons1.flatMap {
-                case None           => Pull.pure(None)
-                case Some((hd, tl)) => Pull.output1(hd).as(Some(tl))
+          assert(
+            (Stream
+              .chunk(Chunk.seq(0 until N)))
+              .repeatPull {
+                _.uncons1.flatMap {
+                  case None           => Pull.pure(None)
+                  case Some((hd, tl)) => Pull.output1(hd).as(Some(tl))
+                }
               }
-            }
-            .toVector shouldBe Vector.range(0, N)
+              .toVector == Vector.range(0, N)
+          )
         }
       }
     }
@@ -196,8 +216,10 @@ class StreamPerformanceSpec extends Fs2Spec {
     "chunky flatMap" - {
       Ns.foreach { N =>
         N.toString in {
-          Stream.emits(Vector.range(0, N)).flatMap(i => Stream.emit(i)).toVector shouldBe Vector
-            .range(0, N)
+          assert(
+            Stream.emits(Vector.range(0, N)).flatMap(i => Stream.emit(i)).toVector == Vector
+              .range(0, N)
+          )
         }
       }
     }
@@ -205,12 +227,14 @@ class StreamPerformanceSpec extends Fs2Spec {
     "chunky map with uncons" - {
       Ns.foreach { N =>
         N.toString in {
-          Stream
-            .emits(Vector.range(0, N))
-            .map(i => i)
-            .chunks
-            .flatMap(Stream.chunk(_))
-            .toVector shouldBe Vector.range(0, N)
+          assert(
+            Stream
+              .emits(Vector.range(0, N))
+              .map(i => i)
+              .chunks
+              .flatMap(Stream.chunk(_))
+              .toVector == Vector.range(0, N)
+          )
         }
       }
     }

--- a/core/shared/src/test/scala/fs2/StreamPerformanceSpec.scala
+++ b/core/shared/src/test/scala/fs2/StreamPerformanceSpec.scala
@@ -156,8 +156,8 @@ class StreamPerformanceSpec extends Fs2Spec {
                   .flatMap(_ => (ok.get, open.get).tupled)
                   .asserting {
                     case (ok, open) =>
-                      ok shouldBe N
-                      open shouldBe 0
+                      assert(ok == N)
+                      assert(open == 0)
                   }
               }
             }

--- a/core/shared/src/test/scala/fs2/StreamPerformanceSpec.scala
+++ b/core/shared/src/test/scala/fs2/StreamPerformanceSpec.scala
@@ -183,8 +183,8 @@ class StreamPerformanceSpec extends Fs2Spec {
                   .flatMap(_ => (ok.get, open.get).tupled)
                   .asserting {
                     case (ok, open) =>
-                      ok shouldBe N
-                      open shouldBe 0
+                      assert(ok == N)
+                      assert(open == 0)
                   }
               }
             }

--- a/core/shared/src/test/scala/fs2/StreamSpec.scala
+++ b/core/shared/src/test/scala/fs2/StreamSpec.scala
@@ -7,10 +7,10 @@ import cats.effect.concurrent.{Deferred, Ref, Semaphore}
 import cats.implicits._
 import scala.concurrent.duration._
 import org.scalactic.anyvals._
-import org.scalatest.{Assertion, Succeeded}
+import org.scalatest.{Assertion, Matchers, Succeeded}
 import fs2.concurrent.{Queue, SignallingRef}
 
-class StreamSpec extends Fs2Spec {
+class StreamSpec extends Fs2Spec with Matchers {
   "Stream" - {
     "++" in forAll { (s1: Stream[Pure, Int], s2: Stream[Pure, Int]) =>
       assert((s1 ++ s2).toList == (s1.toList ++ s2.toList))

--- a/core/shared/src/test/scala/fs2/StreamSpec.scala
+++ b/core/shared/src/test/scala/fs2/StreamSpec.scala
@@ -344,7 +344,7 @@ class StreamSpec extends Fs2Spec {
 
     "buffer" - {
       "identity" in forAll { (s: Stream[Pure, Int], n: PosInt) =>
-        s.buffer(n).toVector shouldBe s.toVector
+        assert(s.buffer(n).toVector == s.toVector)
       }
 
       "buffer results of evalMap" in forAll { (s: Stream[Pure, Int], n0: PosInt) =>
@@ -366,7 +366,7 @@ class StreamSpec extends Fs2Spec {
 
     "bufferAll" - {
       "identity" in forAll { (s: Stream[Pure, Int]) =>
-        s.bufferAll.toVector shouldBe s.toVector
+        assert(s.bufferAll.toVector == s.toVector)
       }
 
       "buffer results of evalMap" in forAll { (s: Stream[Pure, Int]) =>
@@ -465,7 +465,7 @@ class StreamSpec extends Fs2Spec {
 
     "chunk" in {
       forAll { (c: Chunk[Int]) =>
-        Stream.chunk(c).compile.to(Chunk) shouldBe c
+        assert(Stream.chunk(c).compile.to(Chunk) == c)
       }
     }
 
@@ -473,7 +473,7 @@ class StreamSpec extends Fs2Spec {
       val n = n0 % 20 + 1
       val sizeV = s.chunkLimit(n).toVector.map(_.size)
       sizeV.forall(_ <= n) shouldBe true
-      sizeV.combineAll shouldBe s.toVector.size
+      assert(sizeV.combineAll == s.toVector.size)
     }
 
     "chunkMin" in forAll { (s: Stream[Pure, Int], n0: PosInt) =>
@@ -488,12 +488,12 @@ class StreamSpec extends Fs2Spec {
       chunkedV.dropRight(1).forall(_.size >= n) shouldBe true
       // Equivalent to last chunk with allowFewerTotal
       if (chunkedV.nonEmpty && chunkedV.last.size < n)
-        chunkedV.dropRight(1) shouldBe withIfSmallerV
+        assert(chunkedV.dropRight(1) == withIfSmallerV)
       // Flattened sequence with allowFewerTotal true is equal to vector without chunking
       chunkedV.foldLeft(Vector.empty[Int])((v, l) => v ++ l.toVector) shouldBe unchunkedV
       // If smaller than Chunk Size and allowFewerTotal false is empty then
       // no elements should be emitted
-      smallerN shouldBe Vector.empty
+      assert(smallerN == Vector.empty)
       // If smaller than Chunk Size and allowFewerTotal true is equal to the size
       // of the taken chunk initially
       smallerY.foldLeft(Vector.empty[Int])((v, l) => v ++ l.toVector) shouldBe smallerSet
@@ -529,23 +529,23 @@ class StreamSpec extends Fs2Spec {
     "chunks" - {
       "chunks.map identity" in forAll { (v: Vector[Vector[Int]]) =>
         val s = if (v.isEmpty) Stream.empty else v.map(Stream.emits).reduce(_ ++ _)
-        s.chunks.map(_.toVector).toVector shouldBe v.filter(_.nonEmpty)
+        assert(s.chunks.map(_.toVector).toVector == v.filter(_.nonEmpty))
       }
 
       "chunks.flatMap(chunk) identity" in forAll { (v: Vector[Vector[Int]]) =>
         val s = if (v.isEmpty) Stream.empty else v.map(Stream.emits).reduce(_ ++ _)
-        s.chunks.flatMap(Stream.chunk).toVector shouldBe v.flatten
+        assert(s.chunks.flatMap(Stream.chunk).toVector == v.flatten)
       }
     }
 
     "collect" in forAll { (s: Stream[Pure, Int]) =>
       val pf: PartialFunction[Int, Int] = { case x if x % 2 == 0 => x }
-      s.collect(pf).toVector shouldBe s.toVector.collect(pf)
+      assert(s.collect(pf).toVector == s.toVector.collect(pf))
     }
 
     "collectFirst" in forAll { (s: Stream[Pure, Int]) =>
       val pf: PartialFunction[Int, Int] = { case x if x % 2 == 0 => x }
-      s.collectFirst(pf).toVector shouldBe s.collectFirst(pf).toVector
+      assert(s.collectFirst(pf).toVector == s.collectFirst(pf).toVector)
     }
 
     "compile" - {
@@ -819,8 +819,8 @@ class StreamSpec extends Fs2Spec {
                           } else
                             IO {
                               // still the outer finalizer shall be run, but there is no failure in `s`
-                              finalizers shouldBe List("Outer")
-                              r shouldBe Right(())
+                              assert(finalizers == List("Outer"))
+                              assert(r == Right(()))
                             }
                         }
                       }
@@ -852,11 +852,11 @@ class StreamSpec extends Fs2Spec {
       val v = s.toVector
       val n1 = if (v.isEmpty) 0 else n0 % v.size
       val n = if (negate) -n1 else n1
-      s.drop(n).toVector shouldBe s.toVector.drop(n)
+      assert(s.drop(n).toVector == s.toVector.drop(n))
     }
 
     "dropLast" in forAll { (s: Stream[Pure, Int]) =>
-      s.dropLast.toVector shouldBe s.toVector.dropRight(1)
+      assert(s.dropLast.toVector == s.toVector.dropRight(1))
     }
 
     "dropLastIf" in forAll { (s: Stream[Pure, Int]) =>
@@ -868,13 +868,13 @@ class StreamSpec extends Fs2Spec {
       val v = s.toVector
       val n1 = if (v.isEmpty) 0 else n0 % v.size
       val n = if (negate) -n1 else n1
-      s.dropRight(n).toVector shouldBe v.dropRight(n)
+      assert(s.dropRight(n).toVector == v.dropRight(n))
     }
 
     "dropWhile" in forAll { (s: Stream[Pure, Int], n0: PosZInt) =>
       val n = n0 % 20
       val set = s.toVector.take(n).toSet
-      s.dropWhile(set).toVector shouldBe s.toVector.dropWhile(set)
+      assert(s.dropWhile(set).toVector == s.toVector.dropWhile(set))
     }
 
     "dropThrough" in forAll { (s: Stream[Pure, Int], n0: PosZInt) =>
@@ -1161,38 +1161,38 @@ class StreamSpec extends Fs2Spec {
     "exists" in forAll { (s: Stream[Pure, Int], n0: PosInt) =>
       val n = n0 % 20 + 1
       val f = (i: Int) => i % n == 0
-      s.exists(f).toList shouldBe List(s.toList.exists(f))
+      assert(s.exists(f).toList == List(s.toList.exists(f)))
     }
 
     "filter" - {
       "1" in forAll { (s: Stream[Pure, Int], n0: PosInt) =>
         val n = n0 % 20 + 1
         val predicate = (i: Int) => i % n == 0
-        s.filter(predicate).toList shouldBe s.toList.filter(predicate)
+        assert(s.filter(predicate).toList == s.toList.filter(predicate))
       }
 
       "2" in forAll { (s: Stream[Pure, Double]) =>
         val predicate = (i: Double) => i - i.floor < 0.5
         val s2 = s.mapChunks(c => Chunk.doubles(c.toArray))
-        s2.filter(predicate).toList shouldBe s2.toList.filter(predicate)
+        assert(s2.filter(predicate).toList == s2.toList.filter(predicate))
       }
 
       "3" in forAll { (s: Stream[Pure, Byte]) =>
         val predicate = (b: Byte) => b < 0
         val s2 = s.mapChunks(c => Chunk.bytes(c.toArray))
-        s2.filter(predicate).toList shouldBe s2.toList.filter(predicate)
+        assert(s2.filter(predicate).toList == s2.toList.filter(predicate))
       }
 
       "4" in forAll { (s: Stream[Pure, Boolean]) =>
         val predicate = (b: Boolean) => !b
         val s2 = s.mapChunks(c => Chunk.booleans(c.toArray))
-        s2.filter(predicate).toList shouldBe s2.toList.filter(predicate)
+        assert(s2.filter(predicate).toList == s2.toList.filter(predicate))
       }
     }
 
     "find" in forAll { (s: Stream[Pure, Int], i: Int) =>
       val predicate = (item: Int) => item < i
-      s.find(predicate).toList shouldBe s.toList.find(predicate).toList
+      assert(s.find(predicate).toList == s.toList.find(predicate).toList)
     }
 
     "flatMap" in forAll { (s: Stream[Pure, Stream[Pure, Int]]) =>
@@ -1202,22 +1202,22 @@ class StreamSpec extends Fs2Spec {
     "fold" - {
       "1" in forAll { (s: Stream[Pure, Int], n: Int) =>
         val f = (a: Int, b: Int) => a + b
-        s.fold(n)(f).toList shouldBe List(s.toList.foldLeft(n)(f))
+        assert(s.fold(n)(f).toList == List(s.toList.foldLeft(n)(f)))
       }
 
       "2" in forAll { (s: Stream[Pure, Int], n: String) =>
         val f = (a: String, b: Int) => a + b
-        s.fold(n)(f).toList shouldBe List(s.toList.foldLeft(n)(f))
+        assert(s.fold(n)(f).toList == List(s.toList.foldLeft(n)(f)))
       }
     }
 
     "foldMonoid" - {
       "1" in forAll { (s: Stream[Pure, Int]) =>
-        s.foldMonoid.toVector shouldBe Vector(s.toVector.combineAll)
+        assert(s.foldMonoid.toVector == Vector(s.toVector.combineAll))
       }
 
       "2" in forAll { (s: Stream[Pure, Double]) =>
-        s.foldMonoid.toVector shouldBe Vector(s.toVector.combineAll)
+        assert(s.foldMonoid.toVector == Vector(s.toVector.combineAll))
       }
     }
 
@@ -1232,14 +1232,14 @@ class StreamSpec extends Fs2Spec {
     "forall" in forAll { (s: Stream[Pure, Int], n0: PosInt) =>
       val n = n0 % 20 + 1
       val f = (i: Int) => i % n == 0
-      s.forall(f).toList shouldBe List(s.toList.forall(f))
+      assert(s.forall(f).toList == List(s.toList.forall(f)))
     }
 
     "fromEither" in forAll { either: Either[Throwable, Int] =>
       val stream: Stream[Fallible, Int] = Stream.fromEither[Fallible](either)
       either match {
-        case Left(t)  => stream.toList shouldBe Left(t)
-        case Right(i) => stream.toList shouldBe Right(List(i))
+        case Left(t)  => assert(stream.toList == Left(t))
+        case Right(i) => assert(stream.toList == Right(List(i)))
       }
     }
 
@@ -1264,8 +1264,8 @@ class StreamSpec extends Fs2Spec {
       val f = (i: Int) => i % n
       val s1 = s.groupAdjacentBy(f)
       val s2 = s.map(f).changes
-      s1.map(_._2).toList.flatMap(_.toList) shouldBe s.toList
-      s1.map(_._1).toList shouldBe s2.toList
+      assert(s1.map(_._2).toList.flatMap(_.toList) == s.toList)
+      assert(s1.map(_._1).toList == s2.toList)
       s1.map { case (k, vs) => vs.toVector.forall(f(_) == k) }.toList shouldBe s2
         .map(_ => true)
         .toList
@@ -1275,7 +1275,7 @@ class StreamSpec extends Fs2Spec {
       "limiting" in forAll { (s: Stream[Pure, Int], n0: PosInt) =>
         val n = n0 % 20 + 1
         val s1 = s.groupAdjacentByLimit(n)(_ => true)
-        s1.map(_._2).toList.map(_.toList) shouldBe s.toList.grouped(n).toList
+        assert(s1.map(_._2).toList.map(_.toList) == s.toList.grouped(n).toList)
       }
     }
 
@@ -1561,7 +1561,7 @@ class StreamSpec extends Fs2Spec {
     }
 
     "head" in forAll { (s: Stream[Pure, Int]) =>
-      s.head.toList shouldBe s.toList.take(1)
+      assert(s.head.toList == s.toList.take(1))
     }
 
     "interleave" - {
@@ -2023,17 +2023,17 @@ class StreamSpec extends Fs2Spec {
 
     "last" in forAll { (s: Stream[Pure, Int]) =>
       val _ = s.last
-      s.last.toList shouldBe List(s.toList.lastOption)
+      assert(s.last.toList == List(s.toList.lastOption))
     }
 
     "lastOr" in forAll { (s: Stream[Pure, Int], n0: PosInt) =>
       val n = n0 % 20 + 1
-      s.lastOr(n).toList shouldBe List(s.toList.lastOption.getOrElse(n))
+      assert(s.lastOr(n).toList == List(s.toList.lastOption.getOrElse(n)))
     }
 
     "map" - {
       "map.toList == toList.map" in forAll { (s: Stream[Pure, Int], f: Int => Int) =>
-        s.map(f).toList shouldBe s.toList.map(f)
+        assert(s.map(f).toList == s.toList.map(f))
       }
 
       "regression #1335 - stack safety of map" in {
@@ -2055,7 +2055,7 @@ class StreamSpec extends Fs2Spec {
       val r = s.mapAccumulate(m)((s, i) => (s + i, f(i)))
 
       r.map(_._1).toList shouldBe s.toList.scanLeft(m)(_ + _).tail
-      r.map(_._2).toList shouldBe s.toList.map(f)
+      assert(r.map(_._2).toList == s.toList.map(f))
     }
 
     "mapAsync" - {
@@ -2081,7 +2081,7 @@ class StreamSpec extends Fs2Spec {
     }
 
     "mapChunks" in forAll { (s: Stream[Pure, Int]) =>
-      s.mapChunks(identity).chunks.toList shouldBe s.chunks.toList
+      assert(s.mapChunks(identity).chunks.toList == s.chunks.toList)
     }
 
     "merge" - {
@@ -2176,20 +2176,20 @@ class StreamSpec extends Fs2Spec {
                       case (left, right) =>
                         if (left && right) IO {
                           (finalizers should contain).allOf("Inner L", "Inner R", "Outer")
-                          finalizers.lastOption shouldBe Some("Outer")
-                          r shouldBe Left(err)
+                          assert(finalizers.lastOption == Some("Outer"))
+                          assert(r == Left(err))
                         } else if (left) IO {
                           finalizers shouldBe List("Inner L", "Outer")
-                          if (leftBiased) r shouldBe Left(err)
-                          else r shouldBe Right(())
+                          if (leftBiased) assert(r == Left(err))
+                          else assert(r == Right(()))
                         } else if (right) IO {
                           finalizers shouldBe List("Inner R", "Outer")
-                          if (!leftBiased) r shouldBe Left(err)
-                          else r shouldBe Right(())
+                          if (!leftBiased) assert(r == Left(err))
+                          else assert(r == Right(()))
                         } else
                           IO {
-                            finalizers shouldBe List("Outer")
-                            r shouldBe Right(())
+                            assert(finalizers == List("Outer"))
+                            assert(r == Right(()))
                           }
                     }
                   }
@@ -2505,9 +2505,9 @@ class StreamSpec extends Fs2Spec {
                             s"Inner $idx"
                           }) :+ "Outer"
                           (finalizers should contain).theSameElementsAs(expectedFinalizers)
-                          finalizers.lastOption shouldBe Some("Outer")
-                          if (streamRunned.contains(biasIdx)) r shouldBe Left(err)
-                          else r shouldBe Right(())
+                          assert(finalizers.lastOption == Some("Outer"))
+                          if (streamRunned.contains(biasIdx)) assert(r == Left(err))
+                          else assert(r == Right(()))
                         }
                       }
                     }
@@ -2663,7 +2663,7 @@ class StreamSpec extends Fs2Spec {
     "randomSeeded" in {
       val x = Stream.randomSeeded(1L).take(100).toList
       val y = Stream.randomSeeded(1L).take(100).toList
-      x shouldBe y
+      assert(x == y)
     }
 
     "range" in {
@@ -2686,7 +2686,7 @@ class StreamSpec extends Fs2Spec {
     "rechunkRandomlyWithSeed" - {
       "is deterministic" in forAll { (s0: Stream[Pure, Int], seed: Long) =>
         def s = s0.rechunkRandomlyWithSeed(minFactor = 0.1, maxFactor = 2.0)(seed)
-        s.toList shouldBe s.toList
+        assert(s.toList == s.toList)
       }
 
       "does not drop elements" in forAll { (s: Stream[Pure, Int], seed: Long) =>
@@ -2774,7 +2774,7 @@ class StreamSpec extends Fs2Spec {
     "repeatN" in {
       forAll(intsBetween(1, 200), lists[Int].havingSizesBetween(1, 200)) {
         (n: Int, testValues: List[Int]) =>
-          Stream.emits(testValues).repeatN(n).toList shouldBe List.fill(n)(testValues).flatten
+          assert(Stream.emits(testValues).repeatN(n).toList == List.fill(n)(testValues).flatten)
       }
     }
 
@@ -3124,13 +3124,13 @@ class StreamSpec extends Fs2Spec {
     "scan" - {
       "1" in forAll { (s: Stream[Pure, Int], n: Int) =>
         val f = (a: Int, b: Int) => a + b
-        s.scan(n)(f).toList shouldBe s.toList.scanLeft(n)(f)
+        assert(s.scan(n)(f).toList == s.toList.scanLeft(n)(f))
       }
 
       "2" in {
         val s = Stream(1).map(x => x)
         val f = (a: Int, b: Int) => a + b
-        s.scan(0)(f).toList shouldBe s.toList.scanLeft(0)(f)
+        assert(s.scan(0)(f).toList == s.toList.scanLeft(0)(f))
       }
 
       "temporal" in {
@@ -3367,14 +3367,14 @@ class StreamSpec extends Fs2Spec {
     }
 
     "tail" in forAll { (s: Stream[Pure, Int]) =>
-      s.tail.toList shouldBe s.toList.drop(1)
+      assert(s.tail.toList == s.toList.drop(1))
     }
 
     "take" - {
       "identity" in forAll { (s: Stream[Pure, Int], negate: Boolean, n0: PosInt) =>
         val n1 = n0 % 20 + 1
         val n = if (negate) -n1 else n1
-        s.take(n).toList shouldBe s.toList.take(n)
+        assert(s.take(n).toList == s.toList.take(n))
       }
       "chunks" in {
         val s = Stream(1, 2) ++ Stream(3, 4)
@@ -3385,13 +3385,13 @@ class StreamSpec extends Fs2Spec {
     "takeRight" in forAll { (s: Stream[Pure, Int], negate: Boolean, n0: PosInt) =>
       val n1 = n0 % 20 + 1
       val n = if (negate) -n1 else n1
-      s.takeRight(n).toList shouldBe s.toList.takeRight(n)
+      assert(s.takeRight(n).toList == s.toList.takeRight(n))
     }
 
     "takeWhile" in forAll { (s: Stream[Pure, Int], n0: PosInt) =>
       val n = n0 % 20 + 1
       val set = s.toList.take(n).toSet
-      s.takeWhile(set).toList shouldBe s.toList.takeWhile(set)
+      assert(s.takeWhile(set).toList == s.toList.takeWhile(set))
     }
 
     "takeThrough" in forAll { (s: Stream[Pure, Int], n0: PosInt) =>
@@ -3399,7 +3399,7 @@ class StreamSpec extends Fs2Spec {
       val f = (i: Int) => i % n == 0
       val vec = s.toVector
       val result = vec.takeWhile(f) ++ vec.dropWhile(f).headOption
-      withClue(vec)(s.takeThrough(f).toVector shouldBe result)
+      assert(withClue(vec)(s.takeThrough(f).toVector == result))
     }
 
     "translate" - {
@@ -3580,7 +3580,7 @@ class StreamSpec extends Fs2Spec {
     }
 
     "unNone" in forAll { (s: Stream[Pure, Option[Int]]) =>
-      s.unNone.chunks.toList shouldBe s.filter(_.isDefined).map(_.get).chunks.toList
+      assert(s.unNone.chunks.toList == s.filter(_.isDefined).map(_.get).chunks.toList)
     }
 
     "zip" - {
@@ -3741,7 +3741,7 @@ class StreamSpec extends Fs2Spec {
     }
 
     "zipWithIndex" in forAll { (s: Stream[Pure, Int]) =>
-      s.zipWithIndex.toList shouldBe s.toList.zipWithIndex
+      assert(s.zipWithIndex.toList == s.toList.zipWithIndex)
     }
 
     "zipWithNext" - {
@@ -3753,7 +3753,7 @@ class StreamSpec extends Fs2Spec {
       }
 
       "2" in {
-        Stream().zipWithNext.toList shouldBe Nil
+        assert(Stream().zipWithNext.toList == Nil)
         Stream(0).zipWithNext.toList shouldBe List((0, None))
         Stream(0, 1, 2).zipWithNext.toList shouldBe List((0, Some(1)), (1, Some(2)), (2, None))
       }
@@ -3768,7 +3768,7 @@ class StreamSpec extends Fs2Spec {
       }
 
       "2" in {
-        Stream().zipWithPrevious.toList shouldBe Nil
+        assert(Stream().zipWithPrevious.toList == Nil)
         Stream(0).zipWithPrevious.toList shouldBe List((None, 0))
         Stream(0, 1, 2).zipWithPrevious.toList shouldBe List((None, 0), (Some(0), 1), (Some(1), 2))
       }
@@ -3787,7 +3787,7 @@ class StreamSpec extends Fs2Spec {
       }
 
       "2" in {
-        Stream().zipWithPreviousAndNext.toList shouldBe Nil
+        assert(Stream().zipWithPreviousAndNext.toList == Nil)
         Stream(0).zipWithPreviousAndNext.toList shouldBe List((None, 0, None))
         Stream(0, 1, 2).zipWithPreviousAndNext.toList shouldBe List(
           (None, 0, Some(1)),

--- a/core/shared/src/test/scala/fs2/TextSpec.scala
+++ b/core/shared/src/test/scala/fs2/TextSpec.scala
@@ -66,8 +66,8 @@ class TextSpec extends Fs2Spec {
       }
 
       "utf8Encode |> utf8Decode = id" in forAll { (s: String) =>
-        Stream(s).through(utf8EncodeC).through(utf8DecodeC).toList shouldBe List(s)
-        if (s.nonEmpty) Stream(s).through(utf8Encode).through(utf8Decode).toList shouldBe List(s)
+        assert(Stream(s).through(utf8EncodeC).through(utf8DecodeC).toList == List(s))
+        if (s.nonEmpty) assert(Stream(s).through(utf8Encode).through(utf8Decode).toList == List(s))
         else Succeeded
       }
 
@@ -95,11 +95,11 @@ class TextSpec extends Fs2Spec {
         val bom = Chunk[Byte](0xef.toByte, 0xbb.toByte, 0xbf.toByte)
         "single chunk" in forAll { (s: String) =>
           val c = Chunk.concat(List(bom, utf8Bytes(s)))
-          Stream.chunk(c).through(text.utf8Decode).compile.string shouldBe s
+          assert(Stream.chunk(c).through(text.utf8Decode).compile.string == s)
         }
         "spanning chunks" in forAll { (s: String) =>
           val c = Chunk.concat(List(bom, utf8Bytes(s)))
-          Stream.emits(c.toArray[Byte]).through(text.utf8Decode).compile.string shouldBe s
+          assert(Stream.emits(c.toArray[Byte]).through(text.utf8Decode).compile.string == s)
         }
       }
 
@@ -219,7 +219,7 @@ class TextSpec extends Fs2Spec {
         val lines = lines0.map(escapeCrLf)
         if (lines.toList.nonEmpty) {
           val s = lines.intersperse("\r\n").toList.mkString
-          Stream.emit(s).through(text.lines).toList shouldBe lines.toList
+          assert(Stream.emit(s).through(text.lines).toList == lines.toList)
         } else Succeeded
       }
 
@@ -227,10 +227,10 @@ class TextSpec extends Fs2Spec {
         val lines = lines0.map(escapeCrLf)
         val s = lines.intersperse("\r\n").toList.mkString.grouped(3).toList
         if (s.isEmpty) {
-          Stream.emits(s).through(text.lines).toList shouldBe Nil
+          assert(Stream.emits(s).through(text.lines).toList == Nil)
         } else {
-          Stream.emits(s).through(text.lines).toList shouldBe lines.toList
-          Stream.emits(s).unchunk.through(text.lines).toList shouldBe lines.toList
+          assert(Stream.emits(s).through(text.lines).toList == lines.toList)
+          assert(Stream.emits(s).unchunk.through(text.lines).toList == lines.toList)
         }
       }
     }

--- a/core/shared/src/test/scala/fs2/TextSpec.scala
+++ b/core/shared/src/test/scala/fs2/TextSpec.scala
@@ -15,12 +15,14 @@ class TextSpec extends Fs2Spec {
 
       def checkChar(c: Char): Assertion = {
         (1 to 6).foreach { n =>
-          Stream
-            .chunk(utf8Bytes(c.toString))
-            .chunkLimit(n)
-            .flatMap(Stream.chunk)
-            .through(utf8Decode)
-            .toList shouldBe List(c.toString)
+          assert(
+            Stream
+              .chunk(utf8Bytes(c.toString))
+              .chunkLimit(n)
+              .flatMap(Stream.chunk)
+              .through(utf8Decode)
+              .toList == List(c.toString)
+          )
         }
         Succeeded
       }
@@ -28,22 +30,25 @@ class TextSpec extends Fs2Spec {
       def checkBytes(is: Int*): Assertion = {
         (1 to 6).foreach { n =>
           val bytes = Chunk.bytes(is.map(_.toByte).toArray)
-          Stream
-            .chunk(bytes)
-            .chunkLimit(n)
-            .flatMap(Stream.chunk)
-            .through(utf8Decode)
-            .toList shouldBe List(utf8String(bytes))
+          assert(
+            Stream
+              .chunk(bytes)
+              .chunkLimit(n)
+              .flatMap(Stream.chunk)
+              .through(utf8Decode)
+              .toList == List(utf8String(bytes))
+          )
         }
         Succeeded
       }
 
       def checkBytes2(is: Int*): Assertion = {
         val bytes = Chunk.bytes(is.map(_.toByte).toArray)
-        Stream(bytes).flatMap(Stream.chunk).through(utf8Decode).toList.mkString shouldBe utf8String(
-          bytes
+        assert(
+          Stream(bytes).flatMap(Stream.chunk).through(utf8Decode).toList.mkString == utf8String(
+            bytes
+          )
         )
-        Succeeded
       }
 
       "all chars" in forAll { (c: Char) =>
@@ -61,8 +66,8 @@ class TextSpec extends Fs2Spec {
 
       "preserve complete inputs" in forAll { (l0: List[String]) =>
         val l = l0.filter { _.nonEmpty }
-        Stream(l: _*).map(utf8Bytes).flatMap(Stream.chunk).through(utf8Decode).toList shouldBe l
-        Stream(l0: _*).map(utf8Bytes).through(utf8DecodeC).toList shouldBe l0
+        assert(Stream(l: _*).map(utf8Bytes).flatMap(Stream.chunk).through(utf8Decode).toList == l)
+        assert(Stream(l0: _*).map(utf8Bytes).through(utf8DecodeC).toList == l0)
       }
 
       "utf8Encode |> utf8Decode = id" in forAll { (s: String) =>
@@ -72,23 +77,27 @@ class TextSpec extends Fs2Spec {
       }
 
       "1 byte sequences" in forAll { (s: String) =>
-        Stream
-          .chunk(utf8Bytes(s))
-          .chunkLimit(1)
-          .flatMap(Stream.chunk)
-          .through(utf8Decode)
-          .filter(_.nonEmpty)
-          .toList shouldBe s.grouped(1).toList
+        assert(
+          Stream
+            .chunk(utf8Bytes(s))
+            .chunkLimit(1)
+            .flatMap(Stream.chunk)
+            .through(utf8Decode)
+            .filter(_.nonEmpty)
+            .toList == s.grouped(1).toList
+        )
       }
 
       "n byte sequences" in forAll(strings, intsBetween(1, 9)) { (s: String, n: Int) =>
-        Stream
-          .chunk(utf8Bytes(s))
-          .chunkLimit(n)
-          .flatMap(Stream.chunk)
-          .through(utf8Decode)
-          .toList
-          .mkString shouldBe s
+        assert(
+          Stream
+            .chunk(utf8Bytes(s))
+            .chunkLimit(n)
+            .flatMap(Stream.chunk)
+            .through(utf8Decode)
+            .toList
+            .mkString == s
+        )
       }
 
       "handles byte order mark" - {
@@ -211,8 +220,8 @@ class TextSpec extends Fs2Spec {
 
       "newlines appear in between chunks" in forAll { (lines0: Stream[Pure, String]) =>
         val lines = lines0.map(escapeCrLf)
-        lines.intersperse("\n").through(text.lines).toList shouldBe lines.toList
-        lines.intersperse("\r\n").through(text.lines).toList shouldBe lines.toList
+        assert(lines.intersperse("\n").through(text.lines).toList == lines.toList)
+        assert(lines.intersperse("\r\n").through(text.lines).toList == lines.toList)
       }
 
       "single string" in forAll { (lines0: Stream[Pure, String]) =>
@@ -237,8 +246,10 @@ class TextSpec extends Fs2Spec {
 
     "base64Encode" in {
       forAll { (bs: List[Array[Byte]]) =>
-        bs.map(Chunk.bytes).foldMap(Stream.chunk).through(text.base64Encode).compile.string shouldBe
-          bs.map(ByteVector.view(_)).foldLeft(ByteVector.empty)(_ ++ _).toBase64
+        assert(
+          bs.map(Chunk.bytes).foldMap(Stream.chunk).through(text.base64Encode).compile.string ==
+            bs.map(ByteVector.view(_)).foldLeft(ByteVector.empty)(_ ++ _).toBase64
+        )
       }
     }
 
@@ -246,55 +257,64 @@ class TextSpec extends Fs2Spec {
 
       "base64Encode andThen base64Decode" in {
         forAll { (bs: List[Array[Byte]], unchunked: Boolean, rechunkSeed: Long) =>
-          bs.map(Chunk.bytes)
-            .foldMap(Stream.chunk)
-            .through(text.base64Encode)
-            .through {
-              // Change chunk structure to validate carries
-              if (unchunked) _.unchunk
-              else _.rechunkRandomlyWithSeed(0.1, 2.0)(rechunkSeed)
-            }
-            .through {
-              // Add some whitespace
-              _.chunks
-                .interleave(Stream(" ", "\r\n", "\n", "  \r\n  ").map(Chunk.singleton).repeat)
-                .flatMap(Stream.chunk)
-            }
-            .through(text.base64Decode[Fallible])
-            .compile
-            .to(ByteVector) shouldBe
-            Right(bs.map(ByteVector.view(_)).foldLeft(ByteVector.empty)(_ ++ _))
+          assert(
+            bs.map(Chunk.bytes)
+              .foldMap(Stream.chunk)
+              .through(text.base64Encode)
+              .through {
+                // Change chunk structure to validate carries
+                if (unchunked) _.unchunk
+                else _.rechunkRandomlyWithSeed(0.1, 2.0)(rechunkSeed)
+              }
+              .through {
+                // Add some whitespace
+                _.chunks
+                  .interleave(Stream(" ", "\r\n", "\n", "  \r\n  ").map(Chunk.singleton).repeat)
+                  .flatMap(Stream.chunk)
+              }
+              .through(text.base64Decode[Fallible])
+              .compile
+              .to(ByteVector)
+              ==
+                Right(bs.map(ByteVector.view(_)).foldLeft(ByteVector.empty)(_ ++ _))
+          )
         }
       }
 
       "invalid padding" in {
-        Stream(hex"00deadbeef00".toBase64, "=====", hex"00deadbeef00".toBase64)
-          .through(text.base64Decode[Fallible])
-          .chunks
-          .attempt
-          .map(_.leftMap(_.getMessage))
-          .compile
-          .to(List) shouldBe
-          Right(
-            List(
-              Right(Chunk.byteVector(hex"00deadbeef00")),
-              Left(
-                "Malformed padding - final quantum may optionally be padded with one or two padding characters such that the quantum is completed"
+        assert(
+          Stream(hex"00deadbeef00".toBase64, "=====", hex"00deadbeef00".toBase64)
+            .through(text.base64Decode[Fallible])
+            .chunks
+            .attempt
+            .map(_.leftMap(_.getMessage))
+            .compile
+            .to(List)
+            ==
+              Right(
+                List(
+                  Right(Chunk.byteVector(hex"00deadbeef00")),
+                  Left(
+                    "Malformed padding - final quantum may optionally be padded with one or two padding characters such that the quantum is completed"
+                  )
+                )
               )
-            )
-          )
+        )
       }
 
       "optional padding" in {
         forAll { (bs: List[Array[Byte]]) =>
-          bs.map(Chunk.bytes)
-            .foldMap(Stream.chunk)
-            .through(text.base64Encode)
-            .takeWhile(_ != '=')
-            .through(text.base64Decode[Fallible])
-            .compile
-            .to(ByteVector) shouldBe
-            Right(bs.map(ByteVector.view(_)).foldLeft(ByteVector.empty)(_ ++ _))
+          assert(
+            bs.map(Chunk.bytes)
+              .foldMap(Stream.chunk)
+              .through(text.base64Encode)
+              .takeWhile(_ != '=')
+              .through(text.base64Decode[Fallible])
+              .compile
+              .to(ByteVector)
+              ==
+                Right(bs.map(ByteVector.view(_)).foldLeft(ByteVector.empty)(_ ++ _))
+          )
         }
       }
     }

--- a/core/shared/src/test/scala/fs2/concurrent/BalanceSpec.scala
+++ b/core/shared/src/test/scala/fs2/concurrent/BalanceSpec.scala
@@ -16,7 +16,7 @@ class BalanceSpec extends Fs2Spec {
           .balanceThrough(chunkSize = chunkSize, maxConcurrent = concurrent)(_.map(_.toLong))
           .compile
           .toVector
-          .asserting(_.sorted shouldBe expected)
+          .asserting(_.sorted == expected)
       }
     }
   }

--- a/core/shared/src/test/scala/fs2/concurrent/BalanceSpec.scala
+++ b/core/shared/src/test/scala/fs2/concurrent/BalanceSpec.scala
@@ -16,7 +16,7 @@ class BalanceSpec extends Fs2Spec {
           .balanceThrough(chunkSize = chunkSize, maxConcurrent = concurrent)(_.map(_.toLong))
           .compile
           .toVector
-          .assert(_.sorted == expected)
+          .asserting(it => assert(it.sorted == expected))
       }
     }
   }

--- a/core/shared/src/test/scala/fs2/concurrent/BalanceSpec.scala
+++ b/core/shared/src/test/scala/fs2/concurrent/BalanceSpec.scala
@@ -16,7 +16,7 @@ class BalanceSpec extends Fs2Spec {
           .balanceThrough(chunkSize = chunkSize, maxConcurrent = concurrent)(_.map(_.toLong))
           .compile
           .toVector
-          .asserting(_.sorted == expected)
+          .assert(_.sorted == expected)
       }
     }
   }

--- a/core/shared/src/test/scala/fs2/concurrent/BroadcastSpec.scala
+++ b/core/shared/src/test/scala/fs2/concurrent/BroadcastSpec.scala
@@ -3,6 +3,7 @@ package concurrent
 
 import cats.effect.IO
 import org.scalactic.anyvals.PosInt
+import org.scalatest.Succeeded
 
 class BroadcastSpec extends Fs2Spec {
   "Broadcast" - {
@@ -24,7 +25,8 @@ class BroadcastSpec extends Fs2Spec {
           .asserting { result =>
             if (expect.nonEmpty) {
               assert(result.size == concurrent)
-              all(result.values) shouldBe expect
+              result.values.foreach(it => assert(it == expect))
+              Succeeded
             } else {
               assert(result.values.isEmpty)
             }

--- a/core/shared/src/test/scala/fs2/concurrent/BroadcastSpec.scala
+++ b/core/shared/src/test/scala/fs2/concurrent/BroadcastSpec.scala
@@ -23,10 +23,10 @@ class BroadcastSpec extends Fs2Spec {
           .map(_.groupBy(_._1).map { case (k, v) => (k, v.map(_._2).toVector) })
           .asserting { result =>
             if (expect.nonEmpty) {
-              result.size shouldBe (concurrent)
+              assert(result.size == concurrent)
               all(result.values) shouldBe expect
             } else {
-              result.values.size shouldBe 0
+              assert(result.values.isEmpty)
             }
           }
       }

--- a/core/shared/src/test/scala/fs2/concurrent/QueueSpec.scala
+++ b/core/shared/src/test/scala/fs2/concurrent/QueueSpec.scala
@@ -53,8 +53,8 @@ class QueueSpec extends Fs2Spec {
           .compile
           .toList
           .asserting { result =>
-            result.size should be < 2
-            result.flatMap(_.toList) shouldBe expected
+            assert(result.size < 2)
+            assert(result.flatMap(_.toList) == expected)
           }
       }
     }

--- a/core/shared/src/test/scala/fs2/concurrent/QueueSpec.scala
+++ b/core/shared/src/test/scala/fs2/concurrent/QueueSpec.scala
@@ -21,7 +21,7 @@ class QueueSpec extends Fs2Spec {
           }
           .compile
           .toList
-          .asserting(_ shouldBe expected)
+          .asserting(_ == expected)
       }
     }
     "circularBuffer" in {
@@ -37,7 +37,7 @@ class QueueSpec extends Fs2Spec {
           }
           .compile
           .toList
-          .asserting(_ shouldBe expected)
+          .asserting(_ == expected)
       }
     }
     "dequeueAvailable" in {
@@ -72,7 +72,7 @@ class QueueSpec extends Fs2Spec {
           }
           .compile
           .toList
-          .asserting(_ shouldBe expected)
+          .asserting(_ == expected)
       }
     }
     "dequeueBatch circularBuffer" in {
@@ -90,7 +90,7 @@ class QueueSpec extends Fs2Spec {
           }
           .compile
           .toList
-          .asserting(_ shouldBe expected)
+          .asserting(_ == expected)
       }
     }
 
@@ -104,7 +104,7 @@ class QueueSpec extends Fs2Spec {
               q.enqueue1(2) >>
               q.dequeue1
           }
-          .asserting(_ shouldBe 1)
+          .asserting(_ == 1)
       }
 
       "cancel" in {
@@ -116,7 +116,7 @@ class QueueSpec extends Fs2Spec {
               q.enqueue1(2) >>
               q.dequeue1
           }
-          .asserting(_ shouldBe 1)
+          .asserting(_ == 1)
       }
     }
 
@@ -127,7 +127,7 @@ class QueueSpec extends Fs2Spec {
         .take(1)
         .compile
         .toList
-        .asserting(_ shouldBe List(0))
+        .asserting(_ == List(0))
     }
 
     "size stream is discrete" in {
@@ -143,7 +143,7 @@ class QueueSpec extends Fs2Spec {
         .interruptWhen(Stream.sleep[IO](2.seconds).as(true))
         .compile
         .toList
-        .asserting(_.size shouldBe <=(11)) // if the stream won't be discrete we will get much more size notifications
+        .asserting(_.size <= 11) // if the stream won't be discrete we will get much more size notifications
     }
 
     "peek1" in {
@@ -160,7 +160,7 @@ class QueueSpec extends Fs2Spec {
         )
         .compile
         .toList
-        .asserting(_.flatten shouldBe List(42, 42))
+        .asserting(_.flatten == List(42, 42))
     }
 
     "peek1 with dequeue1" in {
@@ -180,7 +180,7 @@ class QueueSpec extends Fs2Spec {
         )
         .compile
         .toList
-        .asserting(_.flatten shouldBe List((42, 42), (43, 43), (44, 44)))
+        .asserting(_.flatten == List((42, 42), (43, 43), (44, 44)))
     }
 
     "peek1 bounded queue" in {
@@ -199,7 +199,7 @@ class QueueSpec extends Fs2Spec {
         )
         .compile
         .toList
-        .asserting(_.flatten shouldBe List(false, 42, 42, 42))
+        .asserting(_.flatten == List(false, 42, 42, 42))
     }
 
     "peek1 circular buffer" in {
@@ -218,7 +218,7 @@ class QueueSpec extends Fs2Spec {
         )
         .compile
         .toList
-        .asserting(_.flatten shouldBe List(true, 42, 42, 43))
+        .asserting(_.flatten == List(true, 42, 42, 43))
     }
   }
 }

--- a/core/shared/src/test/scala/fs2/concurrent/QueueSpec.scala
+++ b/core/shared/src/test/scala/fs2/concurrent/QueueSpec.scala
@@ -21,7 +21,7 @@ class QueueSpec extends Fs2Spec {
           }
           .compile
           .toList
-          .assert(_ == expected)
+          .asserting(it => assert(it == expected))
       }
     }
     "circularBuffer" in {
@@ -37,7 +37,7 @@ class QueueSpec extends Fs2Spec {
           }
           .compile
           .toList
-          .assert(_ == expected)
+          .asserting(it => assert(it == expected))
       }
     }
     "dequeueAvailable" in {
@@ -72,7 +72,7 @@ class QueueSpec extends Fs2Spec {
           }
           .compile
           .toList
-          .assert(_ == expected)
+          .asserting(it => assert(it == expected))
       }
     }
     "dequeueBatch circularBuffer" in {
@@ -90,7 +90,7 @@ class QueueSpec extends Fs2Spec {
           }
           .compile
           .toList
-          .assert(_ == expected)
+          .asserting(it => assert(it == expected))
       }
     }
 
@@ -104,7 +104,7 @@ class QueueSpec extends Fs2Spec {
               q.enqueue1(2) >>
               q.dequeue1
           }
-          .assert(_ == 1)
+          .asserting(it => assert(it == 1))
       }
 
       "cancel" in {
@@ -116,7 +116,7 @@ class QueueSpec extends Fs2Spec {
               q.enqueue1(2) >>
               q.dequeue1
           }
-          .assert(_ == 1)
+          .asserting(it => assert(it == 1))
       }
     }
 
@@ -127,7 +127,7 @@ class QueueSpec extends Fs2Spec {
         .take(1)
         .compile
         .toList
-        .assert(_ == List(0))
+        .asserting(it => assert(it == List(0)))
     }
 
     "size stream is discrete" in {
@@ -143,7 +143,7 @@ class QueueSpec extends Fs2Spec {
         .interruptWhen(Stream.sleep[IO](2.seconds).as(true))
         .compile
         .toList
-        .assert(_.size <= 11) // if the stream won't be discrete we will get much more size notifications
+        .asserting(it => assert(it.size <= 11)) // if the stream won't be discrete we will get much more size notifications
     }
 
     "peek1" in {
@@ -160,7 +160,7 @@ class QueueSpec extends Fs2Spec {
         )
         .compile
         .toList
-        .assert(_.flatten == List(42, 42))
+        .asserting(it => assert(it.flatten == List(42, 42)))
     }
 
     "peek1 with dequeue1" in {
@@ -180,7 +180,7 @@ class QueueSpec extends Fs2Spec {
         )
         .compile
         .toList
-        .assert(_.flatten == List((42, 42), (43, 43), (44, 44)))
+        .asserting(it => assert(it.flatten == List((42, 42), (43, 43), (44, 44))))
     }
 
     "peek1 bounded queue" in {
@@ -199,7 +199,7 @@ class QueueSpec extends Fs2Spec {
         )
         .compile
         .toList
-        .assert(_.flatten == List(false, 42, 42, 42))
+        .asserting(it => assert(it.flatten == List(false, 42, 42, 42)))
     }
 
     "peek1 circular buffer" in {
@@ -218,7 +218,7 @@ class QueueSpec extends Fs2Spec {
         )
         .compile
         .toList
-        .assert(_.flatten == List(true, 42, 42, 43))
+        .asserting(it => assert(it.flatten == List(true, 42, 42, 43)))
     }
   }
 }

--- a/core/shared/src/test/scala/fs2/concurrent/QueueSpec.scala
+++ b/core/shared/src/test/scala/fs2/concurrent/QueueSpec.scala
@@ -21,7 +21,7 @@ class QueueSpec extends Fs2Spec {
           }
           .compile
           .toList
-          .asserting(_ == expected)
+          .assert(_ == expected)
       }
     }
     "circularBuffer" in {
@@ -37,7 +37,7 @@ class QueueSpec extends Fs2Spec {
           }
           .compile
           .toList
-          .asserting(_ == expected)
+          .assert(_ == expected)
       }
     }
     "dequeueAvailable" in {
@@ -72,7 +72,7 @@ class QueueSpec extends Fs2Spec {
           }
           .compile
           .toList
-          .asserting(_ == expected)
+          .assert(_ == expected)
       }
     }
     "dequeueBatch circularBuffer" in {
@@ -90,7 +90,7 @@ class QueueSpec extends Fs2Spec {
           }
           .compile
           .toList
-          .asserting(_ == expected)
+          .assert(_ == expected)
       }
     }
 
@@ -104,7 +104,7 @@ class QueueSpec extends Fs2Spec {
               q.enqueue1(2) >>
               q.dequeue1
           }
-          .asserting(_ == 1)
+          .assert(_ == 1)
       }
 
       "cancel" in {
@@ -116,7 +116,7 @@ class QueueSpec extends Fs2Spec {
               q.enqueue1(2) >>
               q.dequeue1
           }
-          .asserting(_ == 1)
+          .assert(_ == 1)
       }
     }
 
@@ -127,7 +127,7 @@ class QueueSpec extends Fs2Spec {
         .take(1)
         .compile
         .toList
-        .asserting(_ == List(0))
+        .assert(_ == List(0))
     }
 
     "size stream is discrete" in {
@@ -143,7 +143,7 @@ class QueueSpec extends Fs2Spec {
         .interruptWhen(Stream.sleep[IO](2.seconds).as(true))
         .compile
         .toList
-        .asserting(_.size <= 11) // if the stream won't be discrete we will get much more size notifications
+        .assert(_.size <= 11) // if the stream won't be discrete we will get much more size notifications
     }
 
     "peek1" in {
@@ -160,7 +160,7 @@ class QueueSpec extends Fs2Spec {
         )
         .compile
         .toList
-        .asserting(_.flatten == List(42, 42))
+        .assert(_.flatten == List(42, 42))
     }
 
     "peek1 with dequeue1" in {
@@ -180,7 +180,7 @@ class QueueSpec extends Fs2Spec {
         )
         .compile
         .toList
-        .asserting(_.flatten == List((42, 42), (43, 43), (44, 44)))
+        .assert(_.flatten == List((42, 42), (43, 43), (44, 44)))
     }
 
     "peek1 bounded queue" in {
@@ -199,7 +199,7 @@ class QueueSpec extends Fs2Spec {
         )
         .compile
         .toList
-        .asserting(_.flatten == List(false, 42, 42, 42))
+        .assert(_.flatten == List(false, 42, 42, 42))
     }
 
     "peek1 circular buffer" in {
@@ -218,7 +218,7 @@ class QueueSpec extends Fs2Spec {
         )
         .compile
         .toList
-        .asserting(_.flatten == List(true, 42, 42, 43))
+        .assert(_.flatten == List(true, 42, 42, 43))
     }
   }
 }

--- a/core/shared/src/test/scala/fs2/concurrent/TopicSpec.scala
+++ b/core/shared/src/test/scala/fs2/concurrent/TopicSpec.scala
@@ -33,8 +33,8 @@ class TopicSpec extends Fs2Spec {
               idx -> (for { i <- -1 until count } yield i).toVector
             }.toMap
 
-            result.toMap.size shouldBe subs
-            result.toMap shouldBe expected
+            assert(result.toMap.size == subs)
+            assert(result.toMap == expected)
           }
       }
     }
@@ -67,7 +67,7 @@ class TopicSpec extends Fs2Spec {
             .compile
             .toVector
             .asserting { result =>
-              result.toMap.size shouldBe subs
+              assert(result.toMap.size == subs)
 
               result.foreach {
                 case (_, subResults) =>
@@ -97,7 +97,7 @@ class TopicSpec extends Fs2Spec {
           .interruptWhen(Stream.sleep[IO](2.seconds).as(true))
 
       p.compile.toList
-        .asserting(_.size shouldBe <=(11)) // if the stream won't be discrete we will get much more size notifications
+        .asserting(it => assert(it.size <= 11)) // if the stream won't be discrete we will get much more size notifications
     }
 
     "unregister subscribers under concurrent load" in {
@@ -110,7 +110,7 @@ class TopicSpec extends Fs2Spec {
             .compile
             .drain >> topic.subscribers.take(1).compile.lastOrError
         }
-        .asserting(_ shouldBe 0)
+        .asserting(it => assert(it == 0))
     }
   }
 }

--- a/io/src/test/scala/fs2/io/IoSpec.scala
+++ b/io/src/test/scala/fs2/io/IoSpec.scala
@@ -14,7 +14,7 @@ class IoSpec extends Fs2Spec {
         val is: InputStream = new ByteArrayInputStream(bytes)
         Blocker[IO].use { blocker =>
           val stream = readInputStream(IO(is), chunkSize, blocker)
-          stream.compile.toVector.asserting(_.toArray shouldBe bytes)
+          stream.compile.toVector.asserting(it => assert(it.toArray === bytes))
         }
     }
 
@@ -23,7 +23,7 @@ class IoSpec extends Fs2Spec {
         val is: InputStream = new ByteArrayInputStream(bytes)
         Blocker[IO].use { blocker =>
           val stream = readInputStream(IO(is), chunkSize, blocker)
-          stream.buffer(chunkSize * 2).compile.toVector.asserting(_.toArray shouldBe bytes)
+          stream.buffer(chunkSize * 2).compile.toVector.asserting(it => assert(it.toArray === bytes))
         }
     }
   }
@@ -38,14 +38,14 @@ class IoSpec extends Fs2Spec {
           blocker.delay[IO, Unit](os.write(bytes))
         ).compile
           .to(Array)
-          .asserting(_ shouldEqual bytes)
+          .asserting(it => assert(it === bytes))
       }
     }
 
     "can be manually closed from inside `f`" in forAll(intsBetween(1, 20)) { chunkSize: Int =>
       Blocker[IO].use { blocker =>
         readOutputStream[IO](blocker, chunkSize)((os: OutputStream) => IO(os.close()) *> IO.never).compile.toVector
-          .asserting(_ shouldBe Vector.empty)
+          .asserting(it => assert(it == Vector.empty))
       }
     }
 
@@ -53,7 +53,7 @@ class IoSpec extends Fs2Spec {
       val e = new Exception("boom")
       Blocker[IO].use { blocker =>
         readOutputStream[IO](blocker, chunkSize)((_: OutputStream) => IO.raiseError(e)).compile.toVector.attempt
-          .asserting(_ shouldBe Left(e))
+          .asserting(it => assert(it == Left(e)))
       }
     }
 
@@ -79,7 +79,7 @@ class IoSpec extends Fs2Spec {
               .compile
               .toVector
           }
-          .asserting(_ should have size 5)
+          .asserting(it => assert(it.size == 5))
       }
     }
   }
@@ -90,7 +90,7 @@ class IoSpec extends Fs2Spec {
         val is: InputStream = new ByteArrayInputStream(bytes)
         Blocker[IO].use { blocker =>
           val stream = unsafeReadInputStream(IO(is), chunkSize, blocker)
-          stream.compile.toVector.asserting(_.toArray shouldBe bytes)
+          stream.compile.toVector.asserting(it => assert(it.toArray === bytes))
         }
     }
   }

--- a/io/src/test/scala/fs2/io/IoSpec.scala
+++ b/io/src/test/scala/fs2/io/IoSpec.scala
@@ -23,7 +23,11 @@ class IoSpec extends Fs2Spec {
         val is: InputStream = new ByteArrayInputStream(bytes)
         Blocker[IO].use { blocker =>
           val stream = readInputStream(IO(is), chunkSize, blocker)
-          stream.buffer(chunkSize * 2).compile.toVector.asserting(it => assert(it.toArray === bytes))
+          stream
+            .buffer(chunkSize * 2)
+            .compile
+            .toVector
+            .asserting(it => assert(it.toArray === bytes))
         }
     }
   }

--- a/io/src/test/scala/fs2/io/JavaInputOutputStreamSpec.scala
+++ b/io/src/test/scala/fs2/io/JavaInputOutputStreamSpec.scala
@@ -43,7 +43,7 @@ class JavaInputOutputStreamSpec extends Fs2Spec with EventuallySupport {
 
       toInputStreamResource(s).use(_ => IO.unit).unsafeRunSync()
 
-      eventually { closed shouldBe true }
+      eventually { assert(closed) }
     }
 
     "upstream.is.force-closed" in {

--- a/io/src/test/scala/fs2/io/JavaInputOutputStreamSpec.scala
+++ b/io/src/test/scala/fs2/io/JavaInputOutputStreamSpec.scala
@@ -32,7 +32,7 @@ class JavaInputOutputStreamSpec extends Fs2Spec with EventuallySupport {
           }
           .unsafeRunSync()
 
-      example shouldBe fromInputStream
+      assert(example == fromInputStream)
     }
 
     "upstream.is.closed" in {
@@ -62,7 +62,7 @@ class JavaInputOutputStreamSpec extends Fs2Spec with EventuallySupport {
           }
           .unsafeRunSync()
 
-      result shouldBe Vector(true)
+      assert(result == Vector(true))
     }
 
     "converts to 0..255 int values except EOF mark" in {

--- a/io/src/test/scala/fs2/io/JavaInputOutputStreamSpec.scala
+++ b/io/src/test/scala/fs2/io/JavaInputOutputStreamSpec.scala
@@ -62,7 +62,7 @@ class JavaInputOutputStreamSpec extends Fs2Spec with EventuallySupport {
           }
           .unsafeRunSync()
 
-      assert(result == Vector(true))
+      assert(result)
     }
 
     "converts to 0..255 int values except EOF mark" in {

--- a/io/src/test/scala/fs2/io/JavaInputOutputStreamSpec.scala
+++ b/io/src/test/scala/fs2/io/JavaInputOutputStreamSpec.scala
@@ -77,7 +77,7 @@ class JavaInputOutputStreamSpec extends Fs2Spec with EventuallySupport {
         .compile
         .toVector
         .map(_.flatten)
-        .asserting(_ shouldBe (Stream.range(0, 256, 1) ++ Stream(-1)).toVector)
+        .asserting(it => assert(it == (Stream.range(0, 256, 1) ++ Stream(-1)).toVector))
     }
   }
 }

--- a/io/src/test/scala/fs2/io/file/FileSpec.scala
+++ b/io/src/test/scala/fs2/io/file/FileSpec.scala
@@ -15,147 +15,170 @@ import scala.concurrent.duration._
 class FileSpec extends BaseFileSpec {
   "readAll" - {
     "retrieves whole content of a file" in {
-      Stream
-        .resource(Blocker[IO])
-        .flatMap { bec =>
-          tempFile
-            .flatTap(modify)
-            .flatMap(path => file.readAll[IO](path, bec, 4096))
-        }
-        .compile
-        .toList
-        .map(_.size)
-        .unsafeRunSync() shouldBe 4
+      assert(
+        Stream
+          .resource(Blocker[IO])
+          .flatMap { bec =>
+            tempFile
+              .flatTap(modify)
+              .flatMap(path => file.readAll[IO](path, bec, 4096))
+          }
+          .compile
+          .toList
+          .map(_.size)
+          .unsafeRunSync() == 4
+      )
     }
   }
 
   "readRange" - {
     "reads half of a file" in {
-      Stream
-        .resource(Blocker[IO])
-        .flatMap { bec =>
-          tempFile
-            .flatTap(modify)
-            .flatMap(path => file.readRange[IO](path, bec, 4096, 0, 2))
-        }
-        .compile
-        .toList
-        .map(_.size)
-        .unsafeRunSync() shouldBe 2
+      assert(
+        Stream
+          .resource(Blocker[IO])
+          .flatMap { bec =>
+            tempFile
+              .flatTap(modify)
+              .flatMap(path => file.readRange[IO](path, bec, 4096, 0, 2))
+          }
+          .compile
+          .toList
+          .map(_.size)
+          .unsafeRunSync() == 2
+      )
     }
 
     "reads full file if end is bigger than file size" in {
-      Stream
-        .resource(Blocker[IO])
-        .flatMap { bec =>
-          tempFile
-            .flatTap(modify)
-            .flatMap(path => file.readRange[IO](path, bec, 4096, 0, 100))
-        }
-        .compile
-        .toList
-        .map(_.size)
-        .unsafeRunSync() shouldBe 4
+      assert(
+        Stream
+          .resource(Blocker[IO])
+          .flatMap { bec =>
+            tempFile
+              .flatTap(modify)
+              .flatMap(path => file.readRange[IO](path, bec, 4096, 0, 100))
+          }
+          .compile
+          .toList
+          .map(_.size)
+          .unsafeRunSync() == 4
+      )
     }
   }
 
   "writeAll" - {
     "simple write" in {
-      Stream
-        .resource(Blocker[IO])
-        .flatMap { bec =>
-          tempFile
-            .flatMap(path =>
-              Stream("Hello", " world!")
-                .covary[IO]
-                .through(text.utf8Encode)
-                .through(file.writeAll[IO](path, bec))
-                .drain ++ file.readAll[IO](path, bec, 4096).through(text.utf8Decode)
-            )
-        }
-        .compile
-        .foldMonoid
-        .unsafeRunSync() shouldBe "Hello world!"
+      assert(
+        Stream
+          .resource(Blocker[IO])
+          .flatMap { bec =>
+            tempFile
+              .flatMap(path =>
+                Stream("Hello", " world!")
+                  .covary[IO]
+                  .through(text.utf8Encode)
+                  .through(file.writeAll[IO](path, bec))
+                  .drain ++ file.readAll[IO](path, bec, 4096).through(text.utf8Decode)
+              )
+          }
+          .compile
+          .foldMonoid
+          .unsafeRunSync() == "Hello world!"
+      )
     }
 
     "append" in {
-      Stream
-        .resource(Blocker[IO])
-        .flatMap { bec =>
-          tempFile
-            .flatMap { path =>
-              val src = Stream("Hello", " world!").covary[IO].through(text.utf8Encode)
+      assert(
+        Stream
+          .resource(Blocker[IO])
+          .flatMap { bec =>
+            tempFile
+              .flatMap { path =>
+                val src = Stream("Hello", " world!").covary[IO].through(text.utf8Encode)
 
-              src.through(file.writeAll[IO](path, bec)).drain ++
-                src.through(file.writeAll[IO](path, bec, List(StandardOpenOption.APPEND))).drain ++
-                file.readAll[IO](path, bec, 4096).through(text.utf8Decode)
-            }
-        }
-        .compile
-        .foldMonoid
-        .unsafeRunSync() shouldBe "Hello world!Hello world!"
+                src.through(file.writeAll[IO](path, bec)).drain ++
+                  src
+                    .through(file.writeAll[IO](path, bec, List(StandardOpenOption.APPEND)))
+                    .drain ++
+                  file.readAll[IO](path, bec, 4096).through(text.utf8Decode)
+              }
+          }
+          .compile
+          .foldMonoid
+          .unsafeRunSync() == "Hello world!Hello world!"
+      )
     }
   }
 
   "tail" - {
     "keeps reading a file as it is appended" in {
-      Stream
-        .resource(Blocker[IO])
-        .flatMap { blocker =>
-          tempFile
-            .flatMap { path =>
-              file
-                .tail[IO](path, blocker, 4096, pollDelay = 25.millis)
-                .concurrently(modifyLater(path, blocker))
-            }
-        }
-        .take(4)
-        .compile
-        .toList
-        .map(_.size)
-        .unsafeRunSync() shouldBe 4
+      assert(
+        Stream
+          .resource(Blocker[IO])
+          .flatMap { blocker =>
+            tempFile
+              .flatMap { path =>
+                file
+                  .tail[IO](path, blocker, 4096, pollDelay = 25.millis)
+                  .concurrently(modifyLater(path, blocker))
+              }
+          }
+          .take(4)
+          .compile
+          .toList
+          .map(_.size)
+          .unsafeRunSync() == 4
+      )
     }
   }
 
   "exists" - {
     "returns false on a non existent file" in {
-      Blocker[IO].use(b => file.exists[IO](b, Paths.get("nothing"))).unsafeRunSync shouldBe false
+      assert(Blocker[IO].use(b => file.exists[IO](b, Paths.get("nothing"))).unsafeRunSync == false)
     }
     "returns true on an existing file" in {
-      Blocker[IO]
-        .use(b => tempFile.evalMap(file.exists[IO](b, _)).compile.fold(true)(_ && _))
-        .unsafeRunSync() shouldBe true
+      assert(
+        Blocker[IO]
+          .use(b => tempFile.evalMap(file.exists[IO](b, _)).compile.fold(true)(_ && _))
+          .unsafeRunSync() == true
+      )
     }
   }
 
   "permissions" - {
     "should fail for a non existent file" in {
-      Blocker[IO]
-        .use(b => file.permissions[IO](b, Paths.get("nothing")))
-        .attempt
-        .unsafeRunSync()
-        .isLeft shouldBe true
+      assert(
+        Blocker[IO]
+          .use(b => file.permissions[IO](b, Paths.get("nothing")))
+          .attempt
+          .unsafeRunSync()
+          .isLeft == true
+      )
     }
     "should return permissions for existing file" in {
       val permissions = PosixFilePermissions.fromString("rwxrwxr-x").asScala
-      Blocker[IO]
-        .use { b =>
-          tempFile
-            .evalMap(p => file.setPermissions[IO](b, p, permissions) >> file.permissions[IO](b, p))
-            .compile
-            .lastOrError
-        }
-        .unsafeRunSync() shouldBe permissions
+      assert(
+        Blocker[IO]
+          .use { b =>
+            tempFile
+              .evalMap(p => file.setPermissions[IO](b, p, permissions) >> file.permissions[IO](b, p)
+              )
+              .compile
+              .lastOrError
+          }
+          .unsafeRunSync() == permissions
+      )
     }
   }
 
   "setPermissions" - {
     "should fail for a non existent file" in {
-      Blocker[IO]
-        .use(b => file.setPermissions[IO](b, Paths.get("nothing"), Set.empty))
-        .attempt
-        .unsafeRunSync()
-        .isLeft shouldBe true
+      assert(
+        Blocker[IO]
+          .use(b => file.setPermissions[IO](b, Paths.get("nothing"), Set.empty))
+          .attempt
+          .unsafeRunSync()
+          .isLeft == true
+      )
     }
     "should correctly change file permissions for existing file" in {
       val permissions = PosixFilePermissions.fromString("rwxrwxr-x").asScala
@@ -174,188 +197,212 @@ class FileSpec extends BaseFileSpec {
         }
         .unsafeRunSync()
 
-      initial should not be updated
+      assert(initial != updated)
       assert(updated == permissions)
     }
   }
 
   "copy" - {
     "returns a path to the new file" in {
-      (for {
-        blocker <- Stream.resource(Blocker[IO])
-        filePath <- tempFile
-        tempDir <- tempDirectory
-        result <- Stream.eval(file.copy[IO](blocker, filePath, tempDir.resolve("newfile")))
-        exists <- Stream.eval(file.exists[IO](blocker, result))
-      } yield exists).compile.fold(true)(_ && _).unsafeRunSync() shouldBe true
+      assert(
+        (for {
+          blocker <- Stream.resource(Blocker[IO])
+          filePath <- tempFile
+          tempDir <- tempDirectory
+          result <- Stream.eval(file.copy[IO](blocker, filePath, tempDir.resolve("newfile")))
+          exists <- Stream.eval(file.exists[IO](blocker, result))
+        } yield exists).compile.fold(true)(_ && _).unsafeRunSync() == true
+      )
     }
   }
 
   "deleteIfExists" - {
     "should result in non existent file" in {
-      tempFile
-        .flatMap(path =>
-          Stream
-            .resource(Blocker[IO])
-            .evalMap(blocker => file.delete[IO](blocker, path) *> file.exists[IO](blocker, path))
-        )
-        .compile
-        .fold(false)(_ || _)
-        .unsafeRunSync() shouldBe false
+      assert(
+        tempFile
+          .flatMap(path =>
+            Stream
+              .resource(Blocker[IO])
+              .evalMap(blocker => file.delete[IO](blocker, path) *> file.exists[IO](blocker, path))
+          )
+          .compile
+          .fold(false)(_ || _)
+          .unsafeRunSync() == false
+      )
     }
   }
 
   "delete" - {
     "should fail on a non existent file" in {
-      Blocker[IO]
-        .use(blocker => file.delete[IO](blocker, Paths.get("nothing")))
-        .attempt
-        .unsafeRunSync()
-        .isLeft shouldBe true
+      assert(
+        Blocker[IO]
+          .use(blocker => file.delete[IO](blocker, Paths.get("nothing")))
+          .attempt
+          .unsafeRunSync()
+          .isLeft == true
+      )
     }
   }
 
   "move" - {
     "should result in the old path being deleted" in {
-      (for {
-        blocker <- Stream.resource(Blocker[IO])
-        filePath <- tempFile
-        tempDir <- tempDirectory
-        _ <- Stream.eval(file.move[IO](blocker, filePath, tempDir.resolve("newfile")))
-        exists <- Stream.eval(file.exists[IO](blocker, filePath))
-      } yield exists).compile.fold(false)(_ || _).unsafeRunSync() shouldBe false
+      assert(
+        (for {
+          blocker <- Stream.resource(Blocker[IO])
+          filePath <- tempFile
+          tempDir <- tempDirectory
+          _ <- Stream.eval(file.move[IO](blocker, filePath, tempDir.resolve("newfile")))
+          exists <- Stream.eval(file.exists[IO](blocker, filePath))
+        } yield exists).compile.fold(false)(_ || _).unsafeRunSync() == false
+      )
     }
   }
 
   "size" - {
     "should return correct size of ay file" in {
-      tempFile
-        .flatTap(modify)
-        .flatMap(path =>
-          Stream
-            .resource(Blocker[IO])
-            .evalMap(blocker => file.size[IO](blocker, path))
-        )
-        .compile
-        .lastOrError
-        .unsafeRunSync() shouldBe 4L
+      assert(
+        tempFile
+          .flatTap(modify)
+          .flatMap(path =>
+            Stream
+              .resource(Blocker[IO])
+              .evalMap(blocker => file.size[IO](blocker, path))
+          )
+          .compile
+          .lastOrError
+          .unsafeRunSync() == 4L
+      )
     }
   }
 
   "createDirectory" - {
     "should return in an existing path" in {
-      tempDirectory
-        .flatMap(path =>
-          Stream
-            .resource(Blocker[IO])
-            .evalMap(blocker =>
-              file
-                .createDirectory[IO](blocker, path.resolve("temp"))
-                .bracket(file.exists[IO](blocker, _))(file.deleteIfExists[IO](blocker, _).void)
-            )
-        )
-        .compile
-        .fold(true)(_ && _)
-        .unsafeRunSync() shouldBe true
+      assert(
+        tempDirectory
+          .flatMap(path =>
+            Stream
+              .resource(Blocker[IO])
+              .evalMap(blocker =>
+                file
+                  .createDirectory[IO](blocker, path.resolve("temp"))
+                  .bracket(file.exists[IO](blocker, _))(file.deleteIfExists[IO](blocker, _).void)
+              )
+          )
+          .compile
+          .fold(true)(_ && _)
+          .unsafeRunSync() == true
+      )
     }
   }
 
   "createDirectories" - {
     "should return in an existing path" in {
-      tempDirectory
-        .flatMap(path =>
-          Stream
-            .resource(Blocker[IO])
-            .evalMap(blocker =>
-              file
-                .createDirectories[IO](blocker, path.resolve("temp/inner"))
-                .bracket(file.exists[IO](blocker, _))(file.deleteIfExists[IO](blocker, _).void)
-            )
-        )
-        .compile
-        .fold(true)(_ && _)
-        .unsafeRunSync() shouldBe true
+      assert(
+        tempDirectory
+          .flatMap(path =>
+            Stream
+              .resource(Blocker[IO])
+              .evalMap(blocker =>
+                file
+                  .createDirectories[IO](blocker, path.resolve("temp/inner"))
+                  .bracket(file.exists[IO](blocker, _))(file.deleteIfExists[IO](blocker, _).void)
+              )
+          )
+          .compile
+          .fold(true)(_ && _)
+          .unsafeRunSync() == true
+      )
     }
   }
 
   "directoryStream" - {
     "returns an empty Stream on an empty directory" in {
-      Stream
-        .resource(Blocker[IO])
-        .flatMap { blocker =>
-          tempDirectory
-            .flatMap { path =>
-              file.directoryStream[IO](blocker, path)
-            }
-        }
-        .compile
-        .toList
-        .unsafeRunSync()
-        .length shouldBe 0
+      assert(
+        Stream
+          .resource(Blocker[IO])
+          .flatMap { blocker =>
+            tempDirectory
+              .flatMap { path =>
+                file.directoryStream[IO](blocker, path)
+              }
+          }
+          .compile
+          .toList
+          .unsafeRunSync()
+          .length == 0
+      )
     }
 
     "returns all files in a directory correctly" in {
-      Stream
-        .resource(Blocker[IO])
-        .flatMap { blocker =>
-          tempFiles(10)
-            .flatMap { paths =>
-              val parent = paths.head.getParent
-              file.directoryStream[IO](blocker, parent).tupleRight(paths)
-            }
-        }
-        .map { case (path, paths) => paths.exists(_.normalize === path.normalize) }
-        .compile
-        .fold(true)(_ & _)
-        .unsafeRunSync() shouldBe true
+      assert(
+        Stream
+          .resource(Blocker[IO])
+          .flatMap { blocker =>
+            tempFiles(10)
+              .flatMap { paths =>
+                val parent = paths.head.getParent
+                file.directoryStream[IO](blocker, parent).tupleRight(paths)
+              }
+          }
+          .map { case (path, paths) => paths.exists(_.normalize === path.normalize) }
+          .compile
+          .fold(true)(_ & _)
+          .unsafeRunSync() == true
+      )
     }
   }
 
   "walk" - {
     "returns the only file in a directory correctly" in {
-      Stream
-        .resource(Blocker[IO])
-        .flatMap { blocker =>
-          tempFile
-            .flatMap { path =>
-              file.walk[IO](blocker, path.getParent).map(_.normalize === path.normalize)
-            }
-        }
-        .compile
-        .toList
-        .unsafeRunSync()
-        .length shouldBe 2 // the directory and the file
+      assert(
+        Stream
+          .resource(Blocker[IO])
+          .flatMap { blocker =>
+            tempFile
+              .flatMap { path =>
+                file.walk[IO](blocker, path.getParent).map(_.normalize === path.normalize)
+              }
+          }
+          .compile
+          .toList
+          .unsafeRunSync()
+          .length == 2 // the directory and the file
+      )
     }
 
     "returns all files in a directory correctly" in {
-      Stream
-        .resource(Blocker[IO])
-        .flatMap { blocker =>
-          tempFiles(10)
-            .flatMap { paths =>
-              val parent = paths.head.getParent
-              file.walk[IO](blocker, parent).tupleRight(parent :: paths)
-            }
-        }
-        .map { case (path, paths) => paths.exists(_.normalize === path.normalize) }
-        .compile
-        .fold(true)(_ & _)
-        .unsafeRunSync() shouldBe true // the directory itself and the files
+      assert(
+        Stream
+          .resource(Blocker[IO])
+          .flatMap { blocker =>
+            tempFiles(10)
+              .flatMap { paths =>
+                val parent = paths.head.getParent
+                file.walk[IO](blocker, parent).tupleRight(parent :: paths)
+              }
+          }
+          .map { case (path, paths) => paths.exists(_.normalize === path.normalize) }
+          .compile
+          .fold(true)(_ & _)
+          .unsafeRunSync() == true // the directory itself and the files
+      )
     }
 
     "returns all files in a nested tree correctly" in {
-      Stream
-        .resource(Blocker[IO])
-        .flatMap { blocker =>
-          tempFilesHierarchy
-            .flatMap { topDir =>
-              file.walk[IO](blocker, topDir)
-            }
-        }
-        .compile
-        .toList
-        .unsafeRunSync()
-        .length shouldBe 31 // the root + 5 children + 5 files per child directory
+      assert(
+        Stream
+          .resource(Blocker[IO])
+          .flatMap { blocker =>
+            tempFilesHierarchy
+              .flatMap { topDir =>
+                file.walk[IO](blocker, topDir)
+              }
+          }
+          .compile
+          .toList
+          .unsafeRunSync()
+          .length == 31 // the root + 5 children + 5 files per child directory
+      )
     }
   }
 

--- a/io/src/test/scala/fs2/io/file/FileSpec.scala
+++ b/io/src/test/scala/fs2/io/file/FileSpec.scala
@@ -175,7 +175,7 @@ class FileSpec extends BaseFileSpec {
         .unsafeRunSync()
 
       initial should not be updated
-      updated shouldBe permissions
+      assert(updated == permissions)
     }
   }
 

--- a/io/src/test/scala/fs2/io/tcp/SocketSpec.scala
+++ b/io/src/test/scala/fs2/io/tcp/SocketSpec.scala
@@ -71,7 +71,7 @@ class SocketSpec extends Fs2Spec {
           .toVector
           .unsafeRunTimed(timeout)
           .get
-      result.size shouldBe clientCount
+      assert(result.size == clientCount)
       result.map { new String(_) }.toSet shouldBe Set("fs2.rocks")
     }
 
@@ -125,7 +125,7 @@ class SocketSpec extends Fs2Spec {
           .toVector
           .unsafeRunTimed(timeout)
           .get
-      result shouldBe sizes
+      assert(result == sizes)
     }
   }
 }

--- a/io/src/test/scala/fs2/io/tcp/SocketSpec.scala
+++ b/io/src/test/scala/fs2/io/tcp/SocketSpec.scala
@@ -72,7 +72,7 @@ class SocketSpec extends Fs2Spec {
           .unsafeRunTimed(timeout)
           .get
       assert(result.size == clientCount)
-      result.map { new String(_) }.toSet shouldBe Set("fs2.rocks")
+      assert(result.map { new String(_) }.toSet == Set("fs2.rocks"))
     }
 
     // Ensure that readN yields chunks of the requested size

--- a/io/src/test/scala/fs2/io/tls/DTLSSocketSpec.scala
+++ b/io/src/test/scala/fs2/io/tls/DTLSSocketSpec.scala
@@ -45,7 +45,7 @@ class DTLSSocketSpec extends TLSSpec {
                           .concurrently(echoServer)
                           .compile
                           .toList
-                          .asserting(_.map(_.bytes) shouldBe List(msg))
+                          .asserting(it => assert(it.map(_.bytes) == List(msg)))
                     }
                   }
                 }

--- a/io/src/test/scala/fs2/io/tls/TLSParametersSpec.scala
+++ b/io/src/test/scala/fs2/io/tls/TLSParametersSpec.scala
@@ -6,26 +6,26 @@ class TLSParametersSpec extends TLSSpec {
   "toSSLParameters" - {
     "no client auth when wantClientAuth=false and needClientAuth=false" in {
       val params = TLSParameters(wantClientAuth = false, needClientAuth = false).toSSLParameters
-      params.getWantClientAuth shouldBe false
-      params.getNeedClientAuth shouldBe false
+      assert(params.getWantClientAuth == false)
+      assert(params.getNeedClientAuth == false)
     }
 
     "wantClientAuth when wantClientAuth=true and needClientAuth=false" in {
       val params = TLSParameters(wantClientAuth = true, needClientAuth = false).toSSLParameters
-      params.getWantClientAuth shouldBe true
-      params.getNeedClientAuth shouldBe false
+      assert(params.getWantClientAuth == true)
+      assert(params.getNeedClientAuth == false)
     }
 
     "needClientAuth when wantClientAuth=false and needClientAuth=true" in {
       val params = TLSParameters(wantClientAuth = false, needClientAuth = true).toSSLParameters
-      params.getWantClientAuth shouldBe false
-      params.getNeedClientAuth shouldBe true
+      assert(params.getWantClientAuth == false)
+      assert(params.getNeedClientAuth == true)
     }
 
     "needClientAuth when wantClientAuth=true and needClientAuth=true" in {
       val params = TLSParameters(wantClientAuth = true, needClientAuth = true).toSSLParameters
-      params.getWantClientAuth shouldBe false
-      params.getNeedClientAuth shouldBe true
+      assert(params.getWantClientAuth == false)
+      assert(params.getNeedClientAuth == true)
     }
   }
 }

--- a/io/src/test/scala/fs2/io/tls/TLSSocketSpec.scala
+++ b/io/src/test/scala/fs2/io/tls/TLSSocketSpec.scala
@@ -46,7 +46,7 @@ class TLSSocketSpec extends TLSSpec {
                               .through(text.utf8Decode)
                               .through(text.lines)).head.compile.string
                         }
-                        .asserting(_ shouldBe "HTTP/1.1 200 OK")
+                        .asserting(it => assert(it == "HTTP/1.1 200 OK"))
                     }
                 }
               }
@@ -83,7 +83,7 @@ class TLSSocketSpec extends TLSSpec {
                       }
                   }
 
-                  client.concurrently(server).compile.to(Chunk).asserting(_ shouldBe msg)
+                  client.concurrently(server).compile.to(Chunk).asserting(it => assert(it == msg))
               }
           }
         }

--- a/io/src/test/scala/fs2/io/udp/UdpSpec.scala
+++ b/io/src/test/scala/fs2/io/udp/UdpSpec.scala
@@ -48,7 +48,7 @@ class UdpSpec extends Fs2Spec {
         }
         .compile
         .toVector
-        .asserting(_.map(_.bytes) shouldBe Vector(msg))
+        .asserting(it => assert(it.map(_.bytes) == Vector(msg)))
     }
 
     "echo lots" in {
@@ -90,10 +90,12 @@ class UdpSpec extends Fs2Spec {
         .compile
         .toVector
         .asserting(res =>
-          res.map(p => new String(p.bytes.toArray)).sorted shouldBe Vector
-            .fill(numClients)(msgs.map(b => new String(b.toArray)))
-            .flatten
-            .sorted
+          assert(
+            res.map(p => new String(p.bytes.toArray)).sorted == Vector
+              .fill(numClients)(msgs.map(b => new String(b.toArray)))
+              .flatten
+              .sorted
+          )
         )
     }
 
@@ -135,7 +137,7 @@ class UdpSpec extends Fs2Spec {
         }
         .compile
         .toVector
-        .asserting(_.map(_.bytes) shouldBe Vector(msg))
+        .asserting(it => assert(it.map(_.bytes) == Vector(msg)))
     }
 
     "timeouts supported" in {

--- a/reactive-streams/src/test/scala/fs2/interop/reactivestreams/PublisherToSubscriberSpec.scala
+++ b/reactive-streams/src/test/scala/fs2/interop/reactivestreams/PublisherToSubscriberSpec.scala
@@ -3,14 +3,10 @@ package interop
 package reactivestreams
 
 import cats.effect._
-import org.scalatest._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-final class PublisherToSubscriberSpec
-    extends AnyFlatSpec
-    with Matchers
-    with ScalaCheckPropertyChecks {
+final class PublisherToSubscriberSpec extends AnyFlatSpec with ScalaCheckPropertyChecks {
   implicit val ctx: ContextShift[IO] =
     IO.contextShift(scala.concurrent.ExecutionContext.Implicits.global)
 
@@ -18,7 +14,7 @@ final class PublisherToSubscriberSpec
     forAll { (ints: Seq[Int]) =>
       val subscriberStream = Stream.emits(ints).covary[IO].toUnicastPublisher.toStream[IO]
 
-      subscriberStream.compile.toVector.unsafeRunSync() should ===(ints.toVector)
+      assert(subscriberStream.compile.toVector.unsafeRunSync() === (ints.toVector))
     }
   }
 
@@ -28,7 +24,7 @@ final class PublisherToSubscriberSpec
     val input: Stream[IO, Int] = Stream(1, 2, 3) ++ Stream.raiseError[IO](TestError)
     val output: Stream[IO, Int] = input.toUnicastPublisher.toStream[IO]
 
-    output.compile.drain.attempt.unsafeRunSync() should ===(Left(TestError))
+    assert(output.compile.drain.attempt.unsafeRunSync() === (Left(TestError)))
   }
 
   it should "cancel upstream if downstream completes" in {
@@ -36,7 +32,7 @@ final class PublisherToSubscriberSpec
       val subscriberStream =
         Stream.emits(as ++ bs).covary[IO].toUnicastPublisher.toStream[IO].take(as.size)
 
-      subscriberStream.compile.toVector.unsafeRunSync() should ===(as.toVector)
+      assert(subscriberStream.compile.toVector.unsafeRunSync() === (as.toVector))
     }
   }
 }


### PR DESCRIPTION
Fixes #1764

This PR replaces all `should` matchers in all tests at one go.
It may be a lot of changes to review... If necessary, I could break this PR into few smaller ones.