### PR TITLE
Remove toBytes intermediate

### DIFF
--- a/io/src/main/scala/fs2/io/tcp/SocketGroup.scala
+++ b/io/src/main/scala/fs2/io/tcp/SocketGroup.scala
@@ -321,7 +321,7 @@ final class SocketGroup(channelGroup: AsynchronousChannelGroup, blocker: Blocker
               case Some(took) => go(buff, (remains - took).max(0))
             }
           writeSemaphore.withPermit {
-            go(bytes.toBytes.toByteBuffer, timeout.map(_.toMillis).getOrElse(0L))
+            go(bytes.toByteBuffer, timeout.map(_.toMillis).getOrElse(0L))
           }
         }
 


### PR DESCRIPTION
I believe this step unnecessarily copies when we just wish to write what we have available.

I might be wrong though.