### PR TITLE
Stream - parEvalMap: rewrite for readability.

### DIFF
--- a/core/shared/src/main/scala/fs2/Stream.scala
+++ b/core/shared/src/main/scala/fs2/Stream.scala
@@ -2101,32 +2101,38 @@ final class Stream[+F[_], +O] private[fs2] (private val underlying: Pull[F, O, U
     */
   def parEvalMap[F2[x] >: F[x]: Concurrent, O2](
       maxConcurrent: Int
-  )(f: O => F2[O2]): Stream[F2, O2] =
-    Stream.eval(Queue.bounded[F2, Option[F2[Either[Throwable, O2]]]](maxConcurrent)).flatMap {
-      queue =>
-        Stream.eval(Deferred[F2, Unit]).flatMap { dequeueDone =>
-          queue.dequeue.unNoneTerminate
-            .evalMap(identity)
-            .rethrow
-            .onFinalize(dequeueDone.complete(()))
-            .concurrently {
-              evalMap { o =>
-                Deferred[F2, Either[Throwable, O2]].flatMap { value =>
-                  val enqueue =
-                    queue.enqueue1(Some(value.get)).as {
-                      Stream.eval(f(o).attempt).evalMap(value.complete)
-                    }
-
-                  Concurrent[F2].race(dequeueDone.get, enqueue).map {
-                    case Left(())      => Stream.empty
-                    case Right(stream) => stream
-                  }
-                }
-              }.parJoin(maxConcurrent)
-                .onFinalize(Concurrent[F2].race(dequeueDone.get, queue.enqueue1(None)).void)
-            }
+  )(f: O => F2[O2]): Stream[F2, O2] = {
+    val fstream: F2[Stream[F2, O2]] = for {
+      queue <- Queue.bounded[F2, Option[F2[Either[Throwable, O2]]]](maxConcurrent)
+      dequeueDone <- Deferred[F2, Unit]
+    } yield {
+      def forkOnElem(o: O): F2[Stream[F2, Unit]] =
+        for {
+          value <- Deferred[F2, Either[Throwable, O2]]
+          enqueue = queue.enqueue1(Some(value.get)).as {
+            Stream.eval(f(o).attempt).evalMap(value.complete)
+          }
+          eit <- Concurrent[F2].race(dequeueDone.get, enqueue)
+        } yield eit match {
+          case Left(())      => Stream.empty
+          case Right(stream) => stream
         }
+
+      val background = this
+        .evalMap(forkOnElem)
+        .parJoin(maxConcurrent)
+        .onFinalize(Concurrent[F2].race(dequeueDone.get, queue.enqueue1(None)).void)
+
+      val foreground =
+        queue.dequeue.unNoneTerminate
+          .evalMap(identity)
+          .rethrow
+          .onFinalize(dequeueDone.complete(()))
+
+      foreground.concurrently(background)
     }
+    Stream.eval(fstream).flatten
+  }
 
   /**
     * Like [[Stream#evalMap]], but will evaluate effects in parallel, emitting the results


### PR DESCRIPTION
We restructure the code implementation of `parEvalMap`
to make it more readable:

- Top-level, we use `Stream.eval(--).flatten`.
- We extract the function for enqueuing each effect-action
- We use for comprehensions to reduce nesting.

_Note_ Since we are replacing a few `Stream.eval(--).flatMap` at the beginning with the use of a for comprehension in `F`, I am not sure if there is any change in the use of scopes that could be a problem. I do not expect it, but cannot be certain.