### PR TITLE
Make .compile.foldMonoid chunk-aware for potential speedups

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -4395,7 +4395,7 @@ object Stream extends StreamLowPriority {
       * }}}
       */
     def foldSemigroup(implicit O: Semigroup[O]): G[Option[O]] =
-      fold(Option.empty[O])((acc, o) => acc.map(O.combine(_, o)).orElse(Some(o)))
+      foldChunks(Option.empty[O])(_ |+| _.combineAllOption)
 
     /**
       * Compiles this stream in to a value of the target effect type `F`,

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -4380,7 +4380,7 @@ object Stream extends StreamLowPriority {
       * }}}
       */
     def foldMonoid(implicit O: Monoid[O]): G[O] =
-      fold(O.empty)(O.combine)
+      foldChunks(O.empty)(_ |+| _.combineAll)
 
     /**
       * Like [[fold]] but uses the implicitly available `Semigroup[O]` to combine elements.


### PR DESCRIPTION
Using `.combineAll` for the chunk allows for potential speedups. For example, this could make `foldMonoid` much more efficient for `Map`s since it can take advantage of the efficient `combineAll`: https://github.com/typelevel/cats/blob/8bd728339b5b1c6b1b2f40f3cc9ef97480e1f02b/kernel/src/main/scala/cats/kernel/instances/MapInstances.scala#L77-L87