### PR TITLE
Fix #1873 - deadlock in TLSEngine

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -237,7 +237,11 @@ lazy val mimaSettings = Seq(
     ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.Stream.to$extension"),
     ProblemFilters.exclude[DirectMissingMethodProblem](
       "fs2.interop.reactivestreams.StreamSubscriber#FSM.stream"
-    ) // FSM is package private
+    ), // FSM is package private
+    ProblemFilters.exclude[Problem]("fs2.io.tls.TLSEngine.*"), // private[fs2] type
+    ProblemFilters.exclude[Problem]("fs2.io.tls.TLSEngine#*"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.tls.TLSSocket.fs2$io$tls$TLSSocket$$binding$default$2"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.tls.TLSSocket.fs2$io$tls$TLSSocket$$binding$default$3")
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -240,8 +240,12 @@ lazy val mimaSettings = Seq(
     ), // FSM is package private
     ProblemFilters.exclude[Problem]("fs2.io.tls.TLSEngine.*"), // private[fs2] type
     ProblemFilters.exclude[Problem]("fs2.io.tls.TLSEngine#*"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.tls.TLSSocket.fs2$io$tls$TLSSocket$$binding$default$2"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.io.tls.TLSSocket.fs2$io$tls$TLSSocket$$binding$default$3")
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "fs2.io.tls.TLSSocket.fs2$io$tls$TLSSocket$$binding$default$2"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "fs2.io.tls.TLSSocket.fs2$io$tls$TLSSocket$$binding$default$3"
+    )
   )
 )
 

