### PR TITLE
Fix #1838 soundness bug that allowed a pure pull to be used on effectful streams

### DIFF
--- a/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
+++ b/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
@@ -52,24 +52,24 @@ object ResourceTrackerSanityTest extends App {
 }
 
 object RepeatPullSanityTest extends App {
-  def id[A]: Pipe[Pure, A, A] = _.repeatPull {
+  def id[F[_], A]: Pipe[F, A, A] = _.repeatPull {
     _.uncons1.flatMap {
       case Some((h, t)) => Pull.output1(h).as(Some(t));
       case None         => Pull.pure(None)
     }
   }
-  Stream.constant(1).covary[IO].through(id[Int]).compile.drain.unsafeRunSync()
+  Stream.constant(1).covary[IO].through(id[IO, Int]).compile.drain.unsafeRunSync()
 }
 
 object RepeatEvalSanityTest extends App {
-  def id[A]: Pipe[Pure, A, A] = {
-    def go(s: Stream[Pure, A]): Pull[Pure, A, Unit] =
+  def id[F[_], A]: Pipe[F, A, A] = {
+    def go(s: Stream[F, A]): Pull[F, A, Unit] =
       s.pull.uncons1.flatMap {
         case Some((h, t)) => Pull.output1(h) >> go(t); case None => Pull.done
       }
     in => go(in).stream
   }
-  Stream.repeatEval(IO(1)).through(id[Int]).compile.drain.unsafeRunSync()
+  Stream.repeatEval(IO(1)).through(id[IO, Int]).compile.drain.unsafeRunSync()
 }
 
 object AppendSanityTest extends App {

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -4687,20 +4687,21 @@ object Stream extends StreamLowPriority {
   /** Provides operations on pure pipes for syntactic convenience. */
   implicit final class PurePipeOps[I, O](private val self: Pipe[Pure, I, O]) extends AnyVal {
 
-    /** Lifts this pipe to the specified effect type. */
-    def covary[F[_]]: Pipe[F, I, O] = self.asInstanceOf[Pipe[F, I, O]]
+    // This is unsound! See #1838. Left for binary compatibility.
+    private[fs2] def covary[F[_]]: Pipe[F, I, O] = self.asInstanceOf[Pipe[F, I, O]]
   }
 
   /** Provides operations on pure pipes for syntactic convenience. */
   implicit final class PurePipe2Ops[I, I2, O](private val self: Pipe2[Pure, I, I2, O])
       extends AnyVal {
 
-    /** Lifts this pipe to the specified effect type. */
-    def covary[F[_]]: Pipe2[F, I, I2, O] = self.asInstanceOf[Pipe2[F, I, I2, O]]
+    // This is unsound! See #1838. Left for binary compatibility.
+    private[fs2] def covary[F[_]]: Pipe2[F, I, I2, O] = self.asInstanceOf[Pipe2[F, I, I2, O]]
   }
 
   // This is unsound! See #1838. Left for binary compatibility.
-  private[fs2] def covaryPurePipe[F[_], I, O](p: Pipe[Pure, I, O]): Pipe[F, I, O] =
+  @deprecated("This is unsound! See #1838.", "2.3.1")
+  def covaryPurePipe[F[_], I, O](p: Pipe[Pure, I, O]): Pipe[F, I, O] =
     p.covary[F]
 
   /**

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -4699,8 +4699,8 @@ object Stream extends StreamLowPriority {
     def covary[F[_]]: Pipe2[F, I, I2, O] = self.asInstanceOf[Pipe2[F, I, I2, O]]
   }
 
-  /** Implicitly covaries a pipe. */
-  implicit def covaryPurePipe[F[_], I, O](p: Pipe[Pure, I, O]): Pipe[F, I, O] =
+  // This is unsound! See #1838. Left for binary compatibility.
+  private[fs2] def covaryPurePipe[F[_], I, O](p: Pipe[Pure, I, O]): Pipe[F, I, O] =
     p.covary[F]
 
   /**

--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -67,7 +67,7 @@ object text {
         )
     }
 
-    def doPull(buf: Chunk[Byte], s: Stream[Pure, Chunk[Byte]]): Pull[Pure, String, Unit] =
+    def doPull(buf: Chunk[Byte], s: Stream[F, Chunk[Byte]]): Pull[F, String, Unit] =
       s.pull.uncons.flatMap {
         case Some((byteChunks, tail)) =>
           val (output, nextBuffer) =
@@ -81,8 +81,8 @@ object text {
 
     def processByteOrderMark(
         buffer: Option[Chunk.Queue[Byte]],
-        s: Stream[Pure, Chunk[Byte]]
-    ): Pull[Pure, String, Unit] =
+        s: Stream[F, Chunk[Byte]]
+    ): Pull[F, String, Unit] =
       s.pull.uncons1.flatMap {
         case Some((hd, tl)) =>
           val newBuffer = buffer.getOrElse(Chunk.Queue.empty[Byte]) :+ hd
@@ -103,7 +103,7 @@ object text {
           }
       }
 
-    (in: Stream[Pure, Chunk[Byte]]) => processByteOrderMark(None, in).stream
+    (in: Stream[F, Chunk[Byte]]) => processByteOrderMark(None, in).stream
   }
 
   /** Encodes a stream of `String` in to a stream of bytes using the given charset. */

--- a/core/shared/src/test/scala/fs2/CompilationTest.scala
+++ b/core/shared/src/test/scala/fs2/CompilationTest.scala
@@ -56,7 +56,6 @@ object ThisModuleShouldCompile {
   val s: Stream[IO, Int] = if (true) Stream(1, 2, 3) else Stream.eval(IO(10))
 
   val t2p: Pipe[Pure, Int, Int] = _.take(2)
-  t2p.covary[IO]
   val t2: Pipe[IO, Int, Int] = _.take(2)
   val p2: Pipe2[IO, Int, Int, Int] = (s1, s2) => s1.interleave(s2)
   t2.attachL(p2)

--- a/core/shared/src/test/scala/fs2/StreamSpec.scala
+++ b/core/shared/src/test/scala/fs2/StreamSpec.scala
@@ -1098,8 +1098,8 @@ class StreamSpec extends Fs2Spec {
     "every" in {
       flickersOnTravis
       type BD = (Boolean, FiniteDuration)
-      val durationSinceLastTrue: Pipe[Pure, BD, BD] = {
-        def go(lastTrue: FiniteDuration, s: Stream[Pure, BD]): Pull[Pure, BD, Unit] =
+      def durationSinceLastTrue[F[_]]: Pipe[F, BD, BD] = {
+        def go(lastTrue: FiniteDuration, s: Stream[F, BD]): Pull[F, BD, Unit] =
           s.pull.uncons1.flatMap {
             case None => Pull.done
             case Some((pair, tl)) =>
@@ -3964,5 +3964,11 @@ class StreamSpec extends Fs2Spec {
         .drain
         .assertThrows[TimeoutException]
     }
+  }
+
+  "pure pipes cannot be used with effectful streams (#1838)" in {
+    val p: Pipe[Pure, Int, List[Int]] = in => Stream(in.toList)
+    identity(p) // Avoid unused warning
+    assertDoesNotCompile("Stream.eval(IO(1)).through(p)")
   }
 }


### PR DESCRIPTION
Fixes #1838

A pipe is invariant so we never should have supported `covary`, either implicitly or explicitly. The minimization in #1838 exposes the variance cheating. :)