### PR TITLE
Prevent concurrent writes to fs2-io TCP socket from causing WritePendingException 

### DIFF
--- a/io/src/main/scala/fs2/io/tcp/SocketGroup.scala
+++ b/io/src/main/scala/fs2/io/tcp/SocketGroup.scala
@@ -212,7 +212,7 @@ final class SocketGroup(channelGroup: AsynchronousChannelGroup, blocker: Blocker
   private def apply[F[_]](
       ch: AsynchronousSocketChannel
   )(implicit F: Concurrent[F], cs: ContextShift[F]): Resource[F, Socket[F]] = {
-    val socket = (Semaphore[F](1), Semaphore[F](1)).flatMap { semaphores =>
+    val socket = (Semaphore[F](1), Semaphore[F](1)).tupled.flatMap { semaphores =>
       val (readSemaphore, writeSemaphore) = semaphores
       Ref.of[F, ByteBuffer](ByteBuffer.allocate(0)).map { bufferRef =>
         // Reads data to remaining capacity of supplied ByteBuffer

--- a/io/src/test/scala/fs2/io/tcp/SocketSpec.scala
+++ b/io/src/test/scala/fs2/io/tcp/SocketSpec.scala
@@ -130,7 +130,7 @@ class SocketSpec extends Fs2Spec {
     }
 
     "write - concurrent calls do not cause WritePendingException" in {
-      val message = Chunk.bytes(("123456789012345678901234567890" * 100000).getBytes)
+      val message = Chunk.bytes(("123456789012345678901234567890" * 10000).getBytes)
 
       val localBindAddress =
         Deferred[IO, InetSocketAddress].unsafeRunSync()
@@ -153,7 +153,7 @@ class SocketSpec extends Fs2Spec {
                   )
                   .flatMap(sock =>
                     Stream(
-                      Stream.eval(sock.write(message)).repeatN(1000L)
+                      Stream.eval(sock.write(message)).repeatN(10L)
                     ).repeatN(2L)
                   )
                   .parJoinUnbounded


### PR DESCRIPTION
I had to tune the test parameters (message size and write buffer size) to make the test consistently fail on my machine without this change - hopefully it does so on other machines too 🙂