### PR TITLE
Remove ScalaTest dependency and more Dotty source compat

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,8 +46,7 @@ lazy val commonSettingsBase = Seq(
   scalacOptions ++= Seq(
     "-feature",
     "-deprecation",
-    "-language:implicitConversions",
-    "-language:higherKinds",
+    "-language:implicitConversions,higherKinds",
     "-Xfatal-warnings"
   ) ++
     (scalaBinaryVersion.value match {
@@ -77,8 +76,7 @@ lazy val commonSettingsBase = Seq(
     "org.typelevel" %%% "cats-effect" % "2.1.4",
     "org.typelevel" %%% "cats-effect-laws" % "2.1.4" % "test",
     "org.scalacheck" %%% "scalacheck" % "1.14.3" % "test",
-    "org.scalameta" %%% "munit-scalacheck" % "0.7.9" % "test",
-    "org.scalatest" %%% "scalatest" % "3.2.0" % "test" // For sbt-doctest
+    "org.scalameta" %%% "munit-scalacheck" % "0.7.9" % "test"
   ),
   testFrameworks += new TestFramework("munit.Framework"),
   scmInfo := Some(
@@ -95,7 +93,7 @@ lazy val commonSettingsBase = Seq(
     implicit val contextShiftIO: ContextShift[IO] = IO.contextShift(global)
     implicit val timerIO: Timer[IO] = IO.timer(global)
   """,
-  doctestTestFramework := DoctestTestFramework.ScalaTest
+  doctestTestFramework := DoctestTestFramework.ScalaCheck
 ) ++ scaladocSettings ++ publishingSettings ++ releaseSettings
 
 lazy val commonSettings = commonSettingsBase ++ testSettings
@@ -112,7 +110,6 @@ lazy val commonTestSettings = Seq(
     case None => Seq()
   })),
   parallelExecution in Test := false,
-  testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDS"),
   publishArtifact in Test := true
 )
 lazy val testSettings =
@@ -263,7 +260,6 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
   .configs(IntegrationTest)
   .settings(Defaults.itSettings: _*)
   .settings(
-    testOptions in IntegrationTest := Seq(Tests.Argument(TestFrameworks.ScalaTest, "-oDF")),
     inConfig(IntegrationTest)(org.scalafmt.sbt.ScalafmtPlugin.scalafmtConfigSettings)
   )
   .settings(crossCommonSettings: _*)

--- a/core/shared/src/test/scala-2.13/fs2/ChunkPlatformSuite.scala
+++ b/core/shared/src/test/scala-2.13/fs2/ChunkPlatformSuite.scala
@@ -21,14 +21,14 @@ class ChunkPlatformSuite extends Fs2Suite {
   )(implicit A: Arbitrary[Chunk[A]]): Unit =
     group(s"Chunk toArraySeq $testName") {
       property("values") {
-        forAll { chunk: Chunk[A] =>
+        forAll { (chunk: Chunk[A]) =>
           assert(f(chunk).toVector == chunk.toVector)
         }
       }
 
       if (shouldSpecialise)
         property("specialised") {
-          forAll { chunk: Chunk[A] =>
+          forAll { (chunk: Chunk[A]) =>
             f(chunk) match {
               case _: ArraySeq.ofRef[A] =>
                 fail("Expected specialised ArraySeq but was not specialised")
@@ -75,13 +75,13 @@ class ChunkPlatformSuite extends Fs2Suite {
 
     group(s"fromArraySeq ArraySeq[$testTypeName]") {
       property("mutable") {
-        forAll { arraySeq: mutable.ArraySeq[A] =>
+        forAll { (arraySeq: mutable.ArraySeq[A]) =>
           assert(Chunk.arraySeq(arraySeq).toVector == arraySeq.toVector)
         }
       }
 
       property("immutable") {
-        forAll { arraySeq: immutable.ArraySeq[A] =>
+        forAll { (arraySeq: immutable.ArraySeq[A]) =>
           assert(Chunk.arraySeq(arraySeq).toVector == arraySeq.toVector)
         }
       }
@@ -103,13 +103,13 @@ class ChunkPlatformSuite extends Fs2Suite {
 
   group("Chunk iterable") {
     property("mutable ArraySeq") {
-      forAll { a: mutable.ArraySeq[String] =>
+      forAll { (a: mutable.ArraySeq[String]) =>
         assert(Chunk.iterable(a).toVector == a.toVector)
       }
     }
 
     property("immutable ArraySeq") {
-      forAll { a: immutable.ArraySeq[String] =>
+      forAll { (a: immutable.ArraySeq[String]) =>
         assert(Chunk.iterable(a).toVector == a.toVector)
       }
     }

--- a/core/shared/src/test/scala/fs2/BracketSuite.scala
+++ b/core/shared/src/test/scala/fs2/BracketSuite.scala
@@ -10,8 +10,8 @@ import cats.implicits._
 class BracketSuite extends Fs2Suite {
 
   sealed trait BracketEvent
-  final case object Acquired extends BracketEvent
-  final case object Released extends BracketEvent
+  case object Acquired extends BracketEvent
+  case object Released extends BracketEvent
 
   def recordBracketEvents[F[_]](events: Ref[F, Vector[BracketEvent]]): Stream[F, Unit] =
     Stream.bracket(events.update(evts => evts :+ Acquired))(_ =>

--- a/core/shared/src/test/scala/fs2/ChunkSuite.scala
+++ b/core/shared/src/test/scala/fs2/ChunkSuite.scala
@@ -79,14 +79,14 @@ class ChunkSuite extends Fs2Suite {
         forAll((c: Chunk[A]) => assert(c.isEmpty == c.toList.isEmpty))
       }
       property("toArray") {
-        forAll { c: Chunk[A] =>
+        forAll { (c: Chunk[A]) =>
           assert(c.toArray.toVector == c.toVector)
           // Do it twice to make sure the first time didn't mutate state
           assert(c.toArray.toVector == c.toVector)
         }
       }
       property("copyToArray") {
-        forAll { c: Chunk[A] =>
+        forAll { (c: Chunk[A]) =>
           val arr = new Array[A](c.size * 2)
           c.copyToArray(arr, 0)
           c.copyToArray(arr, c.size)
@@ -105,13 +105,13 @@ class ChunkSuite extends Fs2Suite {
         assert(Chunk.concat[A](List(Chunk.empty, Chunk.empty)) == Chunk.empty)
       }
       property("scanLeft") {
-        forAll { c: Chunk[A] =>
+        forAll { (c: Chunk[A]) =>
           def step(acc: List[A], item: A) = acc :+ item
           assert(c.scanLeft(List[A]())(step).toList == (c.toList.scanLeft(List[A]())(step)))
         }
       }
       property("scanLeftCarry") {
-        forAll { c: Chunk[A] =>
+        forAll { (c: Chunk[A]) =>
           def step(acc: List[A], item: A) = acc :+ item
           val listScan = c.toList.scanLeft(List[A]())(step)
           val (chunkScan, chunkCarry) = c.scanLeftCarry(List[A]())(step)
@@ -122,7 +122,7 @@ class ChunkSuite extends Fs2Suite {
 
       if (implicitly[ClassTag[A]] == ClassTag.Byte)
         property("toByteBuffer.byte") {
-          forAll { c: Chunk[A] =>
+          forAll { (c: Chunk[A]) =>
             implicit val ev: A =:= Byte = null
             val arr = new Array[Byte](c.size)
             c.toByteBuffer.get(arr, 0, c.size)

--- a/core/shared/src/test/scala/fs2/PullSuite.scala
+++ b/core/shared/src/test/scala/fs2/PullSuite.scala
@@ -21,7 +21,7 @@ class PullSuite extends Fs2Suite {
   }
 
   property("fromEither") {
-    forAll { either: Either[Throwable, Int] =>
+    forAll { (either: Either[Throwable, Int]) =>
       val pull: Pull[Fallible, Int, Unit] = Pull.fromEither[Fallible](either)
 
       either match {

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -253,14 +253,14 @@ class StreamCombinatorsSuite extends Fs2Suite {
 
   group("evalFilter") {
     test("with effectful const(true)") {
-      forAllAsync { s: Stream[Pure, Int] =>
+      forAllAsync { (s: Stream[Pure, Int]) =>
         val s1 = s.toList
         s.evalFilter(_ => IO.pure(true)).compile.toList.map(it => assert(it == s1))
       }
     }
 
     test("with effectful const(false)") {
-      forAllAsync { s: Stream[Pure, Int] =>
+      forAllAsync { (s: Stream[Pure, Int]) =>
         s.evalFilter(_ => IO.pure(false)).compile.toList.map(it => assert(it.isEmpty))
       }
     }
@@ -277,7 +277,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
 
   group("evalFilterAsync") {
     test("with effectful const(true)") {
-      forAllAsync { s: Stream[Pure, Int] =>
+      forAllAsync { (s: Stream[Pure, Int]) =>
         val s1 = s.toList
         s.covary[IO]
           .evalFilterAsync(5)(_ => IO.pure(true))
@@ -288,7 +288,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
     }
 
     test("with effectful const(false)") {
-      forAllAsync { s: Stream[Pure, Int] =>
+      forAllAsync { (s: Stream[Pure, Int]) =>
         s.covary[IO]
           .evalFilterAsync(5)(_ => IO.pure(false))
           .compile
@@ -341,14 +341,14 @@ class StreamCombinatorsSuite extends Fs2Suite {
 
   group("evalFilterNot") {
     test("with effectful const(true)") {
-      forAllAsync { s: Stream[Pure, Int] =>
+      forAllAsync { (s: Stream[Pure, Int]) =>
         val s1 = s.toList
         s.evalFilterNot(_ => IO.pure(false)).compile.toList.map(it => assert(it == s1))
       }
     }
 
     test("with effectful const(false)") {
-      forAllAsync { s: Stream[Pure, Int] =>
+      forAllAsync { (s: Stream[Pure, Int]) =>
         s.evalFilterNot(_ => IO.pure(true)).compile.toList.map(it => assert(it.isEmpty))
       }
     }
@@ -365,7 +365,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
 
   group("evalFilterNotAsync") {
     test("with effectful const(true)") {
-      forAllAsync { s: Stream[Pure, Int] =>
+      forAllAsync { (s: Stream[Pure, Int]) =>
         s.covary[IO]
           .evalFilterNotAsync(5)(_ => IO.pure(true))
           .compile
@@ -375,7 +375,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
     }
 
     test("with effectful const(false)") {
-      forAllAsync { s: Stream[Pure, Int] =>
+      forAllAsync { (s: Stream[Pure, Int]) =>
         val s1 = s.toList
         s.covary[IO]
           .evalFilterNotAsync(5)(_ => IO.pure(false))
@@ -442,14 +442,14 @@ class StreamCombinatorsSuite extends Fs2Suite {
 
   group("evalMapFilter") {
     test("with effectful optional identity function") {
-      forAllAsync { s: Stream[Pure, Int] =>
+      forAllAsync { (s: Stream[Pure, Int]) =>
         val s1 = s.toList
         s.evalMapFilter(n => IO.pure(n.some)).compile.toList.map(it => assert(it == s1))
       }
     }
 
     test("with effectful constant function that returns None for any element") {
-      forAllAsync { s: Stream[Pure, Int] =>
+      forAllAsync { (s: Stream[Pure, Int]) =>
         s.evalMapFilter(_ => IO.pure(none[Int]))
           .compile
           .toList
@@ -620,7 +620,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
   }
 
   property("fromEither") {
-    forAll { either: Either[Throwable, Int] =>
+    forAll { (either: Either[Throwable, Int]) =>
       val stream: Stream[Fallible, Int] = Stream.fromEither[Fallible](either)
       either match {
         case Left(t)  => assert(stream.toList == Left(t))
@@ -630,7 +630,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
   }
 
   test("fromIterator") {
-    forAllAsync { x: List[Int] =>
+    forAllAsync { (x: List[Int]) =>
       Stream
         .fromIterator[IO](x.iterator)
         .compile
@@ -640,7 +640,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
   }
 
   test("fromBlockingIterator") {
-    forAllAsync { x: List[Int] =>
+    forAllAsync { (x: List[Int]) =>
       Stream
         .fromBlockingIterator[IO](Blocker.liftExecutionContext(executionContext), x.iterator)
         .compile
@@ -856,7 +856,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
 
   group("mapAsync") {
     test("same as map") {
-      forAllAsync { s: Stream[Pure, Int] =>
+      forAllAsync { (s: Stream[Pure, Int]) =>
         val f = (_: Int) + 1
         val r = s.covary[IO].mapAsync(16)(i => IO(f(i)))
         val sVector = s.toVector
@@ -865,7 +865,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
     }
 
     test("exception") {
-      forAllAsync { s: Stream[Pure, Int] =>
+      forAllAsync { (s: Stream[Pure, Int]) =>
         val f = (_: Int) => IO.raiseError[Int](new RuntimeException)
         val r = (s ++ Stream(1)).covary[IO].mapAsync(1)(f).attempt
         r.compile.toVector.map(it => assert(it.size == 1))
@@ -874,7 +874,7 @@ class StreamCombinatorsSuite extends Fs2Suite {
   }
 
   test("mapAsyncUnordered") {
-    forAllAsync { s: Stream[Pure, Int] =>
+    forAllAsync { (s: Stream[Pure, Int]) =>
       val f = (_: Int) + 1
       val r = s.covary[IO].mapAsyncUnordered(16)(i => IO(f(i)))
       val sVector = s.toVector

--- a/core/shared/src/test/scala/fs2/StreamConcurrentlySuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamConcurrentlySuite.scala
@@ -76,7 +76,7 @@ class StreamConcurrentlySuite extends Fs2Suite {
   }
 
   test("run finalizers of background stream and properly handle exception") {
-    forAllAsync { s: Stream[Pure, Int] =>
+    forAllAsync { (s: Stream[Pure, Int]) =>
       Ref
         .of[IO, Boolean](false)
         .flatMap { runnerRun =>

--- a/core/shared/src/test/scala/fs2/StreamInterruptSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamInterruptSuite.scala
@@ -217,7 +217,7 @@ class StreamInterruptSuite extends Fs2Suite {
   }
 
   test("14a - interrupt evalMap and then resume on append") {
-    forAllAsync { s: Stream[Pure, Int] =>
+    forAllAsync { (s: Stream[Pure, Int]) =>
       val expected = s.toList
       val interrupt = IO.sleep(50.millis).attempt
       s.covary[IO]
@@ -232,7 +232,7 @@ class StreamInterruptSuite extends Fs2Suite {
   }
 
   test("14b - interrupt evalMap+collect and then resume on append") {
-    forAllAsync { s: Stream[Pure, Int] =>
+    forAllAsync { (s: Stream[Pure, Int]) =>
       val expected = s.toList
       val interrupt = IO.sleep(50.millis).attempt
       s.covary[IO]
@@ -247,7 +247,7 @@ class StreamInterruptSuite extends Fs2Suite {
   }
 
   test("15 - interruption works when flatMap is followed by collect") {
-    forAllAsync { s: Stream[Pure, Int] =>
+    forAllAsync { (s: Stream[Pure, Int]) =>
       val expected = s.toList
       val interrupt = Stream.sleep_[IO](20.millis).compile.drain.attempt
       s.covary[IO]
@@ -329,7 +329,7 @@ class StreamInterruptSuite extends Fs2Suite {
   }
 
   test("20 - nested-interrupt") {
-    forAllAsync { s: Stream[Pure, Int] =>
+    forAllAsync { (s: Stream[Pure, Int]) =>
       val expected = s.toList
       Stream
         .eval(Semaphore[IO](0))

--- a/core/shared/src/test/scala/fs2/StreamSwitchMapSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamSwitchMapSuite.scala
@@ -8,7 +8,7 @@ import cats.implicits._
 
 class StreamSwitchMapSuite extends Fs2Suite {
   test("flatMap equivalence when switching never occurs") {
-    forAllAsync { s: Stream[Pure, Int] =>
+    forAllAsync { (s: Stream[Pure, Int]) =>
       val expected = s.toList
       Stream
         .eval(Semaphore[IO](1))
@@ -25,7 +25,7 @@ class StreamSwitchMapSuite extends Fs2Suite {
   }
 
   test("inner stream finalizer always runs before switching") {
-    forAllAsync { s: Stream[Pure, Int] =>
+    forAllAsync { (s: Stream[Pure, Int]) =>
       Stream
         .eval(Ref[IO].of(true))
         .flatMap { ref =>

--- a/io/src/main/scala/fs2/io/file/Watcher.scala
+++ b/io/src/main/scala/fs2/io/file/Watcher.scala
@@ -74,10 +74,10 @@ object Watcher {
   /** Type of event raised by `Watcher`. Supports the standard events types as well as arbitrary non-standard types (via `NonStandard`). */
   sealed abstract class EventType
   object EventType {
-    final case object Created extends EventType
-    final case object Deleted extends EventType
-    final case object Modified extends EventType
-    final case object Overflow extends EventType
+    case object Created extends EventType
+    case object Deleted extends EventType
+    case object Modified extends EventType
+    case object Overflow extends EventType
     final case class NonStandard(kind: WatchEvent.Kind[_]) extends EventType
 
     def toWatchEventKind(et: EventType): WatchEvent.Kind[_] =

--- a/io/src/test/scala/fs2/io/IoSuite.scala
+++ b/io/src/test/scala/fs2/io/IoSuite.scala
@@ -50,7 +50,7 @@ class IoSuite extends Fs2Suite {
     }
 
     test("can be manually closed from inside `f`") {
-      forAllAsync { chunkSize0: Int =>
+      forAllAsync { (chunkSize0: Int) =>
         val chunkSize = (chunkSize0 % 20).abs + 1
         Blocker[IO].use { blocker =>
           readOutputStream[IO](blocker, chunkSize)((os: OutputStream) =>
@@ -62,7 +62,7 @@ class IoSuite extends Fs2Suite {
     }
 
     test("fails when `f` fails") {
-      forAllAsync { chunkSize0: Int =>
+      forAllAsync { (chunkSize0: Int) =>
         val chunkSize = (chunkSize0 % 20).abs + 1
         val e = new Exception("boom")
         Blocker[IO].use { blocker =>

--- a/reactive-streams/src/test/scala/fs2/interop/reactivestreams/CancellationSpec.scala
+++ b/reactive-streams/src/test/scala/fs2/interop/reactivestreams/CancellationSpec.scala
@@ -6,9 +6,6 @@ import org.reactivestreams._
 import cats.effect._
 
 import java.util.concurrent.atomic.AtomicBoolean
-import scala.concurrent.ExecutionContext
-
-import org.scalatest.funsuite.AnyFunSuite
 
 /**
   * This behaviour is already tested by the Reactive Stream test
@@ -16,9 +13,7 @@ import org.scalatest.funsuite.AnyFunSuite
   * tests that run the assertions multiple times to make possible
   * failures due to race conditions more repeatable
   */
-class CancellationSpec extends AnyFunSuite {
-  implicit val ctx: ContextShift[IO] =
-    IO.contextShift(ExecutionContext.global)
+class CancellationSpec extends Fs2Suite {
 
   case class Sub[A](b: AtomicBoolean) extends Subscriber[A] {
     def onNext(t: A) = b.set(true)


### PR DESCRIPTION
Rather than waiting for sbt-doctest to implement support for munit, this PR just changes sbt-doctest to use ScalaCheck instead of ScalaTest.

This PR also makes a few additional syntax changes due to recent Dotty changes -- in particular, it seems lambdas without parens are no longer supported. E.g. `map { x: Int =>` is no longer allowed.