### PR TITLE
Add some optimizations to utf8 decoding

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/TextBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/TextBenchmark.scala
@@ -1,0 +1,30 @@
+package fs2
+package benchmark
+
+import cats.effect.IO
+import org.openjdk.jmh.annotations.{Benchmark, Param, Scope, Setup, State}
+
+@State(Scope.Thread)
+class TextBenchmark {
+  @Param(Array("128", "1024", "4096"))
+  var asciiStringSize: Int = _
+
+  var asciiBytes: Array[Byte] = _
+  @Setup
+  def setup(): Unit = {
+    val rng = new java.util.Random(7919)
+    asciiBytes = (0 until asciiStringSize).map { _ =>
+      (rng.nextInt(126) + 1).toByte
+    }.toArray
+  }
+
+  @Benchmark
+  def asciiDecode(): String =
+    Stream
+      .emits(asciiBytes)
+      .through(text.utf8Decode[IO])
+      .compile
+      .last
+      .unsafeRunSync
+      .get
+}

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -1709,6 +1709,31 @@ object Chunk extends CollectorK[Chunk] with ChunkCompanionPlatform {
     /** Appends a chunk to the end of this chunk queue. */
     def :+(c: Chunk[A]): Queue[A] = new Queue(chunks :+ c, size + c.size)
 
+    /** check to see if this starts with the items in the given seq
+      * should be the same as take(seq.size).toChunk == Chunk.seq(seq)
+      */
+    def startsWith(seq: Seq[A]): Boolean = {
+      val iter = seq.iterator
+
+      @annotation.tailrec
+      def check(chunks: SQueue[Chunk[A]], idx: Int): Boolean =
+        if (!iter.hasNext) true
+        else if (chunks.isEmpty) false
+        else {
+          val chead = chunks.head
+          if (chead.size == idx) check(chunks.tail, 0)
+          else {
+            val qitem = chead(idx)
+            val iitem = iter.next()
+            if (iitem == qitem)
+              check(chunks, idx + 1)
+            else false
+          }
+        }
+
+      check(chunks, 0)
+    }
+
     /** Takes the first `n` elements of this chunk queue in a way that preserves chunk structure. */
     def take(n: Int): Queue[A] =
       if (n <= 0) Queue.empty

--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -60,12 +60,12 @@ object text {
       val splitAt = allBytes.size - lastIncompleteBytes(allBytes)
 
       if (splitAt == allBytes.size) {
-        bldr += new String(allBytes.toArray, utf8Charset)
+        bldr += new String(allBytes, utf8Charset)
         Chunk.empty
       } else if (splitAt == 0)
         Chunk.bytes(allBytes)
       else {
-        bldr += new String(allBytes.take(splitAt).toArray, utf8Charset)
+        bldr += new String(allBytes.take(splitAt), utf8Charset)
         Chunk.bytes(allBytes.drop(splitAt))
       }
     }

--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -67,9 +67,8 @@ object text {
       while (minIdx <= idx) {
         val c = continuationBytes(bs(idx))
         if (c >= 0) {
-          if (c != counter) {
+          if (c != counter)
             res = counter + 1
-          }
           // exit the loop
           return res
         }

--- a/core/shared/src/main/scala/fs2/text.scala
+++ b/core/shared/src/main/scala/fs2/text.scala
@@ -60,19 +60,18 @@ object text {
 
        */
 
-      val minIdx = 0.max(bs.size - 3)
-      var idx = bs.size - 1
+      val minIdx = 0.max(bs.length - 3)
+      var idx = bs.length - 1
       var counter = 0
       var res = 0
       while (minIdx <= idx) {
         val c = continuationBytes(bs(idx))
         if (c >= 0) {
-          if (c == counter)
-            res = 0
-          else
+          if (c != counter) {
             res = counter + 1
+          }
           // exit the loop
-          idx = 0
+          return res
         }
         idx = idx - 1
         counter = counter + 1
@@ -90,9 +89,9 @@ object text {
         if (buffer.isEmpty) nextBytes.toArray
         else Array.concat(buffer.toArray, nextBytes.toArray)
 
-      val splitAt = allBytes.size - lastIncompleteBytes(allBytes)
+      val splitAt = allBytes.length - lastIncompleteBytes(allBytes)
 
-      if (splitAt == allBytes.size) {
+      if (splitAt == allBytes.length) {
         // in the common case of ASCII chars
         // we are in this branch so the next buffer will
         // be empty

--- a/core/shared/src/test/scala/fs2/ChunkQueueSpec.scala
+++ b/core/shared/src/test/scala/fs2/ChunkQueueSpec.scala
@@ -4,6 +4,24 @@ import org.scalatest.Succeeded
 
 class ChunkQueueSpec extends Fs2Spec {
   "Chunk.Queue" - {
+    "startsWith matches List implementation prefixes" in {
+      forAll { (chunks: List[Chunk[Int]], items: List[Int]) =>
+        val queue = Chunk.Queue(chunks: _*)
+        val flattened: List[Int] = chunks.flatMap(_.toList)
+        val prefixes = (0 until flattened.size).map(flattened.take(_))
+
+        prefixes.foreach { prefix =>
+          assert(queue.startsWith(prefix))
+        }
+
+        val viaTake = queue.take(items.size).toChunk == Chunk.seq(items)
+        val computed = flattened.startsWith(items)
+        assert(computed == viaTake)
+        // here is another way to express the law:
+        assert(computed == queue.startsWith(items))
+      }
+    }
+
     "take" in {
       forAll { (chunks: List[Chunk[Int]], n: Int) =>
         val result = Chunk.Queue(chunks: _*).take(n)


### PR DESCRIPTION
This does four things:

1. adds Chunk.Queue.startsWith so we can be a bit more precise when checking for utf8 byte order mark
2. be miserly in internal methods with allocations and use null instead of Option (avoid allocation of Some on a loop).
3. use a Builder to avoid having to return a tuple and to reverse a list in an internal method.
4. avoid fold on an internal loop and just write out the while loop.