### PR TITLE
Add `evalMapChunk` and `evalTapChunk` which operate on chunks

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/StreamBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/StreamBenchmark.scala
@@ -92,4 +92,12 @@ class StreamBenchmark {
       .compile
       .drain
       .unsafeRunSync
+
+  @Benchmark
+  def evalMap() =
+    Stream.emits(0 until n).evalMap(x => IO(x * 5)).compile.drain.unsafeRunSync
+
+  @Benchmark
+  def evalMaps() =
+    Stream.emits(0 until n).evalMapChunk(x => IO(x * 5)).compile.drain.unsafeRunSync
 }

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -970,7 +970,7 @@ final class Stream[+F[_], +O] private[fs2] (private val free: FreeC[F, O, Unit])
     * }}}
     *
     * Note this operator will de-chunk the stream back into chunks of size 1, which has performance
-    * implications. For maximum performance, `evalMaps` is available, however, with caveats.
+    * implications. For maximum performance, `evalMapChunk` is available, however, with caveats.
     */
   def evalMap[F2[x] >: F[x], O2](f: O => F2[O2]): Stream[F2, O2] =
     flatMap(o => Stream.eval(f(o)))
@@ -1061,7 +1061,7 @@ final class Stream[+F[_], +O] private[fs2] (private val free: FreeC[F, O, Unit])
     evalMap(o => f(o).as(o))
 
   /**
-    * Alias for `evalMaps(o => f(o).as(o))`.
+    * Alias for `evalMapChunk(o => f(o).as(o))`.
     */
   def evalTapChunk[F2[x] >: F[x]: Functor: Applicative](f: O => F2[_]): Stream[F2, O] =
     evalMapChunk(o => f(o).as(o))

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -968,9 +968,37 @@ final class Stream[+F[_], +O] private[fs2] (private val free: FreeC[F, O, Unit])
     * scala> Stream(1,2,3,4).evalMap(i => IO(println(i))).compile.drain.unsafeRunSync
     * res0: Unit = ()
     * }}}
+    *
+    * Note this operator will de-chunk the stream back into chunks of size 1, which has performance
+    * implications. For maximum performance, `evalMaps` is available, however, with caveats.
     */
   def evalMap[F2[x] >: F[x], O2](f: O => F2[O2]): Stream[F2, O2] =
     flatMap(o => Stream.eval(f(o)))
+
+  /**
+    * Like `evalMap`, but operates on chunks for performance. This means this operator
+    * is not lazy on every single element, rather on the chunks.
+    *
+    * For instance, `evalMap` would only print twice in the follow example (note the `take(2)`):
+    * @example {{{
+    * scala> import cats.effect.IO
+    * scala> Stream(1,2,3,4).evalMap(i => IO(println(i))).take(2).compile.drain.unsafeRunSync
+    * 1
+    * 2
+    * }}}
+    *
+    * But with `evalMaps`, it will print 4 times:
+    * @example {{{
+    * scala> import cats.effect.IO
+    * scala> Stream(1,2,3,4).evalMaps(i => IO(println(i))).take(2).compile.drain.unsafeRunSync
+    * 1
+    * 2
+    * 3
+    * 4
+    * }}}
+    */
+  def evalMapChunk[F2[x] >: F[x]: Applicative, O2](f: O => F2[O2]): Stream[F2, O2] =
+    chunks.flatMap(o => Stream.evalUnChunk(o.traverse(f)))
 
   /**
     * Like `[[Stream#mapAccumulate]]`, but accepts a function returning an `F[_]`.
@@ -1031,6 +1059,12 @@ final class Stream[+F[_], +O] private[fs2] (private val free: FreeC[F, O, Unit])
     */
   def evalTap[F2[x] >: F[x]: Functor](f: O => F2[_]): Stream[F2, O] =
     evalMap(o => f(o).as(o))
+
+  /**
+    * Alias for `evalMaps(o => f(o).as(o))`.
+    */
+  def evalTapChunk[F2[x] >: F[x]: Functor: Applicative](f: O => F2[_]): Stream[F2, O] =
+    evalMapChunk(o => f(o).as(o))
 
   /**
     * Emits `true` as soon as a matching element is received, else `false` if no input matches.


### PR DESCRIPTION
```
[info] Benchmark                   (n)   Mode  Cnt       Score       Error  Units
[info] StreamBenchmark.evalMap      10  thrpt    3  240385.919 ± 33389.928  ops/s
[info] StreamBenchmark.evalMap     100  thrpt    3   39834.763 ±  3967.529  ops/s
[info] StreamBenchmark.evalMap    1000  thrpt    3    4105.834 ±   867.816  ops/s
[info] StreamBenchmark.evalMap   10000  thrpt    3     212.373 ±  1205.824  ops/s
[info] StreamBenchmark.evalMaps     10  thrpt    3  230966.575 ± 89764.693  ops/s
[info] StreamBenchmark.evalMaps    100  thrpt    3   71055.648 ± 10100.526  ops/s
[info] StreamBenchmark.evalMaps   1000  thrpt    3    9802.130 ±   795.724  ops/s
[info] StreamBenchmark.evalMaps  10000  thrpt    3     881.018 ±    96.295  ops/s
```

Sorry, I accidentally switched a tab Chrome on the `10_000` run of `evalMap`, but it's around 300 ops/s in reality.