### PR TITLE
Override Chunk.BufferChunk.iterator to return buffer.iterator

### DIFF
--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -624,6 +624,10 @@ object Chunk extends CollectorK[Chunk] {
       else if (n >= size) Chunk.empty
       else buffer(b.drop(n))
 
+    /** Creates an iterator that iterates the elements of this chunk. The returned iterator is not thread safe. */
+    override def iterator: Iterator[O] =
+      b.iterator
+
     override def take(n: Int): Chunk[O] =
       if (n <= 0) Chunk.empty
       else if (n >= size) this


### PR DESCRIPTION
Override Chunk.BufferChunk.iterator to return buffer.iterator.

Chunk.iterator reasonably assumes that the underlying collection is indexed and iterates through the chunk with sequential calls to apply(), but Chunk.BufferChunk can be created from a ListBuffer which has a non-constant time apply() implementation. Because Chunk.flatMap makes use of Chunk.iterator, flat mapping over a ListBuffer backed BufferChunk has high cost complexity. The simplest solution is to override BufferChunk's iterator implementation with the iterator implementation of the underlying buffer.

Alternatively or subsequently, there may be a gain in having different chunk implementations for Buffer and IndexedBuffer.