### PR TITLE
Fix scope leak with Stream.retry and in general, with pulls that do...

### DIFF
--- a/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
+++ b/core/jvm/src/test/scala/fs2/MemorySanityChecks.scala
@@ -227,3 +227,18 @@ object ZipThenBindThenParJoin extends App {
     .drain
     .unsafeRunSync()
 }
+
+object RetrySanityTest extends App {
+  implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.Implicits.global)
+  implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
+  import scala.concurrent.duration._
+
+  Stream.retry(IO.unit, 1.second, _ * 2, 10).repeat.compile.drain.unsafeRunSync()
+}
+
+object AttemptsThenPullSanityTest extends App {
+  implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.Implicits.global)
+  implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
+  import scala.concurrent.duration._
+  Stream.eval(IO.unit).attempts(Stream.constant(1.second)).head.repeat.compile.drain.unsafeRunSync()
+}

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1793,7 +1793,7 @@ final class Stream[+F[_], +O] private[fs2] (private val free: FreeC[F, O, Unit])
     * }}}
     */
   def map[O2](f: O => O2): Stream[F, O2] =
-    this.pull.echo.mapOutput(f).stream
+    this.pull.echo.mapOutput(f).streamNoScope
 
   /**
     * Maps a running total according to `S` and the input with the function `f`.


### PR DESCRIPTION
…not consume all elements from source.

Some observations prior to this PR:

```scala
// No leak:
Stream.eval(IO.unit).attempt.repeat.compile.drain.unsafeRunSync()

// Leaks in 2.1.0+, does not leak in 2.0.1:
Stream.eval(IO.unit).attempts(Stream.constant(1.second)).head.repeat.compile.drain.unsafeRunSync()

// Leak fixed by inserting an explicit scope after head
Stream.eval(IO.unit).attempts(Stream.constant(1.second)).head.scope.repeat.compile.drain.unsafeRunSync()
```

The reason a leak was introduced in 2.1.0 is that `handleErrorWith` was modified to introduce a scope. The use of `head`, which is an alias for `take(1)`, is implemented with a pull that discards the remainder of the stream once a single output element has been output. This has the effect of discarding the release of the scope opened by `handleErrorWith`.

More generally, any pull which discards the remainder of the stream has the potential of causing a similar scope leak. Hence, this PR returns to the FS2 1.0.x design of introducing a scope every time a pull is converted to a stream. Doing so causes the scope introduced by `handleErrorWith` to be a child scope of the pull-to-stream scope, and hence, when the pull-to-stream scope is closed, all descendant scopes are closed too.
