### PR TITLE
Upgrade to cats-effect 2.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,8 +73,8 @@ lazy val commonSettingsBase = Seq(
     compilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3"),
     "org.typelevel" %%% "cats-core" % "2.1.1",
     "org.typelevel" %%% "cats-laws" % "2.1.1" % "test",
-    "org.typelevel" %%% "cats-effect" % "2.1.4",
-    "org.typelevel" %%% "cats-effect-laws" % "2.1.4" % "test",
+    "org.typelevel" %%% "cats-effect" % "2.2.0-RC2",
+    "org.typelevel" %%% "cats-effect-laws" % "2.2.0-RC2" % "test",
     "org.scalacheck" %%% "scalacheck" % "1.14.3" % "test",
     "org.scalameta" %%% "munit-scalacheck" % "0.7.9" % "test"
   ),


### PR DESCRIPTION
Note evalFilterAsync tests are failing with an error related to semaphores. I haven't yet debugged but wanted to open this so folks were aware.

```scala
  + evalFilterAsync - with function that filters out odd elements 0.003s
==> X fs2.StreamCombinatorsSuite.evalFilterAsync - filters up to N items in parallel  0.02s java.lang.Throwable: Couldn't acquire permit
    at fs2.StreamCombinatorsSuite.$anonfun$new$217(StreamCombinatorsSuite.scala:322)
    at cats.FlatMap.$anonfun$ifM$1(FlatMap.scala:121)
    at cats.FlatMap.$anonfun$ifM$1$adapted(FlatMap.scala:121)
    at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:178)
    at cats.effect.internals.IORunLoop$.restart(IORunLoop.scala:40)
    at cats.effect.internals.IOBracket$.$anonfun$apply$1(IOBracket.scala:48)
    at cats.effect.internals.IOBracket$.$anonfun$apply$1$adapted(IOBracket.scala:34)
    at cats.effect.internals.IOAsync$.$anonfun$apply$1(IOAsync.scala:37)
    at cats.effect.internals.IOAsync$.$anonfun$apply$1$adapted(IOAsync.scala:37)
    at cats.effect.internals.IORunLoop$RestartCallback.start(IORunLoop.scala:398)
    at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:152)
    at cats.effect.internals.IORunLoop$RestartCallback.signal(IORunLoop.scala:414)
    at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:435)
    at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:373)
    at cats.effect.internals.IOShift$Tick.run(IOShift.scala:36)
    at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1429)
    at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
    at java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1016)
    at java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1665)
    at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1598)
    at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)
  + evalFilterNot - with effectful const(true) 0.008s
  + evalFilterNot - with effectful const(false) 0.006s
  + evalFilterNot - with function that filters out odd elements 0.001s
  + evalFilterNotAsync - with effectful const(true) 0.166s
  + evalFilterNotAsync - with effectful const(false) 0.08s
  + evalFilterNotAsync - with function that filters out odd elements 0.002s
==> X fs2.StreamCombinatorsSuite.evalFilterNotAsync - filters up to N items in parallel  0.015s java.lang.Throwable: Couldn't acquire permit
    at fs2.StreamCombinatorsSuite.$anonfun$new$270(StreamCombinatorsSuite.scala:410)
    at cats.FlatMap.$anonfun$ifM$1(FlatMap.scala:121)
    at cats.FlatMap.$anonfun$ifM$1$adapted(FlatMap.scala:121)
    at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:178)
    at cats.effect.internals.IORunLoop$.restart(IORunLoop.scala:40)
    at cats.effect.internals.IOBracket$.$anonfun$apply$1(IOBracket.scala:48)
    at cats.effect.internals.IOBracket$.$anonfun$apply$1$adapted(IOBracket.scala:34)
    at cats.effect.internals.IOAsync$.$anonfun$apply$1(IOAsync.scala:37)
    at cats.effect.internals.IOAsync$.$anonfun$apply$1$adapted(IOAsync.scala:37)
    at cats.effect.internals.IORunLoop$RestartCallback.start(IORunLoop.scala:398)
    at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:152)
    at cats.effect.internals.IORunLoop$RestartCallback.signal(IORunLoop.scala:414)
    at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:435)
    at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:373)
    at cats.effect.internals.IOShift$Tick.run(IOShift.scala:36)
    at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1429)
    at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
    at java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1016)
    at java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1665)
    at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1598)
    at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)
  + evalMapAccumulate 0.019s
```