### PR TITLE
Renamed fs2.internal.Resource to fs2.internal.ScopedResource to avoid…

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -7,7 +7,7 @@ import cats.effect.implicits._
 import cats.implicits.{catsSyntaxEither => _, _}
 import fs2.concurrent._
 import fs2.internal.FreeC.{Acquire, Eval, GetScope, Output, Result}
-import fs2.internal.{Resource => _, _}
+import fs2.internal._
 import java.io.PrintStream
 
 import scala.annotation.tailrec


### PR DESCRIPTION
… name clash with cats.effect.Resource