### PR TITLE
Include fd4s/fs2-kafka in the list of projects that use fs2

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ If you have a project you'd like to include in this list, either open a PR or le
 * [fs2-grpc](https://github.com/fiadliel/fs2-grpc): gRPC implementation for FS2 / Cats Effect.
 * [fs2-http](https://github.com/Spinoco/fs2-http): Http server and client library implemented in fs2.
 * [fs2-jms](https://github.com/kiambogo/fs2-jms): JMS connectors for FS2 streams
-* [fs2-kafka](https://github.com/Spinoco/fs2-kafka): Simple client for Apache Kafka.
+* fs2-kafka
+  * [fd4s/fs2-kafka](https://github.com/fd4s/fs2-kafka): Functional Kafka Streams for Scala.
+  * [spinoco/fs2-kafka](https://github.com/Spinoco/fs2-kafka): Simple client for Apache Kafka.
 * [fs2-mail](https://github.com/Spinoco/fs2-mail): Fully asynchronous java non-blocking email client using fs2.
 * [fs2-rabbit](https://github.com/gvolpe/fs2-rabbit): RabbitMQ stream-based client built on top of Fs2.
 * [fs2-reactive-streams](https://github.com/zainab-ali/fs2-reactive-streams): A reactive streams implementation for fs2.


### PR DESCRIPTION
There are two projects with the same name that provide Apache Kafka bindings for fs2. I feel like both should be included in the list of projects that use fs2 because that is something that puzzled me as a new user. I included the projects in lexicographical order, so the ordering should not be interpreted as a matter of personal preference.