### PR TITLE
Adjust thread names of tcp.SocketGroup's nonBlockingThreadFactory

### DIFF
--- a/io/src/main/scala/fs2/io/tcp/SocketGroup.scala
+++ b/io/src/main/scala/fs2/io/tcp/SocketGroup.scala
@@ -378,7 +378,7 @@ object SocketGroup {
       blocker: Blocker,
       nonBlockingThreadCount: Int = 0,
       nonBlockingThreadFactory: ThreadFactory =
-        ThreadFactories.named("fs2-socket-group-blocking", true)
+        ThreadFactories.named("fs2-socket-group-non-blocking", true)
   ): Resource[F, SocketGroup] =
     Resource(blocker.delay {
       val threadCount =


### PR DESCRIPTION
Threads produced by the `nonBlockingThreadFactory` are used in a non-blocking fashion, but their names suggest otherwise. Let's change the prefix to `fs2-socket-group-non-blocking` to align with the actual usage pattern.