### PR TITLE
Collector support for ArraySeq

### DIFF
--- a/core/shared/src/main/scala-2.13/fs2/CollectorPlatform.scala
+++ b/core/shared/src/main/scala-2.13/fs2/CollectorPlatform.scala
@@ -1,6 +1,8 @@
 package fs2
 
+import scala.collection.immutable.ArraySeq
 import scala.collection.{Factory, IterableFactory, MapFactory}
+import scala.reflect.ClassTag
 
 private[fs2] trait CollectorPlatform { self: Collector.type =>
   implicit def supportsFactory[A, C[_], B](
@@ -13,6 +15,14 @@ private[fs2] trait CollectorPlatform { self: Collector.type =>
   implicit def supportsMapFactory[K, V, C[_, _]](f: MapFactory[C]): Collector.Aux[(K, V), C[K, V]] =
     make(Builder.fromMapFactory(f))
 
+  implicit def supportsTaggedArraySeq[A : ClassTag](a: ArraySeq.type): Collector.Aux[A, ArraySeq[A]] = {
+    val _ = a
+    make(implicitly[ClassTag[A]] match {
+      case ClassTag.Byte => Builder.byteArray.mapResult(ArraySeq.unsafeWrapArray).asInstanceOf[Builder[A, ArraySeq[A]]]
+      case _ => Builder.taggedArraySeq[A]
+    })
+  }
+
   private[fs2] trait BuilderPlatform { self: Collector.Builder.type =>
     def fromFactory[A, C[_], B](f: Factory[A, C[B]]): Builder[A, C[B]] =
       fromBuilder(f.newBuilder)
@@ -22,5 +32,8 @@ private[fs2] trait CollectorPlatform { self: Collector.type =>
 
     def fromMapFactory[K, V, C[_, _]](f: MapFactory[C]): Builder[(K, V), C[K, V]] =
       fromBuilder(f.newBuilder)
+
+    def taggedArraySeq[A: ClassTag]: Builder[A, ArraySeq[A]] =
+      array[A].mapResult(ArraySeq.unsafeWrapArray)
   }
 }

--- a/core/shared/src/main/scala-2.13/fs2/CollectorPlatform.scala
+++ b/core/shared/src/main/scala-2.13/fs2/CollectorPlatform.scala
@@ -15,10 +15,13 @@ private[fs2] trait CollectorPlatform { self: Collector.type =>
   implicit def supportsMapFactory[K, V, C[_, _]](f: MapFactory[C]): Collector.Aux[(K, V), C[K, V]] =
     make(Builder.fromMapFactory(f))
 
-  implicit def supportsTaggedArraySeq[A : ClassTag](a: ArraySeq.type): Collector.Aux[A, ArraySeq[A]] = {
+  implicit def supportsTaggedArraySeq[A: ClassTag](
+      a: ArraySeq.type
+  ): Collector.Aux[A, ArraySeq[A]] = {
     val _ = a
     make(implicitly[ClassTag[A]] match {
-      case ClassTag.Byte => Builder.byteArray.mapResult(ArraySeq.unsafeWrapArray).asInstanceOf[Builder[A, ArraySeq[A]]]
+      case ClassTag.Byte =>
+        Builder.byteArray.mapResult(ArraySeq.unsafeWrapArray).asInstanceOf[Builder[A, ArraySeq[A]]]
       case _ => Builder.taggedArraySeq[A]
     })
   }

--- a/core/shared/src/main/scala-2.13/fs2/CollectorPlatform.scala
+++ b/core/shared/src/main/scala-2.13/fs2/CollectorPlatform.scala
@@ -15,6 +15,9 @@ private[fs2] trait CollectorPlatform { self: Collector.type =>
   implicit def supportsMapFactory[K, V, C[_, _]](f: MapFactory[C]): Collector.Aux[(K, V), C[K, V]] =
     make(Builder.fromMapFactory(f))
 
+  /**
+    * Use `ArraySeq.untagged` to build a `Collector` where a `ClassTag` is not available.
+    */
   implicit def supportsTaggedArraySeq[A: ClassTag](
       a: ArraySeq.type
   ): Collector.Aux[A, ArraySeq[A]] = {

--- a/core/shared/src/test/scala-2.13/fs2/ArraySeqCollectorSpec.scala
+++ b/core/shared/src/test/scala-2.13/fs2/ArraySeqCollectorSpec.scala
@@ -1,0 +1,17 @@
+package fs2
+
+import scala.collection.immutable.ArraySeq
+
+class ArraySeqCollectorSpec extends Fs2Spec {
+
+  "the ArraySeq collector" - {
+    "work for a tagged ArraySeq" in {
+      assert(Stream.range(1, 5).compile.to(ArraySeq) == ArraySeq.range(1, 5))
+    }
+
+    "work for an untagged ArraySeq" in {
+      assert(Stream.range(1, 5).compile.to(ArraySeq.untagged) === ArraySeq.range(1, 5))
+    }
+  }
+
+}


### PR DESCRIPTION
This PR adds a `Collector` for `scala.collection.immutable.ArraySeq` where a `ClassTag` is available.

Support for untagged `ArraySeq` already exists via `ArraySeq.untagged`, eg:

```scala
Stream.range(1, 5).compile.to(ArraySeq.untagged)
```

`ArraySeq`s created this way will fail to take advantage of the specialised implementations provided for arrays of primatives.

#### Why provide specialised support for `ArraySeq`?

The immutable `ArraySeq` is newly added in Scala 2.13. It is an immutable wrapper over a bare array with specialised implementations for primitives. As such it is well suited to the kinds of performance-sensitive uses for which fs2 is commonly used.