### PR TITLE
Dotty source compatibility

### DIFF
--- a/core/jvm/src/main/scala/fs2/compression.scala
+++ b/core/jvm/src/main/scala/fs2/compression.scala
@@ -17,8 +17,8 @@ object compression {
       private[compression] def apply(juzDeflaterNoWrap: Boolean): ZLibParams.Header =
         if (juzDeflaterNoWrap) ZLibParams.Header.GZIP else ZLibParams.Header.ZLIB
 
-      final case object ZLIB extends Header(juzDeflaterNoWrap = false)
-      final case object GZIP extends Header(juzDeflaterNoWrap = true)
+      case object ZLIB extends Header(juzDeflaterNoWrap = false)
+      case object GZIP extends Header(juzDeflaterNoWrap = true)
     }
 
   }
@@ -92,20 +92,20 @@ object compression {
           case NINE.juzDeflaterLevel    => Level.NINE
         }
 
-      final case object DEFAULT extends Level(juzDeflaterLevel = Deflater.DEFAULT_COMPRESSION)
-      final case object BEST_SPEED extends Level(juzDeflaterLevel = Deflater.BEST_SPEED)
-      final case object BEST_COMPRESSION extends Level(juzDeflaterLevel = Deflater.BEST_COMPRESSION)
-      final case object NO_COMPRESSION extends Level(juzDeflaterLevel = Deflater.NO_COMPRESSION)
-      final case object ZERO extends Level(juzDeflaterLevel = 0)
-      final case object ONE extends Level(juzDeflaterLevel = 1)
-      final case object TWO extends Level(juzDeflaterLevel = 2)
-      final case object THREE extends Level(juzDeflaterLevel = 3)
-      final case object FOUR extends Level(juzDeflaterLevel = 4)
-      final case object FIVE extends Level(juzDeflaterLevel = 5)
-      final case object SIX extends Level(juzDeflaterLevel = 6)
-      final case object SEVEN extends Level(juzDeflaterLevel = 7)
-      final case object EIGHT extends Level(juzDeflaterLevel = 8)
-      final case object NINE extends Level(juzDeflaterLevel = 9)
+      case object DEFAULT extends Level(juzDeflaterLevel = Deflater.DEFAULT_COMPRESSION)
+      case object BEST_SPEED extends Level(juzDeflaterLevel = Deflater.BEST_SPEED)
+      case object BEST_COMPRESSION extends Level(juzDeflaterLevel = Deflater.BEST_COMPRESSION)
+      case object NO_COMPRESSION extends Level(juzDeflaterLevel = Deflater.NO_COMPRESSION)
+      case object ZERO extends Level(juzDeflaterLevel = 0)
+      case object ONE extends Level(juzDeflaterLevel = 1)
+      case object TWO extends Level(juzDeflaterLevel = 2)
+      case object THREE extends Level(juzDeflaterLevel = 3)
+      case object FOUR extends Level(juzDeflaterLevel = 4)
+      case object FIVE extends Level(juzDeflaterLevel = 5)
+      case object SIX extends Level(juzDeflaterLevel = 6)
+      case object SEVEN extends Level(juzDeflaterLevel = 7)
+      case object EIGHT extends Level(juzDeflaterLevel = 8)
+      case object NINE extends Level(juzDeflaterLevel = 9)
     }
 
     sealed abstract class Strategy(private[compression] val juzDeflaterStrategy: Int)
@@ -117,12 +117,11 @@ object compression {
           case HUFFMAN_ONLY.juzDeflaterStrategy => Strategy.HUFFMAN_ONLY
         }
 
