### PR TITLE
Add `withFilter` to Stream in order to filter in for comprehensions #1971

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2857,6 +2857,12 @@ final class Stream[+F[_], +O] private[fs2] (private val free: FreeC[F, O, Unit])
       }
     }
 
+  /**
+    * Alias for [[filter]]
+    * Implemented to enable filtering in for comprehensions
+    */
+  def withFilter(f: O => Boolean) = this.filter(f)
+
   private type ZipWithCont[G[_], I, O2, R] =
     Either[(Chunk[I], Stream[G, I]), Stream[G, I]] => Pull[G, O2, Option[R]]
 

--- a/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
+++ b/core/shared/src/test/scala/fs2/StreamCombinatorsSuite.scala
@@ -1234,6 +1234,16 @@ class StreamCombinatorsSuite extends Fs2Suite {
     }
   }
 
+  group("withFilter") {
+    test("filter in for comprehension") {
+      val stream = for {
+        value <- Stream.range(0, 10)
+        if value % 2 == 0
+      } yield value
+      assert(stream.compile.toList == List(0, 2, 4, 6, 8))
+    }
+  }
+
   group("withTimeout") {
     test("timeout never-ending stream") {
       Stream.never[IO].timeout(100.millis).compile.drain.assertThrows[TimeoutException]


### PR DESCRIPTION
Added `withFilter` as an alias to `filter` to `Stream` to enable filtering inside of for comprehensions.
Closes #1971 