### PR TITLE
Optimize Chunk traverse

### DIFF
--- a/benchmark/src/main/scala/fs2/benchmark/ChunkBenchmark.scala
+++ b/benchmark/src/main/scala/fs2/benchmark/ChunkBenchmark.scala
@@ -3,6 +3,8 @@ package benchmark
 
 import org.openjdk.jmh.annotations.{Benchmark, Param, Scope, Setup, State}
 
+import cats.implicits._
+
 @State(Scope.Thread)
 class ChunkBenchmark {
   @Param(Array("16", "256", "4096"))
@@ -17,15 +19,29 @@ class ChunkBenchmark {
   }
 
   var chunkSeq: Seq[Chunk[Obj]] = _
+  var flattened: Chunk[Obj] = _
   var sizeHint: Int = _
 
   @Setup
   def setup() = {
     chunkSeq = Seq.range(0, chunkCount).map(_ => Chunk.seq(Seq.fill(chunkSize)(Obj.create)))
     sizeHint = chunkSeq.foldLeft(0)(_ + _.size)
+    flattened = Chunk.seq(chunkSeq).flatten
   }
 
   @Benchmark
   def concat(): Unit =
     Chunk.concat(chunkSeq, sizeHint)
+
+  @Benchmark
+  def traverse(): Boolean = {
+    val fn: () => Chunk[Boolean] =
+      flattened.traverse { obj =>
+        if (obj.dummy) { () => true }
+        else { () => false }
+      }
+
+    fn().isEmpty
+  }
+
 }

--- a/core/shared/src/main/scala/fs2/Chunk.scala
+++ b/core/shared/src/main/scala/fs2/Chunk.scala
@@ -1666,74 +1666,73 @@ object Chunk extends CollectorK[Chunk] with ChunkCompanionPlatform {
       override def traverse: Traverse[Chunk] = this
       override def traverse[F[_], A, B](
           fa: Chunk[A]
-      )(f: A => F[B])(implicit F: Applicative[F]): F[Chunk[B]] = {
-
-        val applied: collection.mutable.Buffer[F[B]] = {
-          val size = fa.size
-          val b = collection.mutable.Buffer.newBuilder[F[B]]
-          b.sizeHint(size)
-          var idx = 0
-          while (idx < size) {
-            b += f(fa(idx))
-            idx = idx + 1
+      )(f: A => F[B])(implicit F: Applicative[F]): F[Chunk[B]] =
+        if (fa.isEmpty) F.pure(Chunk.empty[B])
+        else {
+          val applied: collection.mutable.Buffer[F[B]] = {
+            val size = fa.size
+            val b = collection.mutable.Buffer.newBuilder[F[B]]
+            b.sizeHint(size)
+            var idx = 0
+            while (idx < size) {
+              b += f(fa(idx))
+              idx = idx + 1
+            }
+            b.result()
           }
-          b.result()
+
+          // By making a tree here we don't blow the stack
+          // even if the Chunk is very long
+          // by construction, this is never called with start == end
+          def loop(start: Int, end: Int): F[Chain[B]] =
+            if (start == (end - 1))
+              F.map(applied(start))(Chain.one)
+            else {
+              val end1 = start + ((end - start) / 2)
+              val left = loop(start, end1)
+              val right = loop(end1, end)
+              F.map2(left, right)(_.concat(_))
+            }
+
+          F.map(loop(0, fa.size))(Chunk.chain)
         }
-
-        val fempty = F.pure(Chain.empty[B])
-
-        // By making a tree here we don't blow the stack
-        // even if the Chunk is very long
-        def loop(start: Int, end: Int): F[Chain[B]] =
-          if (start >= end) fempty
-          else if (start == (end - 1))
-            F.map(applied(start))(Chain.one)
-          else {
-            val end1 = start + ((end - start) / 2)
-            val left = loop(start, end1)
-            val right = loop(end1, end)
-            F.map2(left, right)(_.concat(_))
-          }
-
-        F.map(loop(0, fa.size))(Chunk.chain)
-      }
 
       override def traverseFilter[F[_], A, B](
           fa: Chunk[A]
-      )(f: A => F[Option[B]])(implicit F: Applicative[F]): F[Chunk[B]] = {
-        val applied: collection.mutable.Buffer[F[Option[B]]] = {
-          val size = fa.size
-          val b = collection.mutable.Buffer.newBuilder[F[Option[B]]]
-          b.sizeHint(size)
-          var idx = 0
-          while (idx < size) {
-            b += f(fa(idx))
-            idx = idx + 1
-          }
-          b.result()
-        }
-
-        val empty = Chain.empty[B]
-        val fempty = F.pure(empty)
-
-        // By making a tree here we don't blow the stack
-        // even if the Chunk is very long
-        def loop(start: Int, end: Int): F[Chain[B]] =
-          if (start >= end) fempty
-          else if (start == (end - 1))
-            F.map(applied(start)) { opt =>
-              if (opt.isEmpty) empty
-              else Chain.one(opt.get)
+      )(f: A => F[Option[B]])(implicit F: Applicative[F]): F[Chunk[B]] =
+        if (fa.isEmpty) F.pure(Chunk.empty[B])
+        else {
+          val applied: collection.mutable.Buffer[F[Option[B]]] = {
+            val size = fa.size
+            val b = collection.mutable.Buffer.newBuilder[F[Option[B]]]
+            b.sizeHint(size)
+            var idx = 0
+            while (idx < size) {
+              b += f(fa(idx))
+              idx = idx + 1
             }
-          else {
-            val end1 = start + ((end - start) / 2)
-            val left = loop(start, end1)
-            val right = loop(end1, end)
-            F.map2(left, right)(_.concat(_))
+            b.result()
           }
 
-        F.map(loop(0, fa.size))(Chunk.chain)
-      }
+          val empty = Chain.empty[B]
+          // By making a tree here we don't blow the stack
+          // even if the Chunk is very long
+          // by construction, this is never called with start == end
+          def loop(start: Int, end: Int): F[Chain[B]] =
+            if (start == (end - 1))
+              F.map(applied(start)) { opt =>
+                if (opt.isEmpty) empty
+                else Chain.one(opt.get)
+              }
+            else {
+              val end1 = start + ((end - start) / 2)
+              val left = loop(start, end1)
+              val right = loop(end1, end)
+              F.map2(left, right)(_.concat(_))
+            }
+
+          F.map(loop(0, fa.size))(Chunk.chain)
+        }
 
       override def mapFilter[A, B](fa: Chunk[A])(f: A => Option[B]): Chunk[B] = {
         val size = fa.size


### PR DESCRIPTION
I noticed that `Stream.evalMapChunk`, which is a common operation for me, goes through `Chunk.traverse`, however that is implemented in a pretty expensive way: via foldRight which wraps everything in another layer of Eval.

I instead implemented a tree-based approach (to keep stack safety) but without wrapping in another Eval layer.