### PR TITLE
adds zipWithIndex function on Chunk

### DIFF
--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -453,10 +453,9 @@ abstract class Chunk[+O] extends Serializable { self =>
     * }}}
     */
   def zipWithIndex: Chunk[(O, Int)] = {
-    val sz = size
-    val arr = new Array[(O, Int)](sz)
+    val arr = new Array[(O, Int)](size)
     var i = 0
-    while (i < sz) {
+    while (i < size) {
       arr(i) = (apply(i), i)
       i += 1
     }

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -444,6 +444,25 @@ abstract class Chunk[+O] extends Serializable { self =>
     Chunk.array(arr.asInstanceOf[Array[O3]])
   }
 
+  /**
+    * Zips the elements of the input chunk with its indices, and returns the new chunk.
+    *
+    * @example {{{
+    * scala> Chunk("The", "quick", "brown", "fox").zipWithIndex.toList
+    * res0: List[(String, Int)] = List((The,0), (quick,1), (brown,2), (fox,3))
+    * }}}
+    */
+  def zipWithIndex: Chunk[(O, Int)] = {
+    val sz = size
+    val arr = new Array[(O, Int)](sz)
+    var i = 0
+    while (i < sz) {
+      arr(i) = (apply(i), i)
+      i += 1
+    }
+    Chunk.array(arr)
+  }
+
   override def hashCode: Int = {
     import util.hashing.MurmurHash3
     var i = 0

--- a/core/shared/src/test/scala/fs2/ChunkSpec.scala
+++ b/core/shared/src/test/scala/fs2/ChunkSpec.scala
@@ -200,8 +200,7 @@ class ChunkSpec extends Fs2Spec {
   }
 
   "zipWithIndex andThen toArray" in {
-    val chunk = fs2.Chunk("x", "y", "z")
-    assert(chunk.zipWithIndex.toArray === chunk.toArray.zipWithIndex)
+    forAll((chunk: Chunk[Int]) => assert(chunk.zipWithIndex.toArray === chunk.toArray.zipWithIndex))
   }
 
   "Boxed toArray - regression #1745" in {

--- a/core/shared/src/test/scala/fs2/ChunkSpec.scala
+++ b/core/shared/src/test/scala/fs2/ChunkSpec.scala
@@ -199,6 +199,11 @@ class ChunkSpec extends Fs2Spec {
     assert(arr2 === Array(0, 0))
   }
 
+  "zipWithIndex andThen toArray" in {
+    val arr: Array[(Int, Int)] = Chunk(0, 0, 0).zipWithIndex.toArray
+    assert(arr === Array((0, 0), (0, 1), (0, 2)))
+  }
+
   "Boxed toArray - regression #1745" in {
     Chunk.Boxed(Array[Any](0)).asInstanceOf[Chunk[Int]].toArray[Any]
     Chunk.Boxed(Array[Any](0)).asInstanceOf[Chunk[Int]].toArray[Int]

--- a/core/shared/src/test/scala/fs2/ChunkSpec.scala
+++ b/core/shared/src/test/scala/fs2/ChunkSpec.scala
@@ -200,8 +200,8 @@ class ChunkSpec extends Fs2Spec {
   }
 
   "zipWithIndex andThen toArray" in {
-    val arr: Array[(Int, Int)] = Chunk(0, 0, 0).zipWithIndex.toArray
-    assert(arr === Array((0, 0), (0, 1), (0, 2)))
+    val chunk = fs2.Chunk("x", "y", "z")
+    assert(chunk.zipWithIndex.toArray === chunk.toArray.zipWithIndex)
   }
 
   "Boxed toArray - regression #1745" in {


### PR DESCRIPTION
Adds zipWithIndex function on `Chunk`, similar to that of `Stream`.

e.g.
```
fs2.Chunk("The", "quick", "brown", "fox").zipWithIndex.toList

res0: List[(String, Int)] = List((The,0), (quick,1), (brown,2), (fox,3))
```