### PR TITLE
Improve compression.gunzip to eagerly stream chunks while the inflater is unfinish before validating the trailer.

### DIFF
--- a/core/jvm/src/main/scala/fs2/compression.scala
+++ b/core/jvm/src/main/scala/fs2/compression.scala
@@ -716,27 +716,30 @@ object compression {
           _.pull.unconsNonEmpty
             .flatMap {
               case Some((next, rest)) =>
-                if (next.size >= gzipTrailerBytes) {
-                  Pull.output(last) >> streamUntilTrailer(next)(rest)
+                if (inflater.finished()) {
+                  if (next.size >= gzipTrailerBytes) {
+                    if (last.nonEmpty) Pull.output(last) >> streamUntilTrailer(next)(rest)
+                    else streamUntilTrailer(next)(rest)
+                  } else {
+                    streamUntilTrailer(Chunk.concatBytes(List(last.toBytes, next.toBytes)))(rest)
+                  }
                 } else {
-                  streamUntilTrailer(Chunk.concatBytes(List(last.toBytes, next.toBytes)))(rest)
+                  if (last.nonEmpty)
+                    Pull.output(last) >> Pull.output(next) >>
+                      streamUntilTrailer(Chunk.empty[Byte])(rest)
+                  else Pull.output(next) >> streamUntilTrailer(Chunk.empty[Byte])(rest)
                 }
               case None =>
                 val preTrailerBytes = last.size - gzipTrailerBytes
                 if (preTrailerBytes > 0) {
-                  Pull.output(last.take(preTrailerBytes)) >> validateTrailer(
-                    last.drop(preTrailerBytes)
-                  )
+                  Pull.output(last.take(preTrailerBytes)) >>
+                    validateTrailer(last.drop(preTrailerBytes))
                 } else {
                   validateTrailer(last)
                 }
             }
 
-        stream.pull.unconsNonEmpty
-          .flatMap {
-            case Some((chunk, rest)) => streamUntilTrailer(chunk)(rest)
-            case None                => Pull.raiseError(new ZipException("Failed to read trailer (2)"))
-          }
+        streamUntilTrailer(Chunk.empty[Byte])(stream)
       }.stream
 
   /**


### PR DESCRIPTION
Improve compression.gunzip to eagerly stream chunks while the inflater is unfinish before validating the trailer.

See: https://github.com/functional-streams-for-scala/fs2/issues/1831

Benchmark of compression.gunzip not significantly changed.

Before:
[info] Benchmark                    (withRandomBytes)   Mode  Cnt     Score    Error  Units
[info] CompressionBenchmark.gunzip               true  thrpt   25  2697.478 ± 23.129  ops/s
[info] CompressionBenchmark.gunzip              false  thrpt   25   472.732 ±  1.771  ops/s

After:
[info] Benchmark                    (withRandomBytes)   Mode  Cnt     Score    Error  Units
[info] CompressionBenchmark.gunzip               true  thrpt   25  2686.658 ± 22.094  ops/s
[info] CompressionBenchmark.gunzip              false  thrpt   25   470.444 ±  2.187  ops/s