### PR TITLE
Fix relative document paths

### DIFF
--- a/site/docs/concurrency-primitives.md
+++ b/site/docs/concurrency-primitives.md
@@ -17,7 +17,7 @@ These data structures could be very handy in a few cases. See below examples of 
 
 ### FIFO (First IN / First OUT)
 
-A typical use case of a `fs2.concurrent.Queue[F, A]`, also quite useful to communicate with the external world as shown in the [guide](guide.md#talking-to-the-external-world).
+A typical use case of a `fs2.concurrent.Queue[F, A]`, also quite useful to communicate with the external world as shown in the [guide](guide.html#talking-to-the-external-world).
 
 q1 has a buffer size of 1 while q2 has a buffer size of 100 so you will notice the buffering when  pulling elements out of the q2.
 

--- a/site/docs/guide.md
+++ b/site/docs/guide.md
@@ -397,7 +397,7 @@ It flattens the nested stream, letting up to `maxOpen` inner streams run at a ti
 
 The `Concurrent` bound on `F` is required anywhere concurrency is used in the library. As mentioned earlier, users can bring their own effect types provided they also supply an `Concurrent` instance in implicit scope.
 
-In addition, there are a number of other concurrency primitives---asynchronous queues, signals, and semaphores. See the [Concurrency Primitives section](concurrency-primitives.md) for more examples. We'll make use of some of these in the next section when discussing how to talk to the external world.
+In addition, there are a number of other concurrency primitives---asynchronous queues, signals, and semaphores. See the [Concurrency Primitives section](concurrency-primitives.html) for more examples. We'll make use of some of these in the next section when discussing how to talk to the external world.
 
 ### Exercises Concurrency
 


### PR DESCRIPTION
Fix relative documentation paths by using a `.html` extension as opposed to `.md` one.

The relative `.md` extensions could work as outlined [here](https://github.com/functional-streams-for-scala/fs2/issues/1836) but that would involve updating a Jekyll instance with a new plugin which could get messy. 

I've based this fix on the Doobie [docs](https://tpolecat.github.io/doobie/docs/18-FAQ.html) which use the same approach.