### PR TITLE
Missing cats instances

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -4968,6 +4968,9 @@ object Stream extends StreamLowPriority {
   implicit def functionKInstance[F[_]]: F ~> Stream[F, *] =
     FunctionK.lift[F, Stream[F, *]](Stream.eval)
 
+  def monoidKInstance[F[_]]: MonoidK[Stream[F, *]] =
+    alternativeInstance
+
   /** `Defer` instance for `Stream` */
   implicit def deferInstance[F[_]]: Defer[Stream[F, *]] =
     new Defer[Stream[F, *]] {

--- a/core/shared/src/test/scala/fs2/StreamLawsSpec.scala
+++ b/core/shared/src/test/scala/fs2/StreamLawsSpec.scala
@@ -50,6 +50,7 @@ class StreamLawsSpec extends Fs2Spec with StreamArbitrary {
     FunctorFilterTests[Stream[IO, *]].functorFilter[String, Int, Int]
   )
   checkAll("MonoidK[Stream[F, *]]", MonoidKTests[Stream[IO, *]].monoidK[Int])
+  checkAll("Alternative[Stream[F, *]]", AlternativeTests[Stream[IO, *]].alternative[Int, Int, Int])
   checkAll(
     "Align[Stream[F, *]]",
     AlignTests[Stream[IO, *]].align[Int, Int, Int, Int]


### PR DESCRIPTION
`cats.Defer` and `cats.Alternative` instances for `Stream`.