### PR TITLE
Add withTimeout combinator

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2715,27 +2715,15 @@ final class Stream[+F[_], +O] private[fs2] (private val free: FreeC[F, O, Unit])
     f(this, s2)
 
   /** Fails this stream with a [[TimeoutException]] if it does not complete within given `timeout`. */
-  def withTimeout[F2[x] >: F[x]](
+  def timeout[F2[x] >: F[x]](
       timeout: FiniteDuration
   )(implicit F2: Concurrent[F2], timer: Timer[F2]): Stream[F2, O] =
-    Stream.eval(Deferred.tryable[F2, Unit]).flatMap { complete =>
-      Stream.eval(Deferred[F2, Either[Throwable, Unit]]).flatMap { interrupt =>
-        val newStream = this.onFinalize(complete.complete(())).interruptWhen(interrupt)
-        val sleepAndInterrupt =
-          timer
-            .sleep(timeout)
-            .flatMap { _ =>
-              complete.tryGet.flatMap {
-                case Some(_) =>
-                  F2.unit
-                case None =>
-                  interrupt.complete(Left(new TimeoutException(s"Timeout after $timeout")))
-              }
-            }
-
-        Stream.eval(sleepAndInterrupt.start).flatMap(_ => newStream)
-      }
-    }
+    this.interruptWhen(
+      timer
+        .sleep(timeout)
+        .as(Left(new TimeoutException(s"Timed out after $timeout")))
+        .widen[Either[Throwable, Unit]]
+    )
 
   /**
     * Translates effect type from `F` to `G` using the supplied `FunctionK`.

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2715,11 +2715,11 @@ final class Stream[+F[_], +O] private[fs2] (private val free: FreeC[F, O, Unit])
     f(this, s2)
 
   /** Fails this stream with a [[TimeoutException]] if it does not complete within given `timeout`. */
-  def timeout[F2[x] >: F[x]](
+  def timeout[F2[x] >: F[x]: Concurrent: Timer](
       timeout: FiniteDuration
-  )(implicit F2: Concurrent[F2], timer: Timer[F2]): Stream[F2, O] =
+  ): Stream[F2, O] =
     this.interruptWhen(
-      timer
+      Timer[F2]
         .sleep(timeout)
         .as(Left(new TimeoutException(s"Timed out after $timeout")))
         .widen[Either[Throwable, Unit]]

--- a/core/shared/src/test/scala/fs2/StreamSpec.scala
+++ b/core/shared/src/test/scala/fs2/StreamSpec.scala
@@ -3800,13 +3800,21 @@ class StreamSpec extends Fs2Spec {
     "compose timeouts d1 and d2 when d1 < d2" in {
       val d1 = 20.millis
       val d2 = 30.millis
-      (Stream.sleep(10.millis).timeout(d1) ++ Stream.sleep(30.millis)).timeout(d2).compile.drain.assertThrows[TimeoutException]
+      (Stream.sleep(10.millis).timeout(d1) ++ Stream.sleep(30.millis))
+        .timeout(d2)
+        .compile
+        .drain
+        .assertThrows[TimeoutException]
     }
 
     "compose timeouts d1 and d2 when d1 > d2" in {
       val d1 = 40.millis
       val d2 = 30.millis
-      (Stream.sleep(10.millis).timeout(d1) ++ Stream.sleep(25.millis)).timeout(d2).compile.drain.assertThrows[TimeoutException]
+      (Stream.sleep(10.millis).timeout(d1) ++ Stream.sleep(25.millis))
+        .timeout(d2)
+        .compile
+        .drain
+        .assertThrows[TimeoutException]
     }
   }
 }

--- a/core/shared/src/test/scala/fs2/StreamSpec.scala
+++ b/core/shared/src/test/scala/fs2/StreamSpec.scala
@@ -6,6 +6,7 @@ import cats.effect._
 import cats.effect.concurrent.{Deferred, Ref, Semaphore}
 import cats.implicits._
 import scala.concurrent.duration._
+import scala.concurrent.TimeoutException
 import org.scalactic.anyvals._
 import org.scalatest.{Assertion, Succeeded}
 import fs2.concurrent.{Queue, SignallingRef}
@@ -3784,6 +3785,16 @@ class StreamSpec extends Fs2Spec {
           .drain
           .assertNoException
       }
+    }
+  }
+
+  "withTimeout" - {
+    "timeout never-ending stream" in {
+      Stream.never[IO].withTimeout(100.millis).compile.drain.assertThrows[TimeoutException]
+    }
+
+    "not trigger timeout on successfully completed stream" in {
+      Stream.sleep(10.millis).withTimeout(1.second).compile.drain.assertNoException
     }
   }
 }

--- a/core/shared/src/test/scala/fs2/StreamSpec.scala
+++ b/core/shared/src/test/scala/fs2/StreamSpec.scala
@@ -3790,11 +3790,11 @@ class StreamSpec extends Fs2Spec {
 
   "withTimeout" - {
     "timeout never-ending stream" in {
-      Stream.never[IO].withTimeout(100.millis).compile.drain.assertThrows[TimeoutException]
+      Stream.never[IO].timeout(100.millis).compile.drain.assertThrows[TimeoutException]
     }
 
     "not trigger timeout on successfully completed stream" in {
-      Stream.sleep(10.millis).withTimeout(1.second).compile.drain.assertNoException
+      Stream.sleep(10.millis).timeout(1.second).compile.drain.assertNoException
     }
   }
 }

--- a/core/shared/src/test/scala/fs2/StreamSpec.scala
+++ b/core/shared/src/test/scala/fs2/StreamSpec.scala
@@ -3796,5 +3796,17 @@ class StreamSpec extends Fs2Spec {
     "not trigger timeout on successfully completed stream" in {
       Stream.sleep(10.millis).timeout(1.second).compile.drain.assertNoException
     }
+
+    "compose timeouts d1 and d2 when d1 < d2" in {
+      val d1 = 20.millis
+      val d2 = 30.millis
+      (Stream.sleep(10.millis).timeout(d1) ++ Stream.sleep(30.millis)).timeout(d2).compile.drain.assertThrows[TimeoutException]
+    }
+
+    "compose timeouts d1 and d2 when d1 > d2" in {
+      val d1 = 40.millis
+      val d2 = 30.millis
+      (Stream.sleep(10.millis).timeout(d1) ++ Stream.sleep(25.millis)).timeout(d2).compile.drain.assertThrows[TimeoutException]
+    }
   }
 }


### PR DESCRIPTION
On a day-to-day job basis we often use such a combinator for `Stream`, allowing us to time out and interrupt streams that do not complete within given `FiniteDuration`. Such a combinator may be useful as a part of the `Stream` itself