--- a/io/src/main/scala/fs2/io/tls/InputOutputBuffer.scala
+++ b/io/src/main/scala/fs2/io/tls/InputOutputBuffer.scala
@@ -82,7 +82,7 @@ private[tls] object InputOutputBuffer {
             Sync[F].delay {
               (out: Buffer).flip()
               val cap = out.limit()
-              val dest = Array.ofDim[Byte](cap)
+              val dest = new Array[Byte](cap)
               out.get(dest)
               (out: Buffer).clear()
               Chunk.bytes(dest)
@@ -90,7 +90,7 @@ private[tls] object InputOutputBuffer {
         }
 
       private def expandBuffer(buffer: ByteBuffer, resizeTo: Int => Int): ByteBuffer = {
-        val copy = Array.ofDim[Byte](buffer.position())
+        val copy = new Array[Byte](buffer.position())
         val next = ByteBuffer.allocate(resizeTo(buffer.capacity()))
         (buffer: Buffer).flip()
         buffer.get(copy)

--- a/io/src/main/scala/fs2/io/tls/TLSEngine.scala
+++ b/io/src/main/scala/fs2/io/tls/TLSEngine.scala
@@ -113,7 +113,7 @@ private[tls] object TLSEngine {
                 }
               case None => Applicative[F].pure(None)
             },
-            write0(Chunk.empty, None) >> read0(maxBytes, timeout)
+            write(Chunk.empty, None) >> read0(maxBytes, timeout)
           )
 
       /** Performs an unwrap operation on the underlying engine. */

--- a/io/src/main/scala/fs2/io/tls/TLSEngine.scala
+++ b/io/src/main/scala/fs2/io/tls/TLSEngine.scala
@@ -76,7 +76,7 @@ private[tls] object TLSEngine {
                 doWrite(timeout) >> {
                   result.getHandshakeStatus match {
                     case SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING =>
-                      wrapBuffer.inputRemains.map(_ > 0).ifM(wrap(timeout), Applicative[F].unit)
+                      wrapBuffer.inputRemains.flatMap(x => wrap(timeout).whenA(x > 0))
                     case _ =>
                       handshakeSemaphore
                         .withPermit(stepHandshake(result, true, timeout)) >> wrap(timeout)

--- a/io/src/main/scala/fs2/io/tls/TLSEngine.scala
+++ b/io/src/main/scala/fs2/io/tls/TLSEngine.scala
@@ -2,6 +2,8 @@ package fs2
 package io
 package tls
 
+import scala.concurrent.duration.FiniteDuration
+
 import javax.net.ssl.{SSLEngine, SSLEngineResult, SSLSession}
 
 import cats.Applicative
@@ -19,18 +21,19 @@ private[tls] trait TLSEngine[F[_]] {
   def session: F[SSLSession]
   def stopWrap: F[Unit]
   def stopUnwrap: F[Unit]
-  def wrap(data: Chunk[Byte], binding: TLSEngine.Binding[F]): F[Unit]
-  def unwrap(data: Chunk[Byte], binding: TLSEngine.Binding[F]): F[Option[Chunk[Byte]]]
+  def write(data: Chunk[Byte], timeout: Option[FiniteDuration]): F[Unit]
+  def read(maxBytes: Int, timeout: Option[FiniteDuration]): F[Option[Chunk[Byte]]]
 }
 
 private[tls] object TLSEngine {
   trait Binding[F[_]] {
-    def write(data: Chunk[Byte]): F[Unit]
-    def read: F[Option[Chunk[Byte]]]
+    def write(data: Chunk[Byte], timeout: Option[FiniteDuration]): F[Unit]
+    def read(maxBytes: Int, timeout: Option[FiniteDuration]): F[Option[Chunk[Byte]]]
   }
 
   def apply[F[_]: Concurrent: ContextShift](
       engine: SSLEngine,
+      binding: Binding[F],
       blocker: Blocker,
       logger: Option[String => F[Unit]] = None
   ): F[TLSEngine[F]] =
@@ -43,9 +46,9 @@ private[tls] object TLSEngine {
         engine.getSession.getPacketBufferSize,
         engine.getSession.getApplicationBufferSize
       )
-      wrapSem <- Semaphore[F](1)
-      unwrapSem <- Semaphore[F](1)
-      handshakeSem <- Semaphore[F](1)
+      readSemaphore <- Semaphore[F](1)
+      writeSemaphore <- Semaphore[F](1)
+      handshakeSemaphore <- Semaphore[F](1)
       sslEngineTaskRunner = SSLEngineTaskRunner[F](engine, blocker)
     } yield new TLSEngine[F] {
       private def log(msg: String): F[Unit] =
@@ -56,51 +59,65 @@ private[tls] object TLSEngine {
       def stopWrap = Sync[F].delay(engine.closeOutbound())
       def stopUnwrap = Sync[F].delay(engine.closeInbound()).attempt.void
 
-      def wrap(data: Chunk[Byte], binding: Binding[F]): F[Unit] =
-        wrapSem.withPermit(wrapBuffer.input(data) >> doWrap(binding))
+      def write(data: Chunk[Byte], timeout: Option[FiniteDuration]): F[Unit] =
+        writeSemaphore.withPermit(write0(data, timeout))
 
-      /**
-        * Performs a wrap operation on the underlying engine.
-        * Must be called with either the `wrapSem` and/or `handshakeSem`.
-        */
-      private def doWrap(binding: Binding[F]): F[Unit] =
+      private def write0(data: Chunk[Byte], timeout: Option[FiniteDuration]): F[Unit] =
+        wrapBuffer.input(data) >> wrap(timeout)
+
+      /** Performs a wrap operation on the underlying engine. */
+      private def wrap(timeout: Option[FiniteDuration]): F[Unit] =
         wrapBuffer
           .perform(engine.wrap(_, _))
-          .flatTap(result => log(s"doWrap result: $result"))
+          .flatTap(result => log(s"wrap result: $result"))
           .flatMap { result =>
             result.getStatus match {
               case SSLEngineResult.Status.OK =>
-                doWrite(binding) >> {
+                doWrite(timeout) >> {
                   result.getHandshakeStatus match {
                     case SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING =>
                       Applicative[F].unit
                     case _ =>
-                      handshake(result, true, binding) >> doWrap(binding)
+                      handshakeSemaphore
+                        .withPermit(stepHandshake(result, true, timeout)) >> wrap(timeout)
                   }
                 }
               case SSLEngineResult.Status.BUFFER_UNDERFLOW =>
-                doWrite(binding)
+                doWrite(timeout)
               case SSLEngineResult.Status.BUFFER_OVERFLOW =>
-                wrapBuffer.expandOutput >> doWrap(binding)
+                wrapBuffer.expandOutput >> wrap(timeout)
               case SSLEngineResult.Status.CLOSED =>
                 stopWrap >> stopUnwrap
             }
           }
 
-      private def doWrite(binding: Binding[F]): F[Unit] =
+      private def doWrite(timeout: Option[FiniteDuration]): F[Unit] =
         wrapBuffer.output.flatMap { out =>
           if (out.isEmpty) Applicative[F].unit
-          else binding.write(out)
+          else binding.write(out, timeout)
         }
 
-      def unwrap(data: Chunk[Byte], binding: Binding[F]): F[Option[Chunk[Byte]]] =
-        unwrapSem.withPermit(unwrapBuffer.input(data) >> doUnwrap(binding))
+      def read(maxBytes: Int, timeout: Option[FiniteDuration]): F[Option[Chunk[Byte]]] =
+        readSemaphore.withPermit(read0(maxBytes, timeout))
 
-      /**
-        * Performs an unwrap operation on the underlying engine.
-        * Must be called with either the `unwrapSem` and/or `handshakeSem`.
-        */
-      private def doUnwrap(binding: Binding[F]): F[Option[Chunk[Byte]]] =
+      private def read0(maxBytes: Int, timeout: Option[FiniteDuration]): F[Option[Chunk[Byte]]] =
+        // Check if a session has been established -- if so, read; otherwise, handshake and then read
+        blocker
+          .delay(engine.getSession.isValid)
+          .ifM(
+            binding.read(maxBytes, timeout).flatMap {
+              case Some(c) =>
+                unwrapBuffer.input(c) >> unwrap(timeout).flatMap {
+                  case s @ Some(_) => Applicative[F].pure(s)
+                  case None        => read0(maxBytes, timeout)
+                }
+              case None => Applicative[F].pure(None)
+            },
+            write0(Chunk.empty, None) >> read0(maxBytes, timeout)
+          )
+
+      /** Performs an unwrap operation on the underlying engine. */
+      private def unwrap(timeout: Option[FiniteDuration]): F[Option[Chunk[Byte]]] =
         unwrapBuffer
           .perform(engine.unwrap(_, _))
           .flatTap(result => log(s"unwrap result: $result"))
@@ -111,14 +128,15 @@ private[tls] object TLSEngine {
                   case SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING =>
                     dequeueUnwrap
                   case SSLEngineResult.HandshakeStatus.FINISHED =>
-                    doUnwrap(binding)
+                    unwrap(timeout)
                   case _ =>
-                    handshake(result, false, binding) >> doUnwrap(binding)
+                    handshakeSemaphore
+                      .withPermit(stepHandshake(result, false, timeout)) >> unwrap(timeout)
                 }
               case SSLEngineResult.Status.BUFFER_UNDERFLOW =>
                 dequeueUnwrap
               case SSLEngineResult.Status.BUFFER_OVERFLOW =>
-                unwrapBuffer.expandOutput >> doUnwrap(binding)
+                unwrapBuffer.expandOutput >> unwrap(timeout)
               case SSLEngineResult.Status.CLOSED =>
                 stopWrap >> stopUnwrap >> dequeueUnwrap
             }
@@ -127,16 +145,6 @@ private[tls] object TLSEngine {
       private def dequeueUnwrap: F[Option[Chunk[Byte]]] =
         unwrapBuffer.output.map(out => if (out.isEmpty) None else Some(out))
 
-      /** Performs a TLS handshake sequence, returning when the session has been esablished. */
-      private def handshake(
-          result: SSLEngineResult,
-          lastOperationWrap: Boolean,
-          binding: Binding[F]
-      ): F[Unit] =
-        handshakeSem.withPermit {
-          stepHandshake(result, lastOperationWrap, binding)
-        }
-
       /**
         * Determines what to do next given the result of a handshake operation.
         * Must be called with `handshakeSem`.
@@ -144,74 +152,68 @@ private[tls] object TLSEngine {
       private def stepHandshake(
           result: SSLEngineResult,
           lastOperationWrap: Boolean,
-          binding: Binding[F]
+          timeout: Option[FiniteDuration]
       ): F[Unit] =
         result.getHandshakeStatus match {
           case SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING =>
             Applicative[F].unit
           case SSLEngineResult.HandshakeStatus.FINISHED =>
             unwrapBuffer.inputRemains.flatMap { remaining =>
-              if (remaining > 0) doHsUnwrap(binding)
+              if (remaining > 0) unwrapHandshake(timeout)
               else Applicative[F].unit
             }
           case SSLEngineResult.HandshakeStatus.NEED_TASK =>
-            sslEngineTaskRunner.runDelegatedTasks >> (if (lastOperationWrap) doHsWrap(binding)
-                                                      else doHsUnwrap(binding))
+            sslEngineTaskRunner.runDelegatedTasks >> (if (lastOperationWrap) wrapHandshake(timeout)
+                                                      else unwrapHandshake(timeout))
           case SSLEngineResult.HandshakeStatus.NEED_WRAP =>
-            doHsWrap(binding)
+            wrapHandshake(timeout)
           case SSLEngineResult.HandshakeStatus.NEED_UNWRAP =>
             unwrapBuffer.inputRemains.flatMap { remaining =>
               if (remaining > 0 && result.getStatus != SSLEngineResult.Status.BUFFER_UNDERFLOW)
-                doHsUnwrap(binding)
+                unwrapHandshake(timeout)
               else
-                binding.read.flatMap {
-                  case Some(c) => unwrapBuffer.input(c) >> doHsUnwrap(binding)
+                binding.read(16 * 1024, timeout).flatMap {
+                  case Some(c) => unwrapBuffer.input(c) >> unwrapHandshake(timeout)
                   case None    => stopWrap >> stopUnwrap
                 }
             }
           case SSLEngineResult.HandshakeStatus.NEED_UNWRAP_AGAIN =>
-            doHsUnwrap(binding)
+            unwrapHandshake(timeout)
         }
 
-      /**
-        * Performs a wrap operation as part of handshaking.
-        * Must be called with `handshakeSem`.
-        */
-      private def doHsWrap(binding: Binding[F]): F[Unit] =
+      /** Performs a wrap operation as part of handshaking. */
+      private def wrapHandshake(timeout: Option[FiniteDuration]): F[Unit] =
         wrapBuffer
           .perform(engine.wrap(_, _))
-          .flatTap(result => log(s"doHsWrap result: $result"))
+          .flatTap(result => log(s"wrapHandshake result: $result"))
           .flatMap { result =>
             result.getStatus match {
               case SSLEngineResult.Status.OK | SSLEngineResult.Status.BUFFER_UNDERFLOW =>
-                doWrite(binding) >> stepHandshake(
+                doWrite(timeout) >> stepHandshake(
                   result,
                   true,
-                  binding
+                  timeout
                 )
               case SSLEngineResult.Status.BUFFER_OVERFLOW =>
-                wrapBuffer.expandOutput >> doHsWrap(binding)
+                wrapBuffer.expandOutput >> wrapHandshake(timeout)
               case SSLEngineResult.Status.CLOSED =>
                 stopWrap >> stopUnwrap
             }
           }
 
-      /**
-        * Performs an unwrap operation as part of handshaking.
-        * Must be called with `handshakeSem`.
-        */
-      private def doHsUnwrap(binding: Binding[F]): F[Unit] =
+      /** Performs an unwrap operation as part of handshaking. */
+      private def unwrapHandshake(timeout: Option[FiniteDuration]): F[Unit] =
         unwrapBuffer
           .perform(engine.unwrap(_, _))
-          .flatTap(result => log(s"doHsUnwrap result: $result"))
+          .flatTap(result => log(s"unwrapHandshake result: $result"))
           .flatMap { result =>
             result.getStatus match {
               case SSLEngineResult.Status.OK =>
-                stepHandshake(result, false, binding)
+                stepHandshake(result, false, timeout)
               case SSLEngineResult.Status.BUFFER_UNDERFLOW =>
-                stepHandshake(result, false, binding)
+                stepHandshake(result, false, timeout)
               case SSLEngineResult.Status.BUFFER_OVERFLOW =>
-                unwrapBuffer.expandOutput >> doHsUnwrap(binding)
+                unwrapBuffer.expandOutput >> unwrapHandshake(timeout)
               case SSLEngineResult.Status.CLOSED =>
                 stopWrap >> stopUnwrap
             }

--- a/io/src/main/scala/fs2/io/tls/TLSSocket.scala
+++ b/io/src/main/scala/fs2/io/tls/TLSSocket.scala
@@ -58,7 +58,7 @@ object TLSSocket {
             val toRead = numBytes - acc.size
             if (toRead <= 0) Applicative[F].pure(Some(acc.toChunk))
             else
-              read(numBytes, timeout).flatMap {
+              read0(numBytes, timeout).flatMap {
                 case Some(chunk) => go(acc :+ chunk): F[Option[Chunk[Byte]]]
                 case None        => Applicative[F].pure(Some(acc.toChunk)): F[Option[Chunk[Byte]]]
               }

--- a/io/src/main/scala/fs2/io/tls/TLSSocket.scala
+++ b/io/src/main/scala/fs2/io/tls/TLSSocket.scala
@@ -33,16 +33,6 @@ sealed trait TLSSocket[F[_]] extends Socket[F] {
 
 object TLSSocket {
 
-  private def binding[F[_]](
-      socket: Socket[F],
-      writeTimeout: Option[FiniteDuration] = None,
-      readMaxBytes: Int = 16 * 1024
-  ): TLSEngine.Binding[F] =
-    new TLSEngine.Binding[F] {
-      def write(data: Chunk[Byte]) = socket.write(data, writeTimeout)
-      def read = socket.read(readMaxBytes, None)
-    }
-
   private[tls] def apply[F[_]: Concurrent](
       socket: Socket[F],
       engine: TLSEngine[F]
@@ -57,18 +47,10 @@ object TLSSocket {
       readSem <- Semaphore(1)
     } yield new TLSSocket[F] {
       def write(bytes: Chunk[Byte], timeout: Option[FiniteDuration]): F[Unit] =
-        engine.wrap(bytes, binding(socket, writeTimeout = timeout))
+        engine.write(bytes, timeout)
 
       private def read0(maxBytes: Int, timeout: Option[FiniteDuration]): F[Option[Chunk[Byte]]] =
-        socket.read(maxBytes, timeout).flatMap {
-          case Some(c) =>
-            engine.unwrap(c, binding(socket)).flatMap {
-              case Some(c) => Applicative[F].pure(Some(c))
-              case None    => read0(maxBytes, timeout)
-            }
-          case None =>
-            Applicative[F].pure(None)
-        }
+        engine.read(maxBytes, timeout)
 
       def readN(numBytes: Int, timeout: Option[FiniteDuration]): F[Option[Chunk[Byte]]] =
         readSem.withPermit {

--- a/io/src/test/scala/fs2/io/tls/TLSSocketSpec.scala
+++ b/io/src/test/scala/fs2/io/tls/TLSSocketSpec.scala
@@ -73,7 +73,7 @@ class TLSSocketSpec extends TLSSpec {
                     }
                   }.parJoinUnbounded
 
-                  val msg = Chunk.bytes("Hello, world!".getBytes)
+                  val msg = Chunk.bytes(("Hello, world! " * 20000).getBytes)
                   val client = Stream.resource(socketGroup.client[IO](serverAddress)).flatMap {
                     clientSocket =>
                       Stream


### PR DESCRIPTION
The key part of the fix is the guard in `TLSEngine.read` that checks if a session is active and if not, handshakes before reading. I think a similar deadlock can still occur if a mid-session renegotiation is requested while an application level read is pending. Though TLS1.3 has dropped support for renegotiation.