-      final case object DEFAULT extends Strategy(juzDeflaterStrategy = Deflater.DEFAULT_STRATEGY)
-      final case object BEST_SPEED extends Strategy(juzDeflaterStrategy = Deflater.HUFFMAN_ONLY)
-      final case object BEST_COMPRESSION
-          extends Strategy(juzDeflaterStrategy = Deflater.DEFAULT_STRATEGY)
-      final case object FILTERED extends Strategy(juzDeflaterStrategy = Deflater.FILTERED)
-      final case object HUFFMAN_ONLY extends Strategy(juzDeflaterStrategy = Deflater.HUFFMAN_ONLY)
+      case object DEFAULT extends Strategy(juzDeflaterStrategy = Deflater.DEFAULT_STRATEGY)
+      case object BEST_SPEED extends Strategy(juzDeflaterStrategy = Deflater.HUFFMAN_ONLY)
+      case object BEST_COMPRESSION extends Strategy(juzDeflaterStrategy = Deflater.DEFAULT_STRATEGY)
+      case object FILTERED extends Strategy(juzDeflaterStrategy = Deflater.FILTERED)
+      case object HUFFMAN_ONLY extends Strategy(juzDeflaterStrategy = Deflater.HUFFMAN_ONLY)
     }
 
     sealed abstract class FlushMode(private[compression] val juzDeflaterFlushMode: Int)
@@ -134,12 +133,12 @@ object compression {
           case FULL_FLUSH.juzDeflaterFlushMode => FlushMode.FULL_FLUSH
         }
 
-      final case object DEFAULT extends FlushMode(juzDeflaterFlushMode = Deflater.NO_FLUSH)
-      final case object BEST_SPEED extends FlushMode(juzDeflaterFlushMode = Deflater.FULL_FLUSH)
-      final case object BEST_COMPRESSION extends FlushMode(juzDeflaterFlushMode = Deflater.NO_FLUSH)
-      final case object NO_FLUSH extends FlushMode(juzDeflaterFlushMode = Deflater.NO_FLUSH)
-      final case object SYNC_FLUSH extends FlushMode(juzDeflaterFlushMode = Deflater.SYNC_FLUSH)
-      final case object FULL_FLUSH extends FlushMode(juzDeflaterFlushMode = Deflater.FULL_FLUSH)
+      case object DEFAULT extends FlushMode(juzDeflaterFlushMode = Deflater.NO_FLUSH)
+      case object BEST_SPEED extends FlushMode(juzDeflaterFlushMode = Deflater.FULL_FLUSH)
+      case object BEST_COMPRESSION extends FlushMode(juzDeflaterFlushMode = Deflater.NO_FLUSH)
+      case object NO_FLUSH extends FlushMode(juzDeflaterFlushMode = Deflater.NO_FLUSH)
+      case object SYNC_FLUSH extends FlushMode(juzDeflaterFlushMode = Deflater.SYNC_FLUSH)
+      case object FULL_FLUSH extends FlushMode(juzDeflaterFlushMode = Deflater.FULL_FLUSH)
     }
 
     /**

--- a/core/jvm/src/main/scala/fs2/internal/AsyncByteArrayInputStream.scala
+++ b/core/jvm/src/main/scala/fs2/internal/AsyncByteArrayInputStream.scala
@@ -75,5 +75,5 @@ private[fs2] final class AsyncByteArrayInputStream(val bound: Int) extends Input
 }
 
 private[fs2] object AsyncByteArrayInputStream {
-  final case object AsyncError extends Error with NoStackTrace
+  case object AsyncError extends Error with NoStackTrace
 }

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -477,7 +477,7 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] { self =>
 
   override def equals(a: Any): Boolean =
     a match {
-      case c: Chunk[O] =>
+      case c: Chunk[_] =>
         size == c.size && {
           var i = 0
           var result = true
@@ -497,7 +497,7 @@ abstract class Chunk[+O] extends Serializable with ChunkPlatform[O] { self =>
 object Chunk extends CollectorK[Chunk] with ChunkCompanionPlatform {
 
   /** Optional mix-in that provides the class tag of the element type in a chunk. */
-  trait KnownElementType[A] { self: Chunk[A] =>
+  trait KnownElementType[A] extends Chunk[A] {
     def elementClassTag: ClassTag[A]
   }
 
@@ -593,9 +593,9 @@ object Chunk extends CollectorK[Chunk] with ChunkCompanionPlatform {
   /** Creates a chunk from a `scala.collection.Iterable`. */
   def iterable[O](i: collection.Iterable[O]): Chunk[O] =
     platformIterable(i).getOrElse(i match {
-      case a: mutable.ArraySeq[O]          => arraySeq(a)
+      case a: mutable.ArraySeq[o]          => arraySeq[o](a).asInstanceOf[Chunk[O]]
       case v: Vector[O]                    => vector(v)
-      case b: collection.mutable.Buffer[O] => buffer(b)
+      case b: collection.mutable.Buffer[o] => buffer[o](b).asInstanceOf[Chunk[O]]
       case l: List[O] =>
         if (l.isEmpty) empty
         else if (l.tail.isEmpty) singleton(l.head)
@@ -851,14 +851,9 @@ object Chunk extends CollectorK[Chunk] with ChunkCompanionPlatform {
       val b = readOnly(buf)
       (b: JBuffer).position(offset)
       (b: JBuffer).limit(offset + size)
-      if (xs.isInstanceOf[Array[C]]) {
-        get(b, xs.asInstanceOf[Array[C]], start, size)
-        ()
-      } else {
-        val arr = new Array[C](size)
-        get(b, arr, 0, size)
-        arr.copyToArray(xs, start)
-      }
+      val arr = new Array[C](size)
+      get(b, arr, 0, size)
+      arr.copyToArray(xs, start)
     }
 
     protected def splitAtChunk_(n: Int): (A, A) = {
@@ -1756,7 +1751,7 @@ object Chunk extends CollectorK[Chunk] with ChunkCompanionPlatform {
 
     override def equals(that: Any): Boolean =
       that match {
-        case that: Queue[A] => size == that.size && chunks == that.chunks
+        case that: Queue[_] => size == that.size && chunks == that.chunks
         case _              => false
       }
 

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -830,7 +830,6 @@ object Pull extends PullLowPriority {
               }
 
             case alg: AlgEffect[F, r] =>
-              // Safe case but needed for Dotty
               translateAlgEffect(alg)
                 .transformWith(r =>
                   translateStep(view.next(r.asInstanceOf[Result[y]]), isMainLevel)

--- a/core/shared/src/main/scala/fs2/Pull.scala
+++ b/core/shared/src/main/scala/fs2/Pull.scala
@@ -4,7 +4,6 @@ import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
 import cats.{Eval => _, _}
-import cats.arrow.FunctionK
 import cats.effect._
 import cats.implicits._
 
@@ -203,8 +202,8 @@ object Pull extends PullLowPriority {
     * Repeatedly uses the output of the pull as input for the next step of the pull.
     * Halts when a step terminates with `None` or `Pull.raiseError`.
     */
-  def loop[F[_], O, R](using: R => Pull[F, O, Option[R]]): R => Pull[F, O, Option[R]] =
-    r => using(r).flatMap(_.map(loop(using)).getOrElse(Pull.pure(None)))
+  def loop[F[_], O, R](f: R => Pull[F, O, Option[R]]): R => Pull[F, O, Option[R]] =
+    r => f(r).flatMap(_.map(loop(f)).getOrElse(Pull.pure(None)))
 
   /** Outputs a single value. */
   def output1[F[x] >: Pure[x], O](o: O): Pull[F, O, Unit] = Output(Chunk.singleton(o))
@@ -273,7 +272,9 @@ object Pull extends PullLowPriority {
     * }}}
     */
   implicit def functionKInstance[F[_]]: F ~> Pull[F, INothing, *] =
-    FunctionK.lift[F, Pull[F, INothing, *]](Pull.eval)
+    new (F ~> Pull[F, INothing, *]) {
+      def apply[X](fx: F[X]) = Pull.eval(fx)
+    }
 
   /* Implementation notes:
    *
@@ -337,7 +338,7 @@ object Pull extends PullLowPriority {
     }
   }
 
-  private abstract class Bind[F[_], O, X, R](val step: Pull[F, O, X]) extends Pull[F, O, R] {
+  private abstract class Bind[+F[_], +O, X, +R](val step: Pull[F, O, X]) extends Pull[F, O, R] {
     def cont(r: Result[X]): Pull[F, O, R]
     def delegate: Bind[F, O, X, R] = this
 
@@ -348,7 +349,7 @@ object Pull extends PullLowPriority {
             new Bind[F, P, x, R](v.step.mapOutput(f)) {
               def cont(e: Result[x]) = v.next(e).mapOutput(f)
             }
-          case r: Result[_] => r
+          case r: Result[R] => r
         }
       }
   }
@@ -361,12 +362,12 @@ object Pull extends PullLowPriority {
   private object ViewL {
 
     /** unrolled view of Pull `bind` structure * */
-    private[Pull] sealed abstract case class View[+F[_], O, X, R](step: Action[F, O, X])
+    private[Pull] sealed abstract case class View[+F[_], +O, X, +R](step: Action[F, O, X])
         extends ViewL[F, O, R] {
       def next(r: Result[X]): Pull[F, O, R]
     }
 
-    final class EvalView[+F[_], O, R](step: Action[F, O, R]) extends View[F, O, R, R](step) {
+    final class EvalView[+F[_], +O, R](step: Action[F, O, R]) extends View[F, O, R, R](step) {
       def next(r: Result[R]): Pull[F, O, R] = r
     }
 
@@ -379,16 +380,18 @@ object Pull extends PullLowPriority {
         case e: Action[F, O, Z] => new EvalView[F, O, Z](e)
         case b: Bind[F, O, y, Z] =>
           b.step match {
-            case r: Result[_] => mk(b.cont(r))
-            case e: Action[F, O, y] =>
-              new ViewL.View[F, O, y, Z](e) {
-                def next(r: Result[y]): Pull[F, O, Z] = b.cont(r)
+            case r: Result[_] =>
+              val ry: Result[y] = r.asInstanceOf[Result[y]]
+              mk(b.cont(ry))
+            case e: Action[F, O, y2] =>
+              new ViewL.View[F, O, y2, Z](e) {
+                def next(r: Result[y2]): Pull[F, O, Z] = b.cont(r.asInstanceOf[Result[y]])
               }
             case bb: Bind[F, O, x, _] =>
               val nb = new Bind[F, O, x, Z](bb.step) {
                 private[this] val bdel: Bind[F, O, y, Z] = b.delegate
                 def cont(zr: Result[x]): Pull[F, O, Z] =
-                  new Bind[F, O, y, Z](bb.cont(zr)) {
+                  new Bind[F, O, y, Z](bb.cont(zr).asInstanceOf[Pull[F, O, y]]) {
                     override val delegate: Bind[F, O, y, Z] = bdel
                     def cont(yr: Result[y]): Pull[F, O, Z] = delegate.cont(yr)
                   }
@@ -406,7 +409,7 @@ object Pull extends PullLowPriority {
    */
   private abstract class Action[+F[_], +O, +R] extends Pull[F, O, R]
 
-  private final case class Output[O](values: Chunk[O]) extends Action[Pure, O, Unit] {
+  private final case class Output[+O](values: Chunk[O]) extends Action[Pure, O, Unit] {
     override def mapOutput[P](f: O => P): Pull[Pure, P, Unit] =
       Pull.suspend {
         try Output(values.map(f))
@@ -421,12 +424,9 @@ object Pull extends PullLowPriority {
     * @param stream             Stream to step
     * @param scopeId            If scope has to be changed before this step is evaluated, id of the scope must be supplied
     */
-  private final case class Step[X](stream: Pull[Any, X, Unit], scope: Option[Token])
-      extends Action[Pure, INothing, Option[(Chunk[X], Token, Pull[Any, X, Unit])]] {
-    /* NOTE: The use of `Any` and `Pure` done to by-pass an error in Scala 2.12 type-checker,
-     * that produces a crash when dealing with Higher-Kinded GADTs in which the F parameter appears
-     * Inside one of the values of the case class.      */
-    override def mapOutput[P](f: INothing => P): Step[X] = this
+  private final case class Step[+F[_], X](stream: Pull[F, X, Unit], scope: Option[Token])
+      extends Action[Pure, INothing, Option[(Chunk[X], Token, Pull[F, X, Unit])]] {
+    override def mapOutput[P](f: INothing => P): Step[F, X] = this
   }
 
   /* The `AlgEffect` trait is for operations on the `F` effect that create no `O` output.
@@ -460,7 +460,7 @@ object Pull extends PullLowPriority {
   private[fs2] def stepLeg[F[_], O](
       leg: Stream.StepLeg[F, O]
   ): Pull[F, Nothing, Option[Stream.StepLeg[F, O]]] =
-    Step[O](leg.next, Some(leg.scopeId)).map {
+    Step[F, O](leg.next, Some(leg.scopeId)).map {
       _.map {
         case (h, id, t) => new Stream.StepLeg[F, O](h, id, t.asInstanceOf[Pull[F, O, Unit]])
       }
@@ -564,12 +564,13 @@ object Pull extends PullLowPriority {
                 go(scope, extendedTopLevelScope, view.next(Result.Interrupted(scopeId, None)))
             }
           view.step match {
-            case output: Output[X] =>
+            case output: Output[_] =>
               interruptGuard(scope)(
                 F.pure(Out(output.values, scope, view.next(Pull.Result.unit)))
               )
 
-            case u: Step[y] =>
+            case uU: Step[f, y] =>
+              val u: Step[F, y] = uU.asInstanceOf[Step[F, y]]
               // if scope was specified in step, try to find it, otherwise use the current scope.
               F.flatMap(u.scope.fold[F[Option[CompileScope[F]]]](F.pure(Some(scope))) { scopeId =>
                 scope.findStepScope(scopeId)
@@ -586,8 +587,9 @@ object Pull extends PullLowPriority {
                       // scope back to the go as that is the scope that is expected to be here.
                       val nextScope = if (u.scope.isEmpty) outScope else scope
                       val result = Result.Succeeded(Some((head, outScope.id, tail)))
+                      val next = view.next(result).asInstanceOf[Pull[F, X, Unit]]
                       interruptGuard(nextScope)(
-                        go(nextScope, extendedTopLevelScope, view.next(result))
+                        go(nextScope, extendedTopLevelScope, next)
                       )
 
                     case Right(Interrupted(scopeId, err)) =>
@@ -807,7 +809,7 @@ object Pull extends PullLowPriority {
                 case r @ Result.Succeeded(_) if isMainLevel =>
                   translateStep(view.next(r), isMainLevel)
 
-                case r @ Result.Succeeded(_) if !isMainLevel =>
+                case r @ Result.Succeeded(_) =>
                   // Cast is safe here, as at this point the evaluation of this Step will end
                   // and the remainder of the free will be passed as a result in Bind. As such
                   // next Step will have this to evaluate, and will try to translate again.
@@ -818,19 +820,21 @@ object Pull extends PullLowPriority {
                 case r @ Result.Interrupted(_, _) => translateStep(view.next(r), isMainLevel)
               }
 
-            case step: Step[x] =>
-              // NOTE: The use of the `asInstanceOf` is to by-pass a compiler-crash in Scala 2.12,
-              // involving GADTs with a covariant Higher-Kinded parameter.
-              Step[x](
-                stream = translateStep[x](step.stream.asInstanceOf[Pull[F, x, Unit]], false),
+            case stepU: Step[f, x] =>
+              val step: Step[F, x] = stepU.asInstanceOf[Step[F, x]]
+              Step[G, x](
+                stream = translateStep[x](step.stream, false),
                 scope = step.scope
               ).transformWith { r =>
                 translateStep[X](view.next(r.asInstanceOf[Result[y]]), isMainLevel)
               }
 
             case alg: AlgEffect[F, r] =>
+              // Safe case but needed for Dotty
               translateAlgEffect(alg)
-                .transformWith(r => translateStep(view.next(r), isMainLevel))
+                .transformWith(r =>
+                  translateStep(view.next(r.asInstanceOf[Result[y]]), isMainLevel)
+                )
           }
       }
 

--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -1032,8 +1032,8 @@ final class Stream[+F[_], +O] private[fs2] (private val underlying: Pull[F, O, U
   }
 
   /**
-    * Like `observe` but observes with a function `O => F[_]` instead of a pipe.
-    * Not as powerful as `observe` since not all pipes can be represented by `O => F[_]`, but much faster.
+    * Like `observe` but observes with a function `O => F[O2]` instead of a pipe.
+    * Not as powerful as `observe` since not all pipes can be represented by `O => F[O2]`, but much faster.
     * Alias for `evalMap(o => f(o).as(o))`.
     */
   def evalTap[F2[x] >: F[x]: Functor, O2](f: O => F2[O2]): Stream[F2, O] =
@@ -3077,9 +3077,9 @@ object Stream extends StreamLowPriority {
     */
   def emits[F[x] >: Pure[x], O](os: scala.collection.Seq[O]): Stream[F, O] =
     os match {
-      case Nil    => empty
-      case Seq(x) => emit(x.asInstanceOf[O])
-      case _      => new Stream(Pull.output(Chunk.seq(os)))
+      case Nil               => empty
+      case collection.Seq(x) => emit(x)
+      case _                 => new Stream(Pull.output(Chunk.seq(os)))
     }
 
   /** Empty pure stream. */
@@ -3724,6 +3724,7 @@ object Stream extends StreamLowPriority {
       Pull.loop(f.andThen(_.map(_.map(_.pull))))(pull).void.stream
   }
 
+  /** Provides syntax for streams of streams. */
   implicit final class NestedStreamOps[F[_], O](private val outer: Stream[F, Stream[F, O]])
       extends AnyVal {
 

--- a/core/shared/src/main/scala/fs2/internal/AcquireAfterScopeClosed.scala
+++ b/core/shared/src/main/scala/fs2/internal/AcquireAfterScopeClosed.scala
@@ -1,5 +1,5 @@
 package fs2.internal
 
-private[fs2] final case object AcquireAfterScopeClosed extends Throwable {
+private[fs2] case object AcquireAfterScopeClosed extends Throwable {
   override def fillInStackTrace = this
 }

--- a/core/shared/src/main/scala/fs2/internal/SizedQueue.scala
+++ b/core/shared/src/main/scala/fs2/internal/SizedQueue.scala
@@ -12,7 +12,7 @@ private[fs2] final class SizedQueue[A](private val underlying: Queue[A], val siz
   def toQueue: Queue[A] = underlying
   override def equals(other: Any): Boolean =
     other match {
-      case that: SizedQueue[A] => underlying == that.underlying && size == that.size
+      case that: SizedQueue[_] => size == that.size && underlying == that.underlying
       case _                   => false
     }
   override def hashCode: Int = underlying.hashCode


### PR DESCRIPTION
This PR makes a bunch of adjustments to the source of coreJVM project so that it cross compiles against 2.12, 2.13, and latest Dotty nightly build. Note Dotty 0.25.0-RC2 has a bug that prevents its use with FS2 (https://github.com/lampepfl/dotty/pull/9275).

In particular, Dotty is much better w.r.t. detecting soundness issues. I fixed as many as possible without casts but had to add some, in particular in `Pull` -- some of those seem to be Dotty limitations but I'm not certain about that. Some of the others are definitely us doing dodgy things.