### PR TITLE
Add parZip

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2266,6 +2266,15 @@ final class Stream[+F[_], +O] private[fs2] (private val free: FreeC[F, O, Unit])
   ): Stream[F2, O2] =
     parJoin(Int.MaxValue)
 
+
+  def parZip[F2[x] >: F[x]: Concurrent, O2](that: Stream[F2, O2]): Stream[F2, (O, O2)] =
+    this zip that
+
+  def parZipWith[F2[x] >: F[x]: Concurrent, O2 >: O, O3, O4](
+      that: Stream[F2, O3]
+  )(f: (O2, O3) => O4): Stream[F2, O4] =
+    this.parZip(that).map(f.tupled)
+
   /** Like `interrupt` but resumes the stream when left branch goes to true. */
   def pauseWhen[F2[x] >: F[x]](
       pauseWhenTrue: Stream[F2, Boolean]

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2266,9 +2266,8 @@ final class Stream[+F[_], +O] private[fs2] (private val free: FreeC[F, O, Unit])
   ): Stream[F2, O2] =
     parJoin(Int.MaxValue)
 
-
   def parZip[F2[x] >: F[x]: Concurrent, O2](that: Stream[F2, O2]): Stream[F2, (O, O2)] =
-    this zip that
+    this.zip(that)
 
   def parZipWith[F2[x] >: F[x]: Concurrent, O2 >: O, O3, O4](
       that: Stream[F2, O3]

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2266,7 +2266,6 @@ final class Stream[+F[_], +O] private[fs2] (private val free: FreeC[F, O, Unit])
   ): Stream[F2, O2] =
     parJoin(Int.MaxValue)
 
-
   /**
     * Concurrent zip.
     *
@@ -4729,7 +4728,10 @@ object Stream extends StreamLowPriority {
     *  classes, so the presence of the `State` trait forces this
     *  method to be outside of the `Stream` class.
     */
-  private[fs2] def parZip[F[_]: Concurrent, L, R](left: Stream[F, L], right: Stream[F, R]): Stream[F, (L, R)] = {
+  private[fs2] def parZip[F[_]: Concurrent, L, R](
+      left: Stream[F, L],
+      right: Stream[F, R]
+  ): Stream[F, (L, R)] = {
     sealed trait State
     case object Racing extends State
     case class LeftFirst(leftValue: L, waitOnRight: Deferred[F, Unit]) extends State
@@ -4741,33 +4743,36 @@ object Stream extends StreamLowPriority {
       def lhs(stream: Stream[F, L]): Pull[F, (L, R), Unit] =
         stream.pull.uncons1.flatMap {
           case None => Pull.done
-          case Some((leftValue, stream)) => Pull.eval {
-            Deferred[F, Unit].flatMap { awaitRight =>
-              state.modify {
-                case Racing =>
-                  LeftFirst(leftValue, awaitRight) -> Pull.eval(awaitRight.get)
-                case RightFirst(rightValue, awaitLeft) =>
-                  Racing -> { emit(leftValue, rightValue) >> Pull.eval(awaitLeft.complete(())) }
-                case LeftFirst(_, _) => sys.error("fs2 parZip protocol broken by lhs. File a bug")
+          case Some((leftValue, stream)) =>
+            Pull.eval {
+              Deferred[F, Unit].flatMap { awaitRight =>
+                state.modify {
+                  case Racing =>
+                    LeftFirst(leftValue, awaitRight) -> Pull.eval(awaitRight.get)
+                  case RightFirst(rightValue, awaitLeft) =>
+                    Racing -> { emit(leftValue, rightValue) >> Pull.eval(awaitLeft.complete(())) }
+                  case LeftFirst(_, _) => sys.error("fs2 parZip protocol broken by lhs. File a bug")
+                }
               }
-            }
-          }.flatten >> lhs(stream)
+            }.flatten >> lhs(stream)
         }
 
       def rhs(stream: Stream[F, R]): Pull[F, (L, R), Unit] =
         stream.pull.uncons1.flatMap {
           case None => Pull.done
-          case Some((rightValue, stream)) => Pull.eval {
-            Deferred[F, Unit].flatMap { awaitLeft =>
-              state.modify {
-                case Racing =>
-                  RightFirst(rightValue, awaitLeft) -> Pull.eval(awaitLeft.get)
-                case LeftFirst(leftValue, awaitRight) =>
-                  Racing -> { emit(leftValue, rightValue) >> Pull.eval(awaitRight.complete(())) }
-                case RightFirst(_, _) => sys.error("fs2 parZip protocol broken by rhs. File a bug")
+          case Some((rightValue, stream)) =>
+            Pull.eval {
+              Deferred[F, Unit].flatMap { awaitLeft =>
+                state.modify {
+                  case Racing =>
+                    RightFirst(rightValue, awaitLeft) -> Pull.eval(awaitLeft.get)
+                  case LeftFirst(leftValue, awaitRight) =>
+                    Racing -> { emit(leftValue, rightValue) >> Pull.eval(awaitRight.complete(())) }
+                  case RightFirst(_, _) =>
+                    sys.error("fs2 parZip protocol broken by rhs. File a bug")
+                }
               }
-            }
-          }.flatten >> rhs(stream)
+            }.flatten >> rhs(stream)
         }
 
       lhs(left).stream.mergeHaltBoth(rhs(right).stream)

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1576,7 +1576,7 @@ final class Stream[+F[_], +O] private[fs2] (private val free: FreeC[F, O, Unit])
     map(Some(_): Option[O2]).holdResource(None)
 
   /**
-    * Determinsitically interleaves elements, starting on the left, terminating when the end of either branch is reached naturally.
+    * Deterministically interleaves elements, starting on the left, terminating when the end of either branch is reached naturally.
     *
     * @example {{{
     * scala> Stream(1, 2, 3).interleave(Stream(4, 5, 6, 7)).toList
@@ -1587,7 +1587,7 @@ final class Stream[+F[_], +O] private[fs2] (private val free: FreeC[F, O, Unit])
     zip(that).flatMap { case (o1, o2) => Stream(o1, o2) }
 
   /**
-    * Determinsitically interleaves elements, starting on the left, terminating when the ends of both branches are reached naturally.
+    * Deterministically interleaves elements, starting on the left, terminating when the ends of both branches are reached naturally.
     *
     * @example {{{
     * scala> Stream(1, 2, 3).interleaveAll(Stream(4, 5, 6, 7)).toList
@@ -2268,7 +2268,7 @@ final class Stream[+F[_], +O] private[fs2] (private val free: FreeC[F, O, Unit])
 
 
   /**
-    * Non-deterministic zip.
+    * Concurrent zip.
     *
     * It combines elements pairwise and in order like `zip`, but
     * instead of pulling from the left stream and then from the right

--- a/core/shared/src/test/scala/fs2/StreamSpec.scala
+++ b/core/shared/src/test/scala/fs2/StreamSpec.scala
@@ -3830,6 +3830,16 @@ class StreamSpec extends Fs2Spec {
       }
     }
 
+    "parZip" - {
+      "parZip outputs same results as zip" in forAll { (s1: Stream[Pure, Int], s2: Stream[Pure, Int]) =>
+
+        val par = s1.covary[IO] parZip s2
+        val seq = s1 zip s2
+
+        par.compile.toList.asserting(result => assert(result == seq.compile.toList))
+      }
+    }
+
     "zipWithIndex" in forAll { (s: Stream[Pure, Int]) =>
       assert(s.zipWithIndex.toList == s.toList.zipWithIndex)
     }


### PR DESCRIPTION
Fixes #936.

This PR adds the elusive `yip` operator, under the more modern name of `parZip`, with the following semantics:
 - combines elements pairwise
 - executes effects concurrently
 - no side is allowed to get ahead by more than one element
 - terminates when either stream terminates
The key insight of the implementation is that `parZip` is a special case of `merge`, where the two sides wait on each other.

I've also added `parZipWith`, and I'm considering `parZipRight` and `parZipLeft`, though I would probably not add `parZipAll` since it requires changing the implementation and it's rare.

Testing has proved a bit challenging, I have added two alternatives for the same test (marked -1 and -2), I'd appreciate input on which one to keep
