### PR TITLE
Fix: redundant cast, forgotten in #1912,

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1236,10 +1236,8 @@ final class Stream[+F[_], +O] private[fs2] (private val free: FreeC[F, O, Unit])
                 f(hd(idx)).free.transformWith {
                   case Result.Pure(_)   => go(idx + 1)
                   case Result.Fail(err) => Result.Fail(err)
-                  case Result.Interrupted(scopeId: Token, err) =>
+                  case Result.Interrupted(scopeId, err) =>
                     new Stream(FreeC.interruptBoundary(tl, scopeId, err)).flatMap(f).free
-                  case Result.Interrupted(invalid, _) =>
-                    sys.error(s"Invalid interruption context: $invalid (flatMap)")
                 }
 
             go(0)


### PR DESCRIPTION
#1912 : forgot to remove this subtype match for `Token`