### PR TITLE
Fix a TLS handshake stall where wrap is recursively called post hands…

### DIFF
--- a/io/src/main/scala/fs2/io/tls/TLSEngine.scala
+++ b/io/src/main/scala/fs2/io/tls/TLSEngine.scala
@@ -76,7 +76,8 @@ private[tls] object TLSEngine {
                 doWrite(timeout) >> {
                   result.getHandshakeStatus match {
                     case SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING =>
-                      wrapBuffer.inputRemains.flatMap(x => wrap(timeout).whenA(x > 0 && result.bytesConsumed > 0))
+                      wrapBuffer.inputRemains
+                        .flatMap(x => wrap(timeout).whenA(x > 0 && result.bytesConsumed > 0))
                     case _ =>
                       handshakeSemaphore
                         .withPermit(stepHandshake(result, true, timeout)) >> wrap(timeout)
@@ -126,7 +127,9 @@ private[tls] object TLSEngine {
               case SSLEngineResult.Status.OK =>
                 result.getHandshakeStatus match {
                   case SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING =>
-                    unwrapBuffer.inputRemains.map(_ > 0 && result.bytesConsumed > 0).ifM(unwrap(timeout), dequeueUnwrap)
+                    unwrapBuffer.inputRemains
+                      .map(_ > 0 && result.bytesConsumed > 0)
+                      .ifM(unwrap(timeout), dequeueUnwrap)
                   case SSLEngineResult.HandshakeStatus.FINISHED =>
                     unwrap(timeout)
                   case _ =>

--- a/io/src/main/scala/fs2/io/tls/TLSEngine.scala
+++ b/io/src/main/scala/fs2/io/tls/TLSEngine.scala
@@ -76,7 +76,7 @@ private[tls] object TLSEngine {
                 doWrite(timeout) >> {
                   result.getHandshakeStatus match {
                     case SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING =>
-                      wrapBuffer.inputRemains.flatMap(x => wrap(timeout).whenA(x > 0))
+                      wrapBuffer.inputRemains.flatMap(x => wrap(timeout).whenA(x > 0 && result.bytesConsumed > 0))
                     case _ =>
                       handshakeSemaphore
                         .withPermit(stepHandshake(result, true, timeout)) >> wrap(timeout)
@@ -126,7 +126,7 @@ private[tls] object TLSEngine {
               case SSLEngineResult.Status.OK =>
                 result.getHandshakeStatus match {
                   case SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING =>
-                    unwrapBuffer.inputRemains.map(_ > 0).ifM(unwrap(timeout), dequeueUnwrap)
+                    unwrapBuffer.inputRemains.map(_ > 0 && result.bytesConsumed > 0).ifM(unwrap(timeout), dequeueUnwrap)
                   case SSLEngineResult.HandshakeStatus.FINISHED =>
                     unwrap(timeout)
                   case _ =>


### PR DESCRIPTION
…hake completion but never makes progress

Original bug posted by @tpolecat in Gitter:

> I'm getting the following behavior with TLS negotiation.
```
wrap result: Status = OK HandshakeStatus = NEED_UNWRAP
bytesConsumed = 0 bytesProduced = 172
unwrapHandshake result: Status = OK HandshakeStatus = NEED_TASK
bytesConsumed = 62 bytesProduced = 0
unwrapHandshake result: Status = OK HandshakeStatus = NEED_TASK
bytesConsumed = 695 bytesProduced = 0
unwrapHandshake result: Status = OK HandshakeStatus = NEED_TASK
bytesConsumed = 338 bytesProduced = 0
unwrapHandshake result: Status = OK HandshakeStatus = NEED_TASK
bytesConsumed = 9 bytesProduced = 0
unwrapHandshake result: Status = OK HandshakeStatus = NEED_WRAP
bytesConsumed = 0 bytesProduced = 0
wrapHandshake result: Status = OK HandshakeStatus = NEED_WRAP
bytesConsumed = 0 bytesProduced = 75
wrapHandshake result: Status = OK HandshakeStatus = NEED_WRAP
bytesConsumed = 0 bytesProduced = 6
wrapHandshake result: Status = OK HandshakeStatus = NEED_UNWRAP
bytesConsumed = 0 bytesProduced = 45
unwrapHandshake result: Status = OK HandshakeStatus = NEED_UNWRAP
bytesConsumed = 6 bytesProduced = 0
unwrapHandshake result: Status = OK HandshakeStatus = FINISHED
bytesConsumed = 45 bytesProduced = 0
wrap result: Status = OK HandshakeStatus = NOT_HANDSHAKING
bytesConsumed = 0 bytesProduced = 0
wrap result: Status = OK HandshakeStatus = NOT_HANDSHAKING
bytesConsumed = 126 bytesProduced = 155
wrap result: Status = OK HandshakeStatus = NOT_HANDSHAKING
bytesConsumed = 0 bytesProduced = 0
wrap result: Status = OK HandshakeStatus = NOT_HANDSHAKING
bytesConsumed = 0 bytesProduced = 0
wrap result: Status = OK HandshakeStatus = NOT_HANDSHAKING
bytesConsumed = 0 bytesProduced = 0
wrap result: Status = OK HandshakeStatus = NOT_HANDSHAKING
bytesConsumed = 0 bytesProduced = 0
wrap result: Status = OK HandshakeStatus = NOT_HANDSHAKING
bytesConsumed = 0 bytesProduced = 0
wrap result: Status = OK HandshakeStatus = NOT_HANDSHAKING
bytesConsumed = 0 bytesProduced = 0
wrap result: Status = OK HandshakeStatus = NOT_HANDSHAKING
bytesConsumed = 0 bytesProduced = 0
wrap result: Status = OK HandshakeStatus = NOT_HANDSHAKING
bytesConsumed = 0 bytesProduced = 0
wrap result: Status = OK HandshakeStatus = NOT_HANDSHAKING
bytesConsumed = 0 bytesProduced = 0
... forever